### PR TITLE
ConstOpMixin.inttoptr's str(self.get_reference()) already includes type

### DIFF
--- a/llvmlite/ir/values.py
+++ b/llvmlite/ir/values.py
@@ -61,9 +61,8 @@ class ConstOpMixin(object):
     def inttoptr(self, typ):
         assert isinstance(self.type, types.IntType)
         assert isinstance(typ, types.PointerType)
-        op = "inttoptr ({0} {1} to {2})".format(self.type,
-                                                self.get_reference(),
-                                                typ)
+        op = "inttoptr ({0} to {1})".format(self.get_reference(),
+                                            typ)
         return ConstOp(typ, op)
 
     def gep(self, indices):


### PR DESCRIPTION
This is a relatively simple fix: without it, IR like this gets created:
    inttoptr (i64 i64 39281280 to %sometype*)
