### PR TITLE
Remove deprecated uses of TargetMachine::getDataLayout()

### DIFF
--- a/ffi/targets.cpp
+++ b/ffi/targets.cpp
@@ -29,6 +29,10 @@ inline Target *unwrap(LLVMTargetRef T) {
     return reinterpret_cast<Target*>(T);
 }
 
+inline TargetMachine *unwrap(LLVMTargetMachineRef TM) {
+    return reinterpret_cast<TargetMachine *>(TM);
+}
+
 inline LLVMTargetMachineRef wrap(TargetMachine *TM) {
     return reinterpret_cast<LLVMTargetMachineRef>(TM);
 }
@@ -268,9 +272,9 @@ LLVMPY_TargetMachineEmitToMemory (
 }
 
 API_EXPORT(LLVMTargetDataRef)
-LLVMPY_GetTargetMachineData(LLVMTargetMachineRef TM)
+LLVMPY_CreateTargetMachineData(LLVMTargetMachineRef TM)
 {
-    return LLVMGetTargetMachineData(TM);
+    return llvm::wrap(new llvm::DataLayout(llvm::unwrap(TM)->createDataLayout()));
 }
 
 API_EXPORT(void)

--- a/llvmlite/binding/targets.py
+++ b/llvmlite/binding/targets.py
@@ -285,9 +285,7 @@ class TargetMachine(ffi.ObjectRef):
 
     @property
     def target_data(self):
-        td = TargetData(ffi.lib.LLVMPY_GetTargetMachineData(self))
-        td._owned = True
-        return td
+        return TargetData(ffi.lib.LLVMPY_CreateTargetMachineData(self))
 
     @property
     def triple(self):
@@ -389,7 +387,7 @@ ffi.lib.LLVMPY_GetBufferSize.restype = c_size_t
 
 ffi.lib.LLVMPY_DisposeMemoryBuffer.argtypes = [ffi.LLVMMemoryBufferRef]
 
-ffi.lib.LLVMPY_GetTargetMachineData.argtypes = [
+ffi.lib.LLVMPY_CreateTargetMachineData.argtypes = [
     ffi.LLVMTargetMachineRef,
 ]
-ffi.lib.LLVMPY_GetTargetMachineData.restype = ffi.LLVMTargetDataRef
+ffi.lib.LLVMPY_CreateTargetMachineData.restype = ffi.LLVMTargetDataRef


### PR DESCRIPTION
`TargetMachine::getDataLayout()` is going away in LLVM 3.8. `TargetMachine::createDataLayout()` returns `DataLayout` by value, so I'm wrapping it in `new`.