### PR TITLE
Readme: added Ubuntu build warning.

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Run `python setup.py build`. This will build the llvmlite C wrapper, which will 
 
 ### Unix requirements
 
-You must have a LLVM build (libraries and header files) available somewhere. If it is not installed in a standard location, you may have to tweak the build script. Under Ubuntu, you can install `llvm-3.5-dev`, but currently only from a Debian repository ([see how](http://askubuntu.com/questions/116257/adding-debian-sid-as-package-repository)).
+You must have a LLVM 3.5 build (libraries and header files) available somewhere. If it is not installed in a standard location, you may have to tweak the build script. Under Ubuntu, you can install `llvm-3.5-dev`, but currently only from a Debian 'unstable' repository ([see how and understand the risk of mixing Debian and Ubuntu](http://askubuntu.com/questions/116257/adding-debian-sid-as-package-repository)).
 
 ### Windows requirements
 

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Run `python setup.py build`. This will build the llvmlite C wrapper, which will 
 
 ### Unix requirements
 
-You must have a LLVM build (libraries and header files) available somewhere. If it is not installed in a standard location, you may have to tweak the build script. Under Ubuntu, try installing `llvm-3.5-dev`.
+You must have a LLVM build (libraries and header files) available somewhere. If it is not installed in a standard location, you may have to tweak the build script. Under Ubuntu, you can install `llvm-3.5-dev`, but currently only from a Debian repository ([see how](http://askubuntu.com/questions/116257/adding-debian-sid-as-package-repository)).
 
 ### Windows requirements
 

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Run `python setup.py build`. This will build the llvmlite C wrapper, which will 
 
 ### Unix requirements
 
-You must have a LLVM 3.5 build (libraries and header files) available somewhere. If it is not installed in a standard location, you may have to tweak the build script. Under Ubuntu, you can install `llvm-3.5-dev`, but currently only from a Debian 'unstable' repository ([see how and understand the risk of mixing Debian and Ubuntu](http://askubuntu.com/questions/116257/adding-debian-sid-as-package-repository)).
+You must have a LLVM 3.5 build (libraries and header files) available somewhere. If it is not installed in a standard location, you may have to tweak the build script. Under Ubuntu 14.10 and Debian unstable, you can install `llvm-3.5-dev`. Versions shipped with earlier versions (Ubuntu 14.04, Debian stable) may not be good enough.
 
 ### Windows requirements
 


### PR DESCRIPTION
Response to issue [#27](https://github.com/numba/llvmlite/issues/27).

I verified that you can build on Ubuntu 14.04 LTS following posted instructions, as long as you use the Debian `llvm-3.5-dev` and not the Ubuntu package. I suggest a note will be added to the readme.