### PR TITLE
Always change to C locale before printing a module

### DIFF
--- a/ffi/module.cpp
+++ b/ffi/module.cpp
@@ -1,4 +1,5 @@
 #include <string>
+#include <clocale>
 #include "llvm-c/Core.h"
 #include "llvm-c/Analysis.h"
 #include "llvm/IR/Module.h"
@@ -79,7 +80,16 @@ API_EXPORT(void)
 LLVMPY_PrintModuleToString(LLVMModuleRef M,
                            const char **outstr)
 {
+    // Change the locale to en_US before calling LLVM to print the module
+    // due to a LLVM bug https://llvm.org/bugs/show_bug.cgi?id=12906
+    char *old_locale = strdup(setlocale(LC_ALL, NULL));
+    setlocale(LC_ALL, "C");
+
     *outstr = LLVMPrintModuleToString(M);
+
+    // Revert locale
+    setlocale(LC_ALL, old_locale);
+    free(old_locale);
 }
 
 API_EXPORT(LLVMValueRef)

--- a/llvmlite/tests/test_binding.py
+++ b/llvmlite/tests/test_binding.py
@@ -15,6 +15,18 @@ from llvmlite.binding import ffi
 from . import TestCase
 
 
+def no_de_locale():
+    cur = locale.setlocale(locale.LC_ALL)
+    try:
+        locale.setlocale(locale.LC_ALL, 'de_DE')
+    except locale.Error:
+        return True
+    else:
+        return False
+    finally:
+        locale.setlocale(locale.LC_ALL, cur)
+
+
 asm_sum = r"""
     ; ModuleID = '<string>'
     target triple = "{triple}"
@@ -175,6 +187,7 @@ class TestMisc(BaseTest):
     def test_check_jit_execution(self):
         llvm.check_jit_execution()
 
+    @unittest.skipIf(no_de_locale(), "Locale not available")
     def test_print_double_locale(self):
         m = self.module(asm_double_locale)
         expect = str(m)


### PR DESCRIPTION
... and reverting afterwards.

* Fix #80
* Without the fix, LLVM will fail with an assertion.
