### PR TITLE
Let Type.get_abi_{size,alignment} not choke on identified types.

### DIFF
--- a/llvmlite/ir/types.py
+++ b/llvmlite/ir/types.py
@@ -42,31 +42,34 @@ class Type(object):
     def __ne__(self, other):
         return not (self == other)
 
-    def _get_ll_pointer_type(self, target_data):
+    def _get_ll_pointer_type(self, target_data, context=None):
         """
         Convert this type object to an LLVM type.
         """
         from . import Module, GlobalVariable
         from ..binding import parse_assembly
 
-        m = Module()
+        if context is None:
+            m = Module()
+        else:
+            m = Module(context=context)
         foo = GlobalVariable(m, self, name="foo")
         with parse_assembly(str(m)) as llmod:
             return llmod.get_global_variable(foo.name).type
 
-    def get_abi_size(self, target_data):
+    def get_abi_size(self, target_data, context=None):
         """
         Get the ABI size of this type according to data layout *target_data*.
         """
-        llty = self._get_ll_pointer_type(target_data)
+        llty = self._get_ll_pointer_type(target_data, context)
         return target_data.get_pointee_abi_size(llty)
 
-    def get_abi_alignment(self, target_data):
+    def get_abi_alignment(self, target_data, context=None):
         """
         Get the minimum ABI alignment of this type according to data layout
         *target_data*.
         """
-        llty = self._get_ll_pointer_type(target_data)
+        llty = self._get_ll_pointer_type(target_data, context)
         return target_data.get_pointee_abi_alignment(llty)
 
     def format_const(self, val):

--- a/llvmlite/tests/test_ir.py
+++ b/llvmlite/tests/test_ir.py
@@ -1175,6 +1175,14 @@ class TestTypes(TestBase):
         self.assert_valid_ir(module)
         self.assertNotEqual(oldstr, str(module))
 
+    def test_target_data_non_default_context(self):
+        context = ir.Context()
+        mytype = context.get_identified_type("MyType")
+        mytype.elements = [ir.IntType(32)]
+        module = ir.Module(context=context)
+        td = llvm.create_target_data("e-m:e-i64:64-f80:128-n8:16:32:64-S128")
+        self.assertEqual(mytype.get_abi_size(td, context=context), 4)
+
 
 c32 = lambda i: ir.Constant(int32, i)
 


### PR DESCRIPTION
If an identified struct type from a context that is not global
is used anywhere in the type that is passed to
get_abi_{size,alignment}, the generated LLVM IR is invalid.

This pull request adds a `context` argument, which allows
to specify a non-global context explicitly.