### PR TITLE
Update for changes in LLVM 3.9

### DIFF
--- a/ffi/build.py
+++ b/ffi/build.py
@@ -109,7 +109,7 @@ def main_posix(kind, library_ext):
 
     out = out.decode('latin1')
     print(out)
-    if not out.startswith('3.8.'):
+    if not out.startswith('3.9.'):
         msg = (
             "Building llvmlite requires LLVM 3.8.x. Be sure to "
             "set LLVM_CONFIG to the right executable path.\n"

--- a/ffi/targets.cpp
+++ b/ffi/targets.cpp
@@ -88,13 +88,6 @@ LLVMPY_CreateTargetData(const char *StringRep)
     return LLVMCreateTargetData(StringRep);
 }
 
-API_EXPORT(void)
-LLVMPY_AddTargetData(LLVMTargetDataRef TD,
-                     LLVMPassManagerRef PM)
-{
-    LLVMAddTargetData(TD, PM);
-}
-
 
 //// Nothing is creating a TargetLibraryInfo
 //    void
@@ -212,7 +205,7 @@ LLVMPY_CreateTargetMachine(LLVMTargetRef T,
     else
         cm = CodeModel::Default;
 
-    Reloc::Model rm;
+    Optional<Reloc::Model> rm;
     std::string rms(RelocModel);
     if (rms == "static")
         rm = Reloc::Static;
@@ -220,8 +213,6 @@ LLVMPY_CreateTargetMachine(LLVMTargetRef T,
         rm = Reloc::PIC_;
     else if (rms == "dynamicnopic")
         rm = Reloc::DynamicNoPIC;
-    else
-        rm = Reloc::Default;
 
     TargetOptions opt;
 //     opt.JITEmitDebugInfo = EmitJITDebug;

--- a/llvmlite/binding/targets.py
+++ b/llvmlite/binding/targets.py
@@ -145,14 +145,6 @@ class TargetData(ffi.ObjectRef):
             raise RuntimeError("Not a pointer type: %s" % (ty,))
         return size
 
-    def add_pass(self, pm):
-        """
-        Add a DataLayout pass to PassManager *pm*.
-        """
-        # AddTargetData claims ownership, so create a copy.
-        target_data = create_target_data(str(self))
-        ffi.lib.LLVMPY_AddTargetData(target_data, pm)
-
 
 RELOC = frozenset(['default', 'static', 'pic', 'dynamicnopic'])
 CODEMODEL = frozenset(['default', 'jitdefault', 'small', 'kernel',
@@ -326,9 +318,6 @@ ffi.lib.LLVMPY_CopyStringRepOfTargetData.argtypes = [
 ffi.lib.LLVMPY_DisposeTargetData.argtypes = [
     ffi.LLVMTargetDataRef,
 ]
-
-ffi.lib.LLVMPY_AddTargetData.argtypes = [ffi.LLVMTargetDataRef,
-                                         ffi.LLVMPassManagerRef]
 
 ffi.lib.LLVMPY_ABISizeOfType.argtypes = [ffi.LLVMTargetDataRef,
                                          ffi.LLVMTypeRef]

--- a/llvmlite/tests/test_binding.py
+++ b/llvmlite/tests/test_binding.py
@@ -269,7 +269,7 @@ class TestMisc(BaseTest):
 
     def test_version(self):
         major, minor, patch = llvm.llvm_version_info
-        self.assertEqual((major, minor), (3, 8))
+        self.assertEqual((major, minor), (3, 9))
         self.assertIn(patch, range(10))
 
     def test_check_jit_execution(self):
@@ -797,18 +797,12 @@ class TestTargetData(BaseTest):
         glob = self.glob()
         self.assertEqual(td.get_abi_size(glob.type), 8)
 
-    def test_add_pass(self):
-        td = self.target_data()
-        pm = llvm.create_module_pass_manager()
-        td.add_pass(pm)
-
 
 class TestTargetMachine(BaseTest):
 
     def test_add_target_data_pass(self):
         tm = self.target_machine()
         pm = llvm.create_module_pass_manager()
-        tm.target_data.add_pass(pm)
 
     def test_add_analysis_passes(self):
         tm = self.target_machine()


### PR DESCRIPTION
RelocMode is now Optional<RelocMode>, where None has the same meaning
as Default used to.

Data layout is no longer ever optional, so there is no need in
explicitly adding it anywhere; those APIs were removed in LLVM.
