### PR TITLE
try to find .dll in local directory to fix support for frozen apps

### DIFF
--- a/llvmlite/binding/ffi.py
+++ b/llvmlite/binding/ffi.py
@@ -34,7 +34,11 @@ if os.name == 'nt':
     # (Windows uses PATH for DLL loading, see http://msdn.microsoft.com/en-us/library/7d83bc18.aspx).
     os.environ['PATH'] += ';' + _lib_dir
 
-lib = ctypes.CDLL(os.path.join(_lib_dir, get_library_name()))
+_lib_name = get_library_name()
+try:
+    lib = ctypes.CDLL(os.path.join(_lib_dir, _lib_name))
+except:
+    lib = ctypes.CDLL(_lib_name)
 
 
 class _DeadPointer(object):


### PR DESCRIPTION
Fixes (AFAIK) numba/numba#1177

With this PR, we simply need to copy llvmlite.dll to the frozen executable directory and it works.