### PR TITLE
Expose initialize_all_{targets,asmprinters}

### DIFF
--- a/docs/source/binding/initfini.rst
+++ b/docs/source/binding/initfini.rst
@@ -11,6 +11,16 @@ These functions need only be called once per process invocation.
 
    Initialize the LLVM core.
 
+.. function:: initialize_all_targets()
+
+   Initialize all targets. Necessary before targets can be looked up
+   via the :class:`Target` class.
+
+.. function:: initialize_all_asmprinters()
+
+   Initialize all code generators. Necessary before generating
+   any assembly or machine code via the :meth:`TargetMachine.emit_object`
+   and :meth:`TargetMachine.emit_assembly` methods.
 
 .. function:: initialize_native_target()
 

--- a/ffi/initfini.cpp
+++ b/ffi/initfini.cpp
@@ -38,9 +38,10 @@ LLVMPY_Shutdown(){
 // NOTE: it is important that we don't export functions which we don't use,
 // especially those which may pull in large amounts of additional code or data.
 
-// INIT(AllTargetInfos)
-// INIT(AllTargets)
-// INIT(AllTargetMCs)
+INIT(AllTargetInfos)
+INIT(AllTargets)
+INIT(AllTargetMCs)
+INIT(AllAsmPrinters)
 INIT(NativeTarget)
 INIT(NativeAsmParser)
 INIT(NativeAsmPrinter)

--- a/llvmlite/binding/initfini.py
+++ b/llvmlite/binding/initfini.py
@@ -10,6 +10,24 @@ def initialize():
     ffi.lib.LLVMPY_InitializeCore()
 
 
+def initialize_all_targets():
+    """
+    Initialize all targets. Necessary before targets can be looked up
+    via the :class:`Target` class.
+    """
+    ffi.lib.LLVMPY_InitializeAllTargetInfos()
+    ffi.lib.LLVMPY_InitializeAllTargets()
+    ffi.lib.LLVMPY_InitializeAllTargetMCs()
+
+def initialize_all_asmprinters():
+    """
+    Initialize all code generators. Necessary before generating
+    any assembly or machine code via the :meth:`TargetMachine.emit_object`
+    and :meth:`TargetMachine.emit_assembly` methods.
+    """
+    ffi.lib.LLVMPY_InitializeAllAsmPrinters()
+
+
 def initialize_native_target():
     """
     Initialize the native (host) target.  Necessary before doing any

--- a/llvmlite/tests/test_binding.py
+++ b/llvmlite/tests/test_binding.py
@@ -246,6 +246,8 @@ class TestMisc(BaseTest):
             llvm.initialize()
             llvm.initialize_native_target()
             llvm.initialize_native_asmprinter()
+            llvm.initialize_all_targets()
+            llvm.initialize_all_asmprinters()
             llvm.shutdown()
             """
         subprocess.check_call([sys.executable, "-c", code])


### PR DESCRIPTION
Without this, it's not possible to emit assembly or code directly using llvmlite, which severely limits its usefulness; one would have to resort to executing llc, which means search path problems, Windows compatibility problems, etc. So, the resulting enlargement of the package is worth it.