### PR TITLE
Implement LLVM scoping correctly

### DIFF
--- a/llvmlite/ir/_utils.py
+++ b/llvmlite/ir/_utils.py
@@ -8,18 +8,12 @@ class DuplicatedNameError(NameError):
 
 
 class NameScope(object):
-    def __init__(self, parent=None):
-        self.parent = parent
+    def __init__(self):
         self._useset = set([''])
         self._basenamemap = defaultdict(int)
 
     def is_used(self, name):
-        scope = self
-        while scope is not None:
-            if name in scope._useset:
-                return True
-            scope = scope.parent
-        return False
+        return name in self._useset
 
     def register(self, name, deduplicate=False):
         if deduplicate:

--- a/llvmlite/ir/module.py
+++ b/llvmlite/ir/module.py
@@ -1,5 +1,5 @@
 from __future__ import print_function, absolute_import
-from . import context, values, types
+from . import context, values, types, _utils
 
 
 class Module(object):
@@ -11,7 +11,7 @@ class Module(object):
         self._metadatacache = {}
         self.data_layout = ""
         self.namedmetadata = {}
-        self.scope = context.scope.get_child()
+        self.scope = _utils.NameScope()
         self.triple = 'unknown-unknown-unknown'
         self._sequence = []
 


### PR DESCRIPTION
LLVM has three scopes: a context-level scope that contains named
types (which have a %name); a module-level scope that contains named
globals (which have a @name); and a function-level scope that
contains instructions (which have a %name). Names in all three scopes
cannot conflict: either the sigil is different, or the sigil is
the same but the names appear in disjoint lexical positions.

So, remove all the logic responsible for handling nested scopes,
since it is pointless.