### PR TITLE
Properly emit IR for metadata null

### DIFF
--- a/llvmlite/ir/values.py
+++ b/llvmlite/ir/values.py
@@ -288,7 +288,10 @@ class MDValue(NamedValue):
         for op in self.operands:
             typestr = str(op.type)
             if isinstance(op.type, types.MetaData):
-                operands.append(op.get_reference())
+                if isinstance(op, Constant) and op.constant == None:
+                    operands.append("null")
+                else:
+                    operands.append(op.get_reference())
             else:
                 operands.append("{0} {1}".format(op.type, op.get_reference()))
         operands = ', '.join(operands)

--- a/llvmlite/tests/test_ir.py
+++ b/llvmlite/tests/test_ir.py
@@ -224,6 +224,12 @@ class TestIR(TestBase):
         self.assertInText("!bar = !{ !0, !0 }", str(mod))
         self.assert_valid_ir(mod)
 
+    def test_metadata_null(self):
+        mod = self.module()
+        md = mod.add_metadata([ir.Constant(ir.PointerType(ir.IntType(32)), None)])
+        self.assertInText("!{ i32* null }", str(mod))
+        self.assert_valid_ir(mod)
+
     def test_inline_assembly(self):
         mod = self.module()
         foo = ir.Function(mod, ir.FunctionType(ir.VoidType(), []), 'foo')


### PR DESCRIPTION
Before, it was emitted as `!0 = { zeroinitializer }`.