### PR TITLE
Default initializer for global variable with non external linkage

### DIFF
--- a/llvmlite/ir/values.py
+++ b/llvmlite/ir/values.py
@@ -388,6 +388,9 @@ class GlobalVariable(GlobalValue):
 
         if self.initializer is not None:
             buf.append(self.initializer.get_reference())
+        elif linkage != 'external':
+            # emit 'undef' for non-external linkage GV
+            buf.append(Constant(self.gtype, Undefined).get_reference())
         buf.append("\n")
 
 

--- a/llvmlite/ir/values.py
+++ b/llvmlite/ir/values.py
@@ -388,7 +388,7 @@ class GlobalVariable(GlobalValue):
 
         if self.initializer is not None:
             buf.append(self.initializer.get_reference())
-        elif linkage != 'external':
+        elif linkage not in ('external', 'extern_weak'):
             # emit 'undef' for non-external linkage GV
             buf.append(Constant(self.gtype, Undefined).get_reference())
         buf.append("\n")

--- a/llvmlite/tests/test_binding.py
+++ b/llvmlite/tests/test_binding.py
@@ -12,7 +12,7 @@ import subprocess
 import sys
 import unittest
 
-from llvmlite import six
+from llvmlite import six, ir
 from llvmlite import binding as llvm
 from llvmlite.binding import ffi
 from . import TestCase
@@ -980,6 +980,24 @@ class TestDylib(BaseTest):
         elif system == "Darwin":
             libm = find_library("libm")
         llvm.load_library_permanently(libm)
+
+
+class TestGlobalVariables(BaseTest):
+    def check_global_variable_linkage(self, linkage):
+        mod = ir.Module()
+        typ = ir.IntType(32)
+        gv = ir.GlobalVariable(mod, typ, "foo")
+        gv.linkage = linkage
+        self.module(str(mod))
+
+    def test_internal_linkage(self):
+        self.check_global_variable_linkage('internal')
+
+    def test_common_linkage(self):
+        self.check_global_variable_linkage('common')
+
+    def test_external_linkage(self):
+        self.check_global_variable_linkage('external')
 
 
 if __name__ == "__main__":

--- a/llvmlite/tests/test_binding.py
+++ b/llvmlite/tests/test_binding.py
@@ -983,12 +983,25 @@ class TestDylib(BaseTest):
 
 
 class TestGlobalVariables(BaseTest):
-    def check_global_variable_linkage(self, linkage):
+    def check_global_variable_linkage(self, linkage, has_undef=True):
+        # This test default initializer on global variables with different
+        # linkages.  Some linkages requires an initializer be present, while
+        # it is optional for others.  This test uses ``parse_assembly()``
+        # to verify that we are adding an `undef` automatically if user didn't
+        # specific one for certain linkages.  It is a IR syntax error if the
+        # initializer is not present for certain linkages e.g. "external".
         mod = ir.Module()
         typ = ir.IntType(32)
         gv = ir.GlobalVariable(mod, typ, "foo")
         gv.linkage = linkage
-        self.module(str(mod))
+        asm = str(mod)
+        # check if 'undef' is present
+        if has_undef:
+            self.assertIn('undef', asm)
+        else:
+            self.assertNotIn('undef', asm)
+        # parse assembly to ensure correctness
+        self.module(asm)
 
     def test_internal_linkage(self):
         self.check_global_variable_linkage('internal')
@@ -997,7 +1010,7 @@ class TestGlobalVariables(BaseTest):
         self.check_global_variable_linkage('common')
 
     def test_external_linkage(self):
-        self.check_global_variable_linkage('external')
+        self.check_global_variable_linkage('external', has_undef=False)
 
     def test_available_externally_linkage(self):
         self.check_global_variable_linkage('available_externally')
@@ -1015,7 +1028,7 @@ class TestGlobalVariables(BaseTest):
         self.check_global_variable_linkage('appending')
 
     def test_extern_weak_linkage(self):
-        self.check_global_variable_linkage('extern_weak')
+        self.check_global_variable_linkage('extern_weak', has_undef=False)
 
     def test_linkonce_odr_linkage(self):
         self.check_global_variable_linkage('linkonce_odr')

--- a/llvmlite/tests/test_binding.py
+++ b/llvmlite/tests/test_binding.py
@@ -999,6 +999,30 @@ class TestGlobalVariables(BaseTest):
     def test_external_linkage(self):
         self.check_global_variable_linkage('external')
 
+    def test_available_externally_linkage(self):
+        self.check_global_variable_linkage('available_externally')
+
+    def test_private_linkage(self):
+        self.check_global_variable_linkage('private')
+
+    def test_linkonce_linkage(self):
+        self.check_global_variable_linkage('linkonce')
+
+    def test_weak_linkage(self):
+        self.check_global_variable_linkage('weak')
+
+    def test_appending_linkage(self):
+        self.check_global_variable_linkage('appending')
+
+    def test_extern_weak_linkage(self):
+        self.check_global_variable_linkage('extern_weak')
+
+    def test_linkonce_odr_linkage(self):
+        self.check_global_variable_linkage('linkonce_odr')
+
+    def test_weak_odr_linkage(self):
+        self.check_global_variable_linkage('weak_odr')
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
IR spec requires GV with non-external linkage (linkage other than external and extern_weak) to have a initializer.  Otherwise, `parse_assembly` will reject the IR as invalid.  This patch makes `undef` the default initializer for these cases.

In details: if the the `.initializer` is `None` and linkage is non-external, emit `undef` to the IR.