### PR TITLE
Add .get_global() accessor to ir.Module

### DIFF
--- a/llvmlite/ir/module.py
+++ b/llvmlite/ir/module.py
@@ -45,6 +45,11 @@ class Module(object):
     def global_variables(self):
         return self.globals.values()
 
+    def get_global(self, name):
+        """Get a global value by name.
+        """
+        return self.globals.get(name)
+
     def add_global(self, globalvalue):
         """Add a global value
         """

--- a/llvmlite/tests/test_ir.py
+++ b/llvmlite/tests/test_ir.py
@@ -111,6 +111,15 @@ class TestFunction(TestBase):
 
 class TestIR(TestBase):
 
+    def test_globals_access(self):
+        mod = self.module()
+        foo = ir.Function(mod, ir.FunctionType(ir.VoidType(), []), 'foo')
+        ir.Function(mod, ir.FunctionType(ir.VoidType(), []), 'bar')
+        globdouble = ir.GlobalVariable(mod, ir.DoubleType(), 'globdouble')
+        self.assertEqual(mod.get_global('foo'), foo)
+        self.assertEqual(mod.get_global('globdouble'), globdouble)
+        self.assertIsNone(mod.get_global('kkk'))
+
     def test_metadata(self):
         mod = self.module()
         md = mod.add_metadata([ir.Constant(ir.IntType(32), 123)])


### PR DESCRIPTION
The accessor allows querying the globals mapping without directly accessing the
class's attributes. Discussed in issue #39 

Note: the C++ API has getFunction and getGlobalVariable, which do the type checking in addition to querying the symbol table. It's possible to redo the API that way, if this is deemed preferable.