### PR TITLE
Add IRBuilder.debug_metadata attribute

### DIFF
--- a/docs/source/ir/builder.rst
+++ b/docs/source/ir/builder.rst
@@ -19,6 +19,10 @@ pointer inside the block's list of instructions.  When adding a new
 instruction, it is inserted at that point and the pointer is then advanced
 after the new instruction.
 
+A :class:`IRBuilder` also maintains a reference to metadata describing
+the current source location, which will be attached to all inserted
+instructions.
+
 Instantiation
 -------------
 
@@ -45,6 +49,10 @@ Properties
 
    The module the builder's function is defined in.
 
+.. attribute:: IRBuilder.debug_metadata
+
+   If not `None`, the metadata that will be attached to any inserted
+   instructions as `!dbg`, unless the instruction already has `!dbg` set.
 
 Utilities
 ---------

--- a/llvmlite/ir/builder.py
+++ b/llvmlite/ir/builder.py
@@ -84,6 +84,7 @@ class IRBuilder(object):
     def __init__(self, block=None):
         self._block = block
         self._anchor = len(block.instructions) if block else 0
+        self.debug_metadata = None
 
     @property
     def block(self):
@@ -206,6 +207,8 @@ class IRBuilder(object):
         self.position_at_end(bbend)
 
     def _insert(self, instr):
+        if self.debug_metadata is not None and 'dbg' not in instr.metadata:
+            instr.metadata['dbg'] = self.debug_metadata
         self._block.instructions.insert(self._anchor, instr)
         self._anchor += 1
 

--- a/llvmlite/tests/test_ir.py
+++ b/llvmlite/tests/test_ir.py
@@ -1018,6 +1018,16 @@ class TestBuilderMisc(TestBase):
             three:
             """)
 
+    def test_metadata(self):
+        block = self.block(name='my_block')
+        builder = ir.IRBuilder(block)
+        builder.debug_metadata = builder.module.add_metadata([])
+        a = builder.alloca(ir.PointerType(int32), name='c')
+        self.check_block(block, """\
+            my_block:
+                %"c" = alloca i32*, !dbg !0
+            """)
+
 
 class TestTypes(TestBase):
 


### PR DESCRIPTION
This attribute may be set by the frontend once prior to emitting
many LLVM IR instructions corresponding to a single source-level
entity (such as an AST node).