### PR TITLE
[WIP] Update Linker for changes in 3.8

### DIFF
--- a/ffi/linker.cpp
+++ b/ffi/linker.cpp
@@ -1,43 +1,12 @@
 #include "core.h"
-#include "llvm/IR/Module.h"
-#include "llvm/IR/DiagnosticPrinter.h"
-#include "llvm/Linker/Linker.h"
-#include "llvm/Support/raw_ostream.h"
+#include "llvm-c/Linker.h"
 
 extern "C" {
 
 API_EXPORT(int)
-LLVMPY_LinkModules(LLVMModuleRef Dest, LLVMModuleRef Src, int Preserve,
-                   const char **Err)
+LLVMPY_LinkModules(LLVMModuleRef Dest, LLVMModuleRef Src)
 {
-    using namespace llvm;
-    std::string errorstring;
-    /* NOTE: can't use LLVMLinkModules() as it fails to return the error
-     * message.
-     */
-    llvm::raw_string_ostream errstream(errorstring);
-    auto diagnose = [&] (const DiagnosticInfo &DI) {
-        switch (DI.getSeverity()) {
-        case DS_Error:
-        case DS_Warning:
-        case DS_Remark:
-        case DS_Note:
-            // Do something different for each of those?
-            break;
-        }
-        llvm::DiagnosticPrinterRawOStream DP(errstream);
-        DI.print(DP);
-    };
-    if (Preserve)
-        Src = LLVMCloneModule(Src);
-    bool failed = Linker::LinkModules(unwrap(Dest), unwrap(Src), diagnose);
-    if (Preserve)
-        LLVMDisposeModule(Src);
-    if (failed) {
-        errstream.flush();
-        *Err = LLVMPY_CreateString(errorstring.c_str());
-    }
-    return failed;
+    return LLVMLinkModules2(Dest, Src);
 }
 
 } // end extern "C"

--- a/llvmlite/binding/linker.py
+++ b/llvmlite/binding/linker.py
@@ -3,12 +3,11 @@ from ctypes import c_int, c_char_p, POINTER
 from . import ffi
 
 
-def link_modules(dst, src, preserve):
+def link_modules(dst, src):
     dst.verify()
     src.verify()
-    with ffi.OutputString() as outerr:
-        if ffi.lib.LLVMPY_LinkModules(dst, src, int(preserve), outerr):
-            raise RuntimeError(str(outerr))
+    if ffi.lib.LLVMPY_LinkModules(dst, src):
+        raise RuntimeError("linking modules failed")
 
 
 ffi.lib.LLVMPY_LinkModules.argtypes = [


### PR DESCRIPTION
This PR is a bit drastic, so let me support the logic behind my changes with a timeline.
  * LLVM adds LinkModules. LinkModules accepts a PreserveSource argument, which was added because someone thought it was useful.
  * PreserveSource argument is not useful. No one uses it.
  * Bit rot sets in.
  * llvmlite implements link_modules, exposing the PreserveSource argument, because whoever wrote that binding decided it was useful.
  * *years pass*
  * PreserveSource in LLVM is discovered to be a buggy feature that no one noticed was buggy because no one used it. It was removed in r220741.

Thus, I think it should just be removed. It's not really the job of llvmlite to emulate obsolete LLVM features that were ripped out from LLVM because no one wanted them. Even if someone does want it, the changes to the frontend are trivial, and they properly highlight the cost of the operation (copying).

As for the diagnostic change: LLVM now reports all errors via the diagnostic handler set via `LLVMContextSetDiagnosticHandler`: linker errors, inline assembly errors, possibly others I don't know of... I feel it is the function that should be exposed, although I'm not sure just quite how. In the meantime, returning a generic error might just be fine, although I would consider defining a separate exception class here.