### PR TITLE
MAINT: ensure no CMakeCache.txt file is included in sdist.

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -3,3 +3,4 @@ include versioneer.py
 include llvmlite/_version.py
 recursive-include examples *.py *.ll
 recursive-include ffi *.txt *.h *.cpp Makefile.* *.py
+global-exclude CMakeCache.txt


### PR DESCRIPTION
Having stray `CMakeCache.txt` files cause trouble when building on windows. Removing them is easier than trying to understand cmake :)

Fix #140 