### PR TITLE
Escape the contents of metadata strings

### DIFF
--- a/llvmlite/ir/values.py
+++ b/llvmlite/ir/values.py
@@ -7,20 +7,22 @@ from __future__ import print_function, absolute_import
 
 import string
 
-from ..six import StringIO
+from ..six import StringIO, text_type
 from . import types, _utils
 from ._utils import _StrCaching, _StringReferenceCaching, _HasMetadata
 
 
 _VALID_CHARS = (frozenset(map(ord, string.ascii_letters)) |
                 frozenset(map(ord, string.digits)) |
-                frozenset('._-$'))
+                frozenset(map(ord, ' !#$%&\'()*+,-./:;<=>?@[]^_`{|}~')))
 
 
 def _escape_string(text, _map={}):
     """
     Escape the given bytestring for safe use as a LLVM array constant.
     """
+    if isinstance(text, str):
+        text = text.encode('ascii')
     assert isinstance(text, (bytes, bytearray))
 
     if not _map:
@@ -258,7 +260,7 @@ class MetaDataString(NamedValue):
         buf += (self.get_reference(), "\n")
 
     def _get_reference(self):
-        return '!"{0}"'.format(self.string)
+        return '!"{0}"'.format(_escape_string(self.string))
 
     _to_string = _get_reference
 

--- a/llvmlite/ir/values.py
+++ b/llvmlite/ir/values.py
@@ -7,7 +7,8 @@ from __future__ import print_function, absolute_import
 
 import string
 
-from ..six import StringIO, text_type
+from .. import six
+from ..six import StringIO
 from . import types, _utils
 from ._utils import _StrCaching, _StringReferenceCaching, _HasMetadata
 
@@ -31,6 +32,8 @@ def _escape_string(text, _map={}):
                 _map[ch] = chr(ch)
             else:
                 _map[ch] = '\\%02x' % ch
+            if six.PY2:
+                _map[chr(ch)] = _map[ch]
 
     buf = [_map[ch] for ch in text]
     return ''.join(buf)

--- a/llvmlite/tests/test_ir.py
+++ b/llvmlite/tests/test_ir.py
@@ -202,6 +202,12 @@ class TestIR(TestBase):
         self.assertInText(pat1, str(mod))
         self.assertInText(pat2, str(mod))
 
+    def test_metadata_string(self):
+        mod = self.module()
+        mod.add_metadata([ir.MetaDataString(mod, "\"\\$")])
+        pat = '!0 = !{ !"\\22\\5c$" }'
+        self.assertInText(pat, str(mod))
+
     def test_named_metadata(self):
         mod = self.module()
         md = mod.add_metadata([ir.Constant(ir.IntType(32), 123)])
@@ -1357,7 +1363,7 @@ class TestConstant(TestBase):
         self.assertEqual(str(c), '[2 x i32] zeroinitializer')
         # Raw array syntax
         c = ir.Constant(ir.ArrayType(int8, 11), bytearray(b"foobar_123\x80"))
-        self.assertEqual(str(c), r'[11 x i8] c"foobar\5f123\80"')
+        self.assertEqual(str(c), r'[11 x i8] c"foobar_123\80"')
         c = ir.Constant(ir.ArrayType(int8, 4), bytearray(b"\x00\x01\x04\xff"))
         self.assertEqual(str(c), r'[4 x i8] c"\00\01\04\ff"')
         # Recursive instantiation of inner constants


### PR DESCRIPTION
Also, allow all printable ASCII characters in IR string literals,
including metadata strings and character array initializers.