### PR TITLE
Allow adding metadata to functions

### DIFF
--- a/docs/source/ir/values.rst
+++ b/docs/source/ir/values.rst
@@ -219,6 +219,11 @@ Global values are values accessible using a module-wide name.
       Similar to :meth:`append_basic_block`, but inserts it before the basic
       block *before* in the function's list of basic blocks.
 
+   .. method:: set_metadata(name, node)
+
+      Add a function-specific metadata named *name* pointing to the given
+      metadata *node* (a :class:`MDValue`).
+
    .. attribute:: args
 
       The function's arguments as a tuple of :class:`Argument` instances.

--- a/llvmlite/ir/_utils.py
+++ b/llvmlite/ir/_utils.py
@@ -53,3 +53,23 @@ class _StringReferenceCaching(object):
         except AttributeError:
             s = self.__cached_refstr = self._get_reference()
             return s
+
+
+class _HasMetadata(object):
+
+    def set_metadata(self, name, node):
+        """
+        Attach unnamed metadata *node* to the metadata slot *name* of this value.
+        """
+        self.metadata[name] = node
+
+    def _stringify_metadata(self, leading_comma=False):
+        if self.metadata:
+            buf = []
+            if leading_comma:
+                buf.append("")
+            buf += ["!{0} {1}".format(k, v.get_reference())
+                    for k, v in self.metadata.items()]
+            return ', '.join(buf)
+        else:
+            return ''

--- a/llvmlite/ir/values.py
+++ b/llvmlite/ir/values.py
@@ -9,7 +9,7 @@ import string
 
 from ..six import StringIO
 from . import types, _utils
-from ._utils import _StrCaching, _StringReferenceCaching
+from ._utils import _StrCaching, _StringReferenceCaching, _HasMetadata
 
 
 _VALID_CHARS = (frozenset(map(ord, string.ascii_letters)) |
@@ -428,7 +428,7 @@ class FunctionAttributes(AttributeSet):
         return ' '.join(attrs)
 
 
-class Function(GlobalValue):
+class Function(GlobalValue, _HasMetadata):
     """Represent a LLVM Function but does uses a Module as parent.
     Global Values are stored as a set of dependencies (attribute `depends`).
     """
@@ -444,6 +444,7 @@ class Function(GlobalValue):
         self.return_value = ReturnValue(self, ftype.return_type)
         self.parent.add_global(self)
         self.calling_convention = ''
+        self.metadata = {}
 
     @property
     def module(self):
@@ -485,7 +486,10 @@ class Function(GlobalValue):
         linkage = self.linkage
         cconv = self.calling_convention
         prefix = " ".join(str(x) for x in [state, linkage, cconv, ret] if x)
-        prototype = "{prefix} {name}({args}{vararg}) {attrs}\n".format(**locals())
+        metadata = self._stringify_metadata()
+        prototype = "{prefix} {name}({args}{vararg}) {attrs}{metadata}\n".format(
+            prefix=prefix, name=name, args=args, vararg=vararg,
+            attrs=attrs, metadata=metadata)
         buf.append(prototype)
 
     def descr_body(self, buf):

--- a/llvmlite/tests/test_ir.py
+++ b/llvmlite/tests/test_ir.py
@@ -127,6 +127,16 @@ class TestFunction(TestBase):
             """declare noalias i32 @"my_func"(i32 zeroext %".1", i32 %".2", double %".3", i32* nonnull %".4")"""
             )
 
+    def test_function_metadata(self):
+        # Now with function metadata
+        module = self.module()
+        func = self.function(module)
+        func.set_metadata('dbg', module.add_metadata([]))
+        asm = self.descr(func).strip()
+        self.assertEqual(asm,
+            """declare i32 @"my_func"(i32 %".1", i32 %".2", double %".3", i32* %".4") !dbg !0"""
+            )
+
     def test_define(self):
         # A simple definition
         func = self.function()


### PR DESCRIPTION
This was brought in around LLVM 3.7 and is only currently used for debug information.

I feel like the `leading_comma` parameter, when it exists, should default to `False`, hence a bit of churn below.