### PR TITLE
Expose functions to create individual passes

### DIFF
--- a/docs/source/binding/passmanager.rst
+++ b/docs/source/binding/passmanager.rst
@@ -56,13 +56,79 @@ configure a :class:`PassManagerBuilder`.
 
 .. class:: PassManager
 
-   The base class for pass managers.
+   The base class for pass managers. Use individual ``add_*`` methods
+   or :meth:`PassManagerBuilder.populate` to add optimization passes.
 
+
+   .. function:: add_constant_merge_pass()
+
+      See `pass documentation <http://llvm.org/docs/Passes.html#constmerge-merge-duplicate-global-constants>`_.
+
+   .. function:: add_dead_arg_elimination_pass()
+
+      See `pass documentation <http://llvm.org/docs/Passes.html#deadargelim-dead-argument-elimination>`_.
+
+   .. function:: add_function_attrs_pass()
+
+      See `pass documentation <http://llvm.org/docs/Passes.html#functionattrs-deduce-function-attributes>`_.
+
+   .. function:: add_function_inlining_pass(self, )
+
+      See `pass documentation <http://llvm.org/docs/Passes.html#inline-function-integration-inlining>`_.
+
+   .. function:: add_global_dce_pass()
+
+      See `pass documentation <http://llvm.org/docs/Passes.html#globaldce-dead-global-elimination>`_.
+
+   .. function:: add_global_optimizer_pass()
+
+      See `pass documentation <http://llvm.org/docs/Passes.html#globalopt-global-variable-optimizer>`_.
+
+   .. function:: add_ipsccp_pass()
+
+      See `pass documentation <http://llvm.org/docs/Passes.html#ipsccp-interprocedural-sparse-conditional-constant-propagation>`_.
+
+   .. function:: add_dead_code_elimination_pass()
+
+      See `pass documentation <http://llvm.org/docs/Passes.html#dce-dead-code-elimination>`_.
+
+   .. function:: add_cfg_simplification_pass()
+
+      See `pass documentation <http://llvm.org/docs/Passes.html#simplifycfg-simplify-the-cfg>`_.
+
+   .. function:: add_gvn_pass()
+
+      See `pass documentation <http://llvm.org/docs/Passes.html#gvn-global-value-numbering>`_.
+
+   .. function:: add_instruction_combining_pass()
+
+      See `pass documentation <http://llvm.org/docs/Passes.html#passes-instcombine>`_.
+
+   .. function:: add_licm_pass()
+
+      See `pass documentation <http://llvm.org/docs/Passes.html#licm-loop-invariant-code-motion>`_.
+
+   .. function:: add_sccp_pass()
+
+      See `pass documentation <http://llvm.org/docs/Passes.html#sccp-sparse-conditional-constant-propagation>`_.
+
+   .. function:: add_sroa_pass()
+
+      See `pass documentation <http://llvm.org/docs/Passes.html#scalarrepl-scalar-replacement-of-aggregates>`_.
+
+      Note that while the link above describes the transformation performed by the pass
+      added by this function, it corresponds to the ``opt -sroa`` command-line option
+      and not ``opt -scalarrepl``.
+
+   .. function:: add_type_based_alias_analysis_pass()
+
+   .. function:: add_basic_alias_analysis_pass()
+
+      See `pass documentation <http://llvm.org/docs/AliasAnalysis.html#the-basicaa-pass>`_.
 
 .. class:: ModulePassManager()
 
    Create a new pass manager to run optimization passes on a module.
-   Use :meth:`PassManagerBuilder.populate` to add optimization passes.
 
    The following method is available:
 
@@ -77,7 +143,6 @@ configure a :class:`PassManagerBuilder`.
 
    Create a new pass manager to run optimization passes on a function of
    the given *module* (an :class:`ModuleRef` instance).
-   Use :meth:`PassManagerBuilder.populate` to add optimization passes.
 
    The following methods are available:
 

--- a/ffi/passmanagers.cpp
+++ b/ffi/passmanagers.cpp
@@ -1,5 +1,11 @@
 #include "core.h"
