### PR TITLE
Support profiing with OProfile

### DIFF
--- a/llvmlite/binding/executionengine.py
+++ b/llvmlite/binding/executionengine.py
@@ -117,6 +117,15 @@ class ExecutionEngine(ffi.ObjectRef):
         self._td._owned = True
         return self._td
 
+    def enable_jit_events(self):
+        """
+        Enable JIT events for profiling of generated code.
+        Return value indicates whether connection to profiling tool
+        was successful.
+        """
+        ret = ffi.lib.LLVMPY_EnableJITEvents(self)
+        return ret
+
     def _find_module_ptr(self, module_ptr):
         """
         Find the ModuleRef corresponding to the given pointer.


### PR DESCRIPTION
Add the OProfile JIT event listener to allow the JIT'ed code
to be analyzed with a hardware profiler on Linux.

To enable this code:
 - enable LLVM for OProfile JIT events (-DLLVM_USE_OPROFILE=ON)
 - define USE_OPROFILE_JITEVENTS when compiling llvmlite
 - define environment variable ENABLE_JITPROFILING
 - LD_LIBRARY_PATH may need to point to the directory containing
        libopagent.so (/usr/lib/oprofile)

Tested with LLVM 3.6

Annotating assembly works (with opannotate), but I think debug information will be needed to annotate source (see issue #10 )