### PR TITLE
Suppress optimization remarks

### DIFF
--- a/ffi/passmanagers.cpp
+++ b/ffi/passmanagers.cpp
@@ -15,7 +15,6 @@
 
 using namespace llvm;
 
-extern "C" {
 
 /* Helpers to override the diagnostic handler when running
  * optimizations.
@@ -56,8 +55,10 @@ UnsetOptimizationDiagnosticHandler(LLVMContext &Ctx, diag_handler_t OldHandler)
 
 
 /*
- * Exposed optimization API
+ * Exposed API
  */
+
+extern "C" {
 
 API_EXPORT(LLVMPassManagerRef)
 LLVMPY_CreatePassManager()

--- a/ffi/passmanagers.cpp
+++ b/ffi/passmanagers.cpp
@@ -1,4 +1,12 @@
+#include <tuple>
+
 #include "core.h"
+
+#include "llvm/IR/Module.h"
+#include "llvm/IR/DiagnosticInfo.h"
+#include "llvm/IR/DiagnosticPrinter.h"
+#include "llvm/Support/raw_ostream.h"
+
 #include "llvm-c/Transforms/Scalar.h"
 #include "llvm-c/Transforms/IPO.h"
 #include "llvm/IR/LegacyPassManager.h"
@@ -8,6 +16,48 @@
 using namespace llvm;
 
 extern "C" {
+
+/* Helpers to override the diagnostic handler when running
+ * optimizations.
+ * The default diagnostic handler prints some remarks unconditionally,
+ * see http://lists.llvm.org/pipermail/llvm-dev/2016-July/102252.html
+ */
+typedef std::tuple<LLVMContext::DiagnosticHandlerTy, void *> diag_handler_t;
+
+static diag_handler_t
+SetOptimizationDiagnosticHandler(LLVMContext &Ctx)
+{
+    auto diagnose = [] (const DiagnosticInfo &DI, void *c) {
+        // If an error, print the message and bail out (as the default
+        // handler does).
+        DiagnosticSeverity DS = DI.getSeverity();
+        if (DS == DS_Error) {
+            raw_ostream &out = errs();
+            DiagnosticPrinterRawOStream DP(out);
+            out << "LLVM error: ";
+            DI.print(DP);
+            out << "\n";
+            exit(1);
+        }
+    };
+    /* Save the current diagnostic handler and set our own */
+    diag_handler_t OldHandler(Ctx.getDiagnosticHandler(),
+                              Ctx.getDiagnosticContext());
+    Ctx.setDiagnosticHandler((LLVMContext::DiagnosticHandlerTy) diagnose,
+                             nullptr);
+    return OldHandler;
+}
+
+static void
+UnsetOptimizationDiagnosticHandler(LLVMContext &Ctx, diag_handler_t OldHandler)
+{
+    Ctx.setDiagnosticHandler(std::get<0>(OldHandler), std::get<1>(OldHandler));
+}
+
+
+/*
+ * Exposed optimization API
+ */
 
 API_EXPORT(LLVMPassManagerRef)
 LLVMPY_CreatePassManager()
@@ -21,7 +71,6 @@ LLVMPY_DisposePassManager(LLVMPassManagerRef PM)
     return LLVMDisposePassManager(PM);
 }
 
-
 API_EXPORT(LLVMPassManagerRef)
 LLVMPY_CreateFunctionPassManager(LLVMModuleRef M)
 {
@@ -32,14 +81,28 @@ API_EXPORT(int)
 LLVMPY_RunPassManager(LLVMPassManagerRef PM,
                       LLVMModuleRef M)
 {
-    return LLVMRunPassManager(PM, M);
+    /* Save the current diagnostic handler and set our own */
+    LLVMContext &Ctx = unwrap(M)->getContext();
+    auto OldHandler = SetOptimizationDiagnosticHandler(Ctx);
+
+    int r = LLVMRunPassManager(PM, M);
+
+    UnsetOptimizationDiagnosticHandler(Ctx, OldHandler);
+    return r;
 }
 
 API_EXPORT(int)
 LLVMPY_RunFunctionPassManager(LLVMPassManagerRef PM,
                               LLVMValueRef F)
 {
-    return LLVMRunFunctionPassManager(PM, F);
+    /* Save the current diagnostic handler and set our own */
+    LLVMContext &Ctx = unwrap(F)->getContext();
+    auto OldHandler = SetOptimizationDiagnosticHandler(Ctx);
+
+    int r = LLVMRunFunctionPassManager(PM, F);
+
+    UnsetOptimizationDiagnosticHandler(Ctx, OldHandler);
+    return r;
 }
 
 API_EXPORT(int)


### PR DESCRIPTION
The default LLVM diagnostic handler always prints some optimization remarks
(see http://lists.llvm.org/pipermail/llvm-dev/2016-July/102252.html).
Work around it by setting our own diagnostic handler during optimization.