+#include "llvm-c/Transforms/Scalar.h"
+#include "llvm-c/Transforms/IPO.h"
+#include "llvm/IR/LegacyPassManager.h"
+#include "llvm/Transforms/Scalar.h"
+#include "llvm/Transforms/IPO.h"
 
+using namespace llvm;
 
 extern "C" {
 
@@ -46,6 +52,102 @@ API_EXPORT(int)
 LLVMPY_FinalizeFunctionPassManager(LLVMPassManagerRef FPM)
 {
     return LLVMFinalizeFunctionPassManager(FPM);
+}
+
+API_EXPORT(void)
+LLVMPY_AddConstantMergePass(LLVMPassManagerRef PM)
+{
+    LLVMAddConstantMergePass(PM);
+}
+
+API_EXPORT(void)
+LLVMPY_AddDeadArgEliminationPass(LLVMPassManagerRef PM)
+{
+    LLVMAddDeadArgEliminationPass(PM);
+}
+
+API_EXPORT(void)
+LLVMPY_AddFunctionAttrsPass(LLVMPassManagerRef PM)
+{
+    LLVMAddFunctionAttrsPass(PM);
+}
+
+API_EXPORT(void)
+LLVMPY_AddFunctionInliningPass(LLVMPassManagerRef PM, int Threshold)
+{
+    unwrap(PM)->add(createFunctionInliningPass(Threshold));
+}
+
+API_EXPORT(void)
+LLVMPY_AddGlobalOptimizerPass(LLVMPassManagerRef PM)
+{
+    LLVMAddGlobalOptimizerPass(PM);
+}
+
+API_EXPORT(void)
+LLVMPY_AddGlobalDCEPass(LLVMPassManagerRef PM)
+{
+    LLVMAddGlobalDCEPass(PM);
+}
+
+API_EXPORT(void)
+LLVMPY_AddIPSCCPPass(LLVMPassManagerRef PM)
+{
+    LLVMAddIPSCCPPass(PM);
+}
+
+API_EXPORT(void)
+LLVMPY_AddDeadCodeEliminationPass(LLVMPassManagerRef PM)
+{
+    unwrap(PM)->add(createDeadCodeEliminationPass());
+}
+
+API_EXPORT(void)
+LLVMPY_AddCFGSimplificationPass(LLVMPassManagerRef PM)
+{
+    LLVMAddCFGSimplificationPass(PM);
+}
+
+API_EXPORT(void)
+LLVMPY_AddGVNPass(LLVMPassManagerRef PM)
+{
+    LLVMAddGVNPass(PM);
+}
+
+API_EXPORT(void)
+LLVMPY_AddInstructionCombiningPass(LLVMPassManagerRef PM)
+{
+    LLVMAddInstructionCombiningPass(PM);
+}
+
+API_EXPORT(void)
+LLVMPY_AddLICMPass(LLVMPassManagerRef PM)
+{
+    LLVMAddLICMPass(PM);
+}
+
+API_EXPORT(void)
+LLVMPY_AddSCCPPass(LLVMPassManagerRef PM)
+{
+    LLVMAddSCCPPass(PM);
+}
+
+API_EXPORT(void)
+LLVMPY_AddSROAPass(LLVMPassManagerRef PM)
+{
+    unwrap(PM)->add(createSROAPass());
+}
+
+API_EXPORT(void)
+LLVMPY_AddTypeBasedAliasAnalysisPass(LLVMPassManagerRef PM)
+{
+    LLVMAddTypeBasedAliasAnalysisPass(PM);
+}
+
+API_EXPORT(void)
+LLVMPY_AddBasicAliasAnalysisPass(LLVMPassManagerRef PM)
+{
+    LLVMAddBasicAliasAnalysisPass(PM);
 }
 
 } // end extern "C"

--- a/llvmlite/binding/passmanagers.py
+++ b/llvmlite/binding/passmanagers.py
@@ -1,5 +1,5 @@
 from __future__ import print_function, absolute_import
-from ctypes import c_bool
+from ctypes import c_bool, c_int
 from . import ffi
 
 
@@ -17,6 +17,71 @@ class PassManager(ffi.ObjectRef):
 
     def _dispose(self):
         self._capi.LLVMPY_DisposePassManager(self)
+
+    def add_constant_merge_pass(self):
+        """See http://llvm.org/docs/Passes.html#constmerge-merge-duplicate-global-constants."""
+        ffi.lib.LLVMPY_AddConstantMergePass(self)
+
+    def add_dead_arg_elimination_pass(self):
+        """See http://llvm.org/docs/Passes.html#deadargelim-dead-argument-elimination."""
+        ffi.lib.LLVMPY_AddDeadArgEliminationPass(self)
+
+    def add_function_attrs_pass(self):
+        """See http://llvm.org/docs/Passes.html#functionattrs-deduce-function-attributes."""
+        ffi.lib.LLVMPY_AddFunctionAttrsPass(self)
+
+    def add_function_inlining_pass(self, threshold):
+        """See http://llvm.org/docs/Passes.html#inline-function-integration-inlining."""
+        ffi.lib.LLVMPY_AddFunctionInliningPass(self, threshold)
+
+    def add_global_dce_pass(self):
+        """See http://llvm.org/docs/Passes.html#globaldce-dead-global-elimination."""
+        ffi.lib.LLVMPY_AddGlobalDCEPass(self)
+
+    def add_global_optimizer_pass(self):
+        """See http://llvm.org/docs/Passes.html#globalopt-global-variable-optimizer."""
+        ffi.lib.LLVMPY_AddGlobalOptimizerPass(self)
+
+    def add_ipsccp_pass(self):
+        """See http://llvm.org/docs/Passes.html#ipsccp-interprocedural-sparse-conditional-constant-propagation."""
+        ffi.lib.LLVMPY_AddIPSCCPPass(self)
+
+    def add_dead_code_elimination_pass(self):
+        """See http://llvm.org/docs/Passes.html#dce-dead-code-elimination."""
+        ffi.lib.LLVMPY_AddDeadCodeEliminationPass(self)
+
+    def add_cfg_simplification_pass(self):
+        """See http://llvm.org/docs/Passes.html#simplifycfg-simplify-the-cfg."""
+        ffi.lib.LLVMPY_AddCFGSimplificationPass(self)
+
+    def add_gvn_pass(self):
+        """See http://llvm.org/docs/Passes.html#gvn-global-value-numbering."""
+        ffi.lib.LLVMPY_AddGVNPass(self)
+
+    def add_instruction_combining_pass(self):
+        """See http://llvm.org/docs/Passes.html#passes-instcombine."""
+        ffi.lib.LLVMPY_AddInstructionCombiningPass(self)
+
+    def add_licm_pass(self):
+        """See http://llvm.org/docs/Passes.html#licm-loop-invariant-code-motion."""
+        ffi.lib.LLVMPY_AddLICMPass(self)
+
+    def add_sccp_pass(self):
+        """See http://llvm.org/docs/Passes.html#sccp-sparse-conditional-constant-propagation."""
+        ffi.lib.LLVMPY_AddSCCPPass(self)
+
+    def add_sroa_pass(self):
+        """See http://llvm.org/docs/Passes.html#scalarrepl-scalar-replacement-of-aggregates-dt.
+        Note that this pass corresponds to the ``opt -sroa`` command-line option,
+        despite the link above."""
+        ffi.lib.LLVMPY_AddSROAPass(self)
+
+    def add_type_based_alias_analysis_pass(self):
+        ffi.lib.LLVMPY_AddTypeBasedAliasAnalysisPass(self)
+
+    def add_basic_alias_analysis_pass(self):
+        """See http://llvm.org/docs/AliasAnalysis.html#the-basicaa-pass."""
+        ffi.lib.LLVMPY_AddBasicAliasAnalysisPass(self)
 
 
 class ModulePassManager(PassManager):
@@ -85,3 +150,21 @@ ffi.lib.LLVMPY_FinalizeFunctionPassManager.restype = c_bool
 ffi.lib.LLVMPY_RunFunctionPassManager.argtypes = [ffi.LLVMPassManagerRef,
                                                   ffi.LLVMValueRef]
 ffi.lib.LLVMPY_RunFunctionPassManager.restype = c_bool
+
+ffi.lib.LLVMPY_AddConstantMergePass.argtypes = [ffi.LLVMPassManagerRef]
+ffi.lib.LLVMPY_AddDeadArgEliminationPass.argtypes = [ffi.LLVMPassManagerRef]
+ffi.lib.LLVMPY_AddFunctionAttrsPass.argtypes = [ffi.LLVMPassManagerRef]
+ffi.lib.LLVMPY_AddFunctionInliningPass.argtypes = [ffi.LLVMPassManagerRef, c_int]
+ffi.lib.LLVMPY_AddGlobalDCEPass.argtypes = [ffi.LLVMPassManagerRef]
+ffi.lib.LLVMPY_AddGlobalOptimizerPass.argtypes = [ffi.LLVMPassManagerRef]
+ffi.lib.LLVMPY_AddIPSCCPPass.argtypes = [ffi.LLVMPassManagerRef]
+
+ffi.lib.LLVMPY_AddDeadCodeEliminationPass.argtypes = [ffi.LLVMPassManagerRef]
+ffi.lib.LLVMPY_AddCFGSimplificationPass.argtypes = [ffi.LLVMPassManagerRef]
+ffi.lib.LLVMPY_AddGVNPass.argtypes = [ffi.LLVMPassManagerRef]
+ffi.lib.LLVMPY_AddInstructionCombiningPass.argtypes = [ffi.LLVMPassManagerRef]
+ffi.lib.LLVMPY_AddLICMPass.argtypes = [ffi.LLVMPassManagerRef]
+ffi.lib.LLVMPY_AddSCCPPass.argtypes = [ffi.LLVMPassManagerRef]
+ffi.lib.LLVMPY_AddSROAPass.argtypes = [ffi.LLVMPassManagerRef]
+ffi.lib.LLVMPY_AddTypeBasedAliasAnalysisPass.argtypes = [ffi.LLVMPassManagerRef]
+ffi.lib.LLVMPY_AddBasicAliasAnalysisPass.argtypes = [ffi.LLVMPassManagerRef]

--- a/llvmlite/tests/test_binding.py
+++ b/llvmlite/tests/test_binding.py
@@ -938,6 +938,31 @@ class TestFunctionPassManager(BaseTest, PassManagerTestMixin):
         self.assertNotIn("%.4", opt_asm)
 
 
+class TestPasses(BaseTest, PassManagerTestMixin):
+
+    def pm(self):
+        return llvm.create_module_pass_manager()
+
+    def test_populate(self):
+        pm = self.pm()
+        pm.add_constant_merge_pass()
+        pm.add_dead_arg_elimination_pass()
+        pm.add_function_attrs_pass()
+        pm.add_function_inlining_pass(225)
+        pm.add_global_dce_pass()
+        pm.add_global_optimizer_pass()
+        pm.add_ipsccp_pass()
+        pm.add_dead_code_elimination_pass()
+        pm.add_cfg_simplification_pass()
+        pm.add_gvn_pass()
+        pm.add_instruction_combining_pass()
+        pm.add_licm_pass()
+        pm.add_sccp_pass()
+        pm.add_sroa_pass()
+        pm.add_type_based_alias_analysis_pass()
+        pm.add_basic_alias_analysis_pass()
+
+
 class TestDylib(BaseTest):
 
     def test_bad_library(self):


### PR DESCRIPTION
This is just a bunch of passes our compiler needs, since exposing them all is a lot of work for unclear benefit (indeed, exposing passes no one needs in practice just adds maintenance burden, as they are removed, renamed, etc in newer LLVM versions). However, this list should nevertheless be generally useful.