### PR TITLE
Fix 'pip' install problem

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,12 +1,14 @@
 try:
     from setuptools import setup, Extension
+    from setuptools.command.build_py import build_py as build
+    from setuptools.command.build_ext import build_ext
+    from setuptools.command.install import install
 except ImportError:
     from distutils.core import setup, Extension
-
+    from distutils.command.build import build
+    from distutils.command.build_ext import build_ext
+    from distutils.command.install import install
 from distutils.spawn import spawn
-from distutils.command.build import build
-from distutils.command.build_ext import build_ext
-from distutils.command.install import install
 import os
 import sys
 


### PR DESCRIPTION
install 'llvmlite' with pip will cause this error
  error: option --single-version-externally-managed not recognized

this patch fix this problem