### PR TITLE
Explain how to install 'enum34' along with the ImportError

### DIFF
--- a/llvmlite/binding/value.py
+++ b/llvmlite/binding/value.py
@@ -1,6 +1,16 @@
+from __future__ import print_function
 
 from ctypes import POINTER, c_char_p, c_int
-import enum
+
+try:
+    import enum
+except ImportError as e:
+    print()
+    print("Python versions < 3.4 need the 'enum34' package.")
+    print("You should be able to fix this with 'pip install enum34'")
+    print()
+    raise e
+
 import itertools
 
 from . import ffi


### PR DESCRIPTION
Although the `README` file mentions that `enum34` is a dependency in Python versions < 3.4, explaining it along with the `ImportError` message may make things easier for users who overlook it, or who install `llvmlite` via pip.