### PR TITLE
Rename Module.global_variables to Module.global_values and add tests.

### DIFF
--- a/llvmlite/ir/module.py
+++ b/llvmlite/ir/module.py
@@ -42,7 +42,7 @@ class Module(object):
                 if isinstance(v, values.Function)]
 
     @property
-    def global_variables(self):
+    def global_values(self):
         return self.globals.values()
 
     def get_global(self, name):

--- a/llvmlite/tests/test_ir.py
+++ b/llvmlite/tests/test_ir.py
@@ -120,6 +120,15 @@ class TestIR(TestBase):
         self.assertEqual(mod.get_global('globdouble'), globdouble)
         self.assertIsNone(mod.get_global('kkk'))
 
+    def test_functions_global_values_access(self):
+        mod = self.module()
+        fty = ir.FunctionType(ir.VoidType(), [])
+        foo = ir.Function(mod, fty, 'foo')
+        bar = ir.Function(mod, fty, 'bar')
+        globdouble = ir.GlobalVariable(mod, ir.DoubleType(), 'globdouble')
+        self.assertEqual(set(mod.functions), set((foo, bar)))
+        self.assertEqual(set(mod.global_values), set((foo, bar, globdouble)))
+
     def test_metadata(self):
         mod = self.module()
         md = mod.add_metadata([ir.Constant(ir.IntType(32), 123)])


### PR DESCRIPTION
global_values is more consistent with the method's actual behavior. Discussed in #41 