### PR TITLE
Allow emission of fast-math fcmp instructions

### DIFF
--- a/docs/source/ir/builder.rst
+++ b/docs/source/ir/builder.rst
@@ -351,15 +351,19 @@ Comparisons
    Unsigned integer compare *lhs* with *rhs*.  *cmpop*, a string, can be one
    of ``<``, ``<=``, ``==``, ``!=``, ``>=``, ``>``.
 
-.. method:: IRBuilder.fcmp_ordered(cmpop, lhs, rhs, name='')
+.. method:: IRBuilder.fcmp_ordered(cmpop, lhs, rhs, name='', flags=[])
 
    Floating-point ordered compare *lhs* with *rhs*.  *cmpop*, a string, can
    be one of ``<``, ``<=``, ``==``, ``!=``, ``>=``, ``>``, ``ord``, ``uno``.
+   *flags*, a list, can include any of ``nnan``, ``ninf``, ``nsz``, ``arcp``,
+   and ``fast`` (which implies all previous flags).
 
-.. method:: IRBuilder.fcmp_unordered(cmpop, lhs, rhs, name='')
+.. method:: IRBuilder.fcmp_unordered(cmpop, lhs, rhs, name='', flags=[])
 
    Floating-point unordered compare *lhs* with *rhs*.  *cmpop*, a string, can
    be one of ``<``, ``<=``, ``==``, ``!=``, ``>=``, ``>``, ``ord``, ``uno``.
+   *flags*, a list, can include any of ``nnan``, ``ninf``, ``nsz``, ``arcp``,
+   and ``fast`` (which implies all previous flags).
 
 
 Conditional move

--- a/llvmlite/ir/builder.py
+++ b/llvmlite/ir/builder.py
@@ -472,7 +472,7 @@ class IRBuilder(object):
         """
         return self._icmp('u', cmpop, lhs, rhs, name)
 
-    def fcmp_ordered(self, cmpop, lhs, rhs, name=''):
+    def fcmp_ordered(self, cmpop, lhs, rhs, name='', flags=[]):
         """
         Floating-point ordered comparison:
             name = lhs <cmpop> rhs
@@ -483,11 +483,11 @@ class IRBuilder(object):
             op = 'o' + _CMP_MAP[cmpop]
         else:
             op = cmpop
-        instr = instructions.FCMPInstr(self.block, op, lhs, rhs, name=name)
+        instr = instructions.FCMPInstr(self.block, op, lhs, rhs, name=name, flags=flags)
         self._insert(instr)
         return instr
 
-    def fcmp_unordered(self, cmpop, lhs, rhs, name=''):
+    def fcmp_unordered(self, cmpop, lhs, rhs, name='', flags=[]):
         """
         Floating-point unordered comparison:
             name = lhs <cmpop> rhs
@@ -498,7 +498,7 @@ class IRBuilder(object):
             op = 'u' + _CMP_MAP[cmpop]
         else:
             op = cmpop
-        instr = instructions.FCMPInstr(self.block, op, lhs, rhs, name=name)
+        instr = instructions.FCMPInstr(self.block, op, lhs, rhs, name=name, flags=flags)
         self._insert(instr)
         return instr
 

--- a/llvmlite/ir/instructions.py
+++ b/llvmlite/ir/instructions.py
@@ -291,16 +291,20 @@ class CompareInstr(Instruction):
     OPNAME = 'invalid-compare'
     VALID_OP = {}
 
-    def __init__(self, parent, op, lhs, rhs, name=''):
+    def __init__(self, parent, op, lhs, rhs, name='', flags=[]):
         if op not in self.VALID_OP:
             raise ValueError("invalid comparison %r for %s" % (op, self.OPNAME))
+        for flag in flags:
+            if flag not in self.VALID_FLAG:
+                raise ValueError("invalid flag %r for %s" % (flag, self.OPNAME))
+        opname = " ".join([self.OPNAME] + flags)
         super(CompareInstr, self).__init__(parent, types.IntType(1),
-                                           self.OPNAME, [lhs, rhs], name=name)
+                                           opname, [lhs, rhs], name=name)
         self.op = op
 
     def descr(self, buf):
         buf.append("{0} {1} {2} {3}, {4} {5}\n".format(
-            self.OPNAME,
+            self.opname,
             self.op,
             self.operands[0].type,
             self.operands[0].get_reference(),
@@ -323,6 +327,7 @@ class ICMPInstr(CompareInstr):
         'slt': 'signed less than',
         'sle': 'signed less or equal',
     }
+    VALID_FLAG = set()
 
 
 class FCMPInstr(CompareInstr):
@@ -345,6 +350,7 @@ class FCMPInstr(CompareInstr):
         'uno': 'unordered (either nans)',
         'true': 'no comparison, always returns true',
     }
+    VALID_FLAG = {'nnan', 'ninf', 'nsz', 'arcp', 'fast'}
 
 
 class CastInstr(Instruction):

--- a/llvmlite/tests/test_ir.py
+++ b/llvmlite/tests/test_ir.py
@@ -461,6 +461,7 @@ class TestBuildInstructions(TestBase):
         builder.fcmp_ordered('uno', a, b, 'v')
         builder.fcmp_unordered('ord', a, b, 'w')
         builder.fcmp_unordered('uno', a, b, 'x')
+        builder.fcmp_unordered('olt', a, b, 'y', flags=['nnan', 'ninf', 'nsz', 'arcp', 'fast'])
         self.assertFalse(block.is_terminated)
         self.check_block(block, """\
             my_block:
@@ -480,6 +481,7 @@ class TestBuildInstructions(TestBase):
                 %"v" = fcmp uno i32 %".1", %".2"
                 %"w" = fcmp ord i32 %".1", %".2"
                 %"x" = fcmp uno i32 %".1", %".2"
+                %"y" = fcmp nnan ninf nsz arcp fast olt i32 %".1", %".2"
             """)
 
     def test_misc_ops(self):


### PR DESCRIPTION
Currently the way to add fast-math flags to instructions in
llvmlite is to mutate Instruction.opname for every individual one
to append flags, e.g. 'add nsw nuw' or 'frem fast'. However,
before this commit CompareInstr used the class attribute
self.OPNAME, defeating this method.