### PR TITLE
Add support for debug information

### DIFF
--- a/llvmlite/ir/module.py
+++ b/llvmlite/ir/module.py
@@ -31,6 +31,23 @@ class Module(object):
             md = self._metadatacache[key]
         return md
 
+    def add_debug_info(self, kind, operands, is_distinct=False):
+        """
+        Add debug information metadata to the module with the given
+        *operands* (a dict of values with string keys) or return
+        a previous equivalent metadata. A DIValue instance is returned,
+        it can then be associated to e.g. an instruction.
+        """
+        n = len(self.metadata)
+        operands = tuple(sorted(operands.items()))
+        key = (kind, operands, is_distinct)
+        if key not in self._metadatacache:
+            di = values.DIValue(self, is_distinct, kind, operands, name=str(n))
+            self._metadatacache[key] = di
+        else:
+            di = self._metadatacache[key]
+        return di
+
     def add_named_metadata(self, name):
         nmd = values.NamedMetaData(self)
         self.namedmetadata[name] = nmd

--- a/llvmlite/ir/values.py
+++ b/llvmlite/ir/values.py
@@ -298,14 +298,9 @@ class MDValue(NamedValue):
         self.operands = tuple(values)
         parent.metadata.append(self)
 
-    @property
-    def operand_count(self):
-        return len(self.operands)
-
     def descr(self, buf):
         operands = []
         for op in self.operands:
-            typestr = str(op.type)
             if isinstance(op.type, types.MetaData):
                 if isinstance(op, Constant) and op.constant == None:
                     operands.append("null")
@@ -330,6 +325,70 @@ class MDValue(NamedValue):
 
     def __hash__(self):
         return hash(self.operands)
+
+
+class DIToken:
+    """
+    A debug information enumeration value that should appear bare in
+    the emitted metadata.
+    """
+    def __init__(self, value):
+        self.value = value
+
+
+class DIValue(NamedValue):
+    """
+    A debug information descriptor, containing key-value pairs.
+    """
+    name_prefix = '!'
+
+    def __init__(self, parent, is_distinct, kind, operands, name):
+        super(DIValue, self).__init__(parent, types.MetaData(), name=name)
+        self.is_distinct = is_distinct
+        self.kind = kind
+        self.operands = tuple(operands)
+        parent.metadata.append(self)
+
+    def descr(self, buf):
+        if self.is_distinct:
+            buf += ("distinct ",)
+        operands = []
+        for key, value in self.operands:
+            if value is None:
+                strvalue = "null"
+            elif value is True:
+                strvalue = "true"
+            elif value is False:
+                strvalue = "false"
+            elif isinstance(value, DIToken):
+                strvalue = value.value
+            elif isinstance(value, str):
+                strvalue = '"{}"'.format(_escape_string(value))
+            elif isinstance(value, int):
+                strvalue = str(value)
+            else:
+                assert isinstance(value, NamedValue)
+                strvalue = value.get_reference()
+            operands.append("{0}: {1}".format(key, strvalue))
+        operands = ', '.join(operands)
+        buf += ("!", self.kind, "(", operands, ")\n")
+
+    def _get_reference(self):
+        return self.name_prefix + str(self.name)
+
+    def __eq__(self, other):
+        if isinstance(other, DIValue):
+            return self.is_distinct == other.is_distinct and \
+                self.kind == other.kind and \
+                self.operands == other.operands
+        else:
+            return False
+
+    def __ne__(self, other):
+        return not self.__eq__(other)
+
+    def __hash__(self):
+        return hash((self.is_distinct, self.kind, self.operands))
 
 
 class GlobalValue(NamedValue, _ConstOpMixin):


### PR DESCRIPTION
This is pretty much enough to do emission of debug info of any complexity, e.g. see https://github.com/m-labs/artiq/blob/ce30045dd4b85d20bd9ac2aa72ca8f7481cc6a43/artiq/compiler/transforms/llvm_ir_generator.py#L42-L127. It is in principle possible to model individual DINodes within llvmlite, but doesn't really make a lot of sense and is prone to breakage after upgrading LLVM.