### PR TITLE
Attempt to fix build on Windows Python 3.3

### DIFF
--- a/conda-recipes/llvmlite-jenkins/bld.bat
+++ b/conda-recipes/llvmlite-jenkins/bld.bat
@@ -5,5 +5,5 @@ set CMAKE_PREFIX_PATH=%LIBRARY_PREFIX%
 @rem Ensure there are no build leftovers (CMake can complain)
 if exist ffi\build rmdir /S /Q ffi\build
 
-python -S setup.py install
+python setup.py install
 if errorlevel 1 exit 1


### PR DESCRIPTION
The -S flag appears to prevent Python from finding any of the packages in the `_build` environment on Python 3.3. on Windows.