### PR TITLE
Always copy TargetData when adding to a pass manager

### DIFF
--- a/llvmlite/binding/targets.py
+++ b/llvmlite/binding/targets.py
@@ -149,9 +149,9 @@ class TargetData(ffi.ObjectRef):
         """
         Add a DataLayout pass to PassManager *pm*.
         """
-        ffi.lib.LLVMPY_AddTargetData(self, pm)
-        # Once added to a PassManager, we can never get it back.
-        self._owned = True
+        # AddTargetData claims ownership, so create a copy.
+        target_data = create_target_data(str(self))
+        ffi.lib.LLVMPY_AddTargetData(target_data, pm)
 
 
 RELOC = frozenset(['default', 'static', 'pic', 'dynamicnopic'])

--- a/llvmlite/tests/test_binding.py
+++ b/llvmlite/tests/test_binding.py
@@ -794,6 +794,11 @@ class TestTargetData(BaseTest):
 
 class TestTargetMachine(BaseTest):
 
+    def test_add_target_data_pass(self):
+        tm = self.target_machine()
+        pm = llvm.create_module_pass_manager()
+        tm.target_data.add_pass(pm)
+
     def test_add_analysis_passes(self):
         tm = self.target_machine()
         pm = llvm.create_module_pass_manager()


### PR DESCRIPTION
There was no check of self._owned, which could lead to a segfault
during the straightforward use of the API. It is essentially never
useful to have a reference to TargetData owned by the pass manager,
so just always make a copy instead.