### PR TITLE
Use latin1 encoding instead of UTF8

### DIFF
--- a/llvmlite/binding/common.py
+++ b/llvmlite/binding/common.py
@@ -8,16 +8,17 @@ if sys.version_info < (3, 0):
         if isinstance(s, bytes):
             return s
         else:
-            return s.encode('utf-8')
+            return s.encode('latin1')
 
     def _decode_string(b):
         return b
 else:
     def _encode_string(s):
-        return s.encode('utf-8')
+        encoded = s.encode('latin1')
+        return encoded
 
     def _decode_string(b):
-        return b.decode('utf-8')
+        return b.decode('latin1')
 
 _encode_string.__doc__ = """Encode a string for use by LLVM."""
 _decode_string.__doc__ = """Decode a LLVM character (byte)string."""

--- a/llvmlite/tests/test_ir.py
+++ b/llvmlite/tests/test_ir.py
@@ -862,8 +862,13 @@ class TestConstant(TestBase):
         self.assertEqual(str(c), '{float, i1} undef')
 
     def test_encoding_problem(self):
+        try:
+            get_buffer = buffer
+        except:
+            get_buffer = lambda x: x   # Insert stub
+
         celems = [ir.Constant(ir.ArrayType(ir.IntType(8), 8),
-                              bytearray(array("d", [i + 0.5])))
+                              bytearray(get_buffer(array("d", [i + 0.5]))))
                   for i in range(10)]
         c = ir.Constant(ir.ArrayType(celems[0].type, len(celems)), celems)
         m = self.module()

--- a/llvmlite/tests/test_ir.py
+++ b/llvmlite/tests/test_ir.py
@@ -862,15 +862,8 @@ class TestConstant(TestBase):
         self.assertEqual(str(c), '{float, i1} undef')
 
     def test_encoding_problem(self):
-        try:
-            get_buffer = buffer
-        except:
-            get_buffer = lambda x: x   # Insert stub
-
-        celems = [ir.Constant(ir.ArrayType(ir.IntType(8), 8),
-                              bytearray(get_buffer(array("d", [i + 0.5]))))
-                  for i in range(10)]
-        c = ir.Constant(ir.ArrayType(celems[0].type, len(celems)), celems)
+        c = ir.Constant(ir.ArrayType(ir.IntType(8), 256),
+                        bytearray(range(256)))
         m = self.module()
         gv = ir.GlobalVariable(m, c.type, "myconstant")
         gv.global_constant = True

--- a/llvmlite/tests/test_ir.py
+++ b/llvmlite/tests/test_ir.py
@@ -9,6 +9,7 @@ import itertools
 import re
 import textwrap
 import unittest
+from array import array
 
 from . import TestCase
 from llvmlite import ir
@@ -859,6 +860,22 @@ class TestConstant(TestBase):
         self.assertEqual(str(c), '{float, i1} {float 0x3ff8000000000000, i1 undef}')
         c = ir.Constant(ir.LiteralStructType((flt, int1)), ir.Undefined)
         self.assertEqual(str(c), '{float, i1} undef')
+
+    def test_encoding_problem(self):
+        celems = [ir.Constant(ir.ArrayType(ir.IntType(8), 8),
+                              bytearray(array("d", [i + 0.5])))
+                  for i in range(10)]
+        c = ir.Constant(ir.ArrayType(celems[0].type, len(celems)), celems)
+        m = self.module()
+        gv = ir.GlobalVariable(m, c.type, "myconstant")
+        gv.global_constant = True
+        gv.initializer = c
+        # With utf-8, the following will cause:
+        # UnicodeDecodeError: 'utf-8' codec can't decode byte 0xe0 in position 136: invalid continuation byte
+        parsed = llvm.parse_assembly(str(m))
+        # Make sure the encoding does not modify the IR
+        reparsed = llvm.parse_assembly(str(parsed))
+        self.assertEqual(str(parsed), str(reparsed))
 
 
 class TestTransforms(TestBase):


### PR DESCRIPTION
With certain constant i8 values, LLVM will generate LLVM IR that contain invalid characters for UTF8.  LLVM is probably using latin1.  Although, I can't find any documentation about character encoding for LLVM IR.

This PR contains a test that fails when using UTF8 encoding.  I have verified that this patch works with Numba on OSX.