### PR TITLE
Adapt Travis config for Trusty beta

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,12 +11,13 @@ dist: trusty
     #packages:
       #- g++-4.8
 
-python:
-  - env: PYTHON=2.6
-  #- env: PYTHON=2.7
-  #- env: PYTHON=3.3
-  #- env: PYTHON=3.4
-  - env: PYTHON=3.5
+matrix:
+    include:
+        - env: PYTHON=2.6
+        #- env: PYTHON=2.7
+        #- env: PYTHON=3.3
+        #- env: PYTHON=3.4
+        - env: PYTHON=3.5
 
 before_install:
     # Install Miniconda
@@ -46,7 +47,7 @@ script:
     - cd $TRAVIS_BUILD_DIR; python runtests.py -v
 
 notifications:
-  email: false
-  flowdock: "cb7bc57e58b3d42f77685f93211c03ab"
-  on_success: "change"
-  on_failure: "always" # "change"
+    email: false
+    flowdock: "cb7bc57e58b3d42f77685f93211c03ab"
+    on_success: "change"
+    on_failure: "always" # "change"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,22 +1,14 @@
 # References https://gist.github.com/dan-blanchard/7045057
-language: python
+# and https://docs.travis-ci.com/user/trusty-ci-environment/
 
-#sudo: required
 dist: trusty
-
-#addons:
-  #apt:
-    #sources:
-      #- ubuntu-toolchain-r-test
-    #packages:
-      #- g++-4.8
 
 matrix:
     include:
         - env: PYTHON=2.6
-        #- env: PYTHON=2.7
-        #- env: PYTHON=3.3
-        #- env: PYTHON=3.4
+        - env: PYTHON=2.7
+        - env: PYTHON=3.3
+        - env: PYTHON=3.4
         - env: PYTHON=3.5
 
 before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,21 +1,22 @@
 # References https://gist.github.com/dan-blanchard/7045057
 language: python
 
-sudo: false
+#sudo: required
+dist: trusty
 
-addons:
-  apt:
-    sources:
-      - ubuntu-toolchain-r-test
-    packages:
-      - g++-4.8
+#addons:
+  #apt:
+    #sources:
+      #- ubuntu-toolchain-r-test
+    #packages:
+      #- g++-4.8
 
 python:
-  - "2.6"
-  - "2.7"
-  - "3.3"
-  - "3.4"
-  - "3.5-dev"
+  - env: PYTHON=2.6
+  #- env: PYTHON=2.7
+  #- env: PYTHON=3.3
+  #- env: PYTHON=3.4
+  - env: PYTHON=3.5
 
 before_install:
     # Install Miniconda
@@ -23,22 +24,20 @@ before_install:
     - chmod +x miniconda.sh
     - ./miniconda.sh -b
     - export PATH=$HOME/miniconda3/bin:$PATH
-    - PY_MAJOR_MINOR=${TRAVIS_PYTHON_VERSION:0:3}
     - CONDA_INSTALL="conda install --yes -q"
     # Setup environment
-    - conda create -n travisci --yes python=$PY_MAJOR_MINOR
+    - conda create -n travisci --yes python=$PYTHON
     - source activate travisci
     # Install llvmdev (separate channel, for now)
     - $CONDA_INSTALL -c numba llvmdev="3.6*"
     # Install unittest2 and argparse for Python 2.6
-    - if [ $PY_MAJOR_MINOR == "2.6" ]; then $CONDA_INSTALL unittest2 argparse; fi
+    - if [ $PYTHON == "2.6" ]; then $CONDA_INSTALL unittest2 argparse; fi
     # Install enum34 for Python < 3.4
-    - if [ $PY_MAJOR_MINOR \< "3.4" ]; then $CONDA_INSTALL enum34; fi
+    - if [ $PYTHON \< "3.4" ]; then $CONDA_INSTALL enum34; fi
     # Install dependencies for building the docs
     - $CONDA_INSTALL pip sphinx sphinx_rtd_theme pygments
 
 install:
-    - export CXX=g++-4.8
     - python setup.py build
 
 script:


### PR DESCRIPTION
This avoids having to install and activate a gcc backport.

See https://docs.travis-ci.com/user/trusty-ci-environment/