### PR TITLE
Fix #121: simplify build process on Unix

### DIFF
--- a/ffi/Makefile.linux
+++ b/ffi/Makefile.linux
@@ -4,9 +4,7 @@ CXX ?= g++
 # -flto and --exclude-libs allow us to remove those parts of LLVM we don't use
 CXXFLAGS = $(LLVM_CXXFLAGS) -flto
 LDFLAGS = $(LLVM_LDFLAGS) -flto -Wl,--exclude-libs=ALL
-# Need to add LLVMOProfileJIT by hand
-# see https://llvm.org/bugs/show_bug.cgi?id=25091
-LIBS = $(LLVM_LIBS) -lLLVMOProfileJIT
+LIBS = $(LLVM_LIBS)
 SRC = assembly.cpp bitcode.cpp core.cpp initfini.cpp module.cpp value.cpp \
 	  executionengine.cpp transforms.cpp passmanagers.cpp targets.cpp dylib.cpp \
 	  linker.cpp

--- a/ffi/build.py
+++ b/ffi/build.py
@@ -108,13 +108,7 @@ def main_posix(kind, library_ext):
                            "to the path for llvm-config" % (llvm_config,))
 
     # Get LLVM information for building
-    # Note we can't use "--libs all" anymore:
-    # https://llvm.org/bugs/show_bug.cgi?id=25088
-    # https://llvm.org/bugs/show_bug.cgi?id=25089
-    libs = run_llvm_config(llvm_config,
-                           "--system-libs --libs engine bitreader "
-                           "bitwriter instrumentation lto irreader "
-                           "asmprinter".split())
+    libs = run_llvm_config(llvm_config, "--system-libs --libs all".split())
     # Normalize whitespace (trim newlines)
     os.environ['LLVM_LIBS'] = ' '.join(libs.split())
 


### PR DESCRIPTION
The workarounds we used to have for bugs in llvm-config don't seem necessary anymore.