### PR TITLE
Allow overriding flto in ffi builds on Linux.

### DIFF
--- a/ffi/Makefile.linux
+++ b/ffi/Makefile.linux
@@ -2,8 +2,11 @@
 CXX ?= g++
 
 # -flto and --exclude-libs allow us to remove those parts of LLVM we don't use
-CXXFLAGS = $(LLVM_CXXFLAGS) -flto
-LDFLAGS = $(LLVM_LDFLAGS) -flto -Wl,--exclude-libs=ALL
+CXX_FLTO_FLAGS ?= -flto
+LD_FLTO_FLAGS ?= -flto -Wl,--exclude-libs=ALL
+
+CXXFLAGS = $(LLVM_CXXFLAGS) $(CXX_FLTO_FLAGS)
+LDFLAGS = $(LLVM_LDFLAGS) $(LD_FLTO_FLAGS)
 LIBS = $(LLVM_LIBS)
 SRC = assembly.cpp bitcode.cpp core.cpp initfini.cpp module.cpp value.cpp \
 	  executionengine.cpp transforms.cpp passmanagers.cpp targets.cpp dylib.cpp \
@@ -18,4 +21,4 @@ $(OUTPUT): $(SRC)
 	$(CXX) -static-libstdc++ -shared $(CXXFLAGS) $(SRC) -o $(OUTPUT) $(LDFLAGS) $(LIBS)
 
 clean:
-	rm -rf test
+	rm -rf test $(OUTPUT)


### PR DESCRIPTION
Background: Clang & LLVM's binary releases are now built with Clang itself,
which means we have to compile llvmlite with Clang when compiling vs. a binary
release taken from http://llvm.org/releases/

However, in that case Clang looks for the Gold plugin for LTO, which is not
built into the binaries by default. So this makes building llvmlite on your own
very cumbersome.

Alternatively we can just not use LTO. This change permits overriding the LTO
setting from the environment when needed.