### PR TITLE
binary intrinsic declarations

### DIFF
--- a/llvmlite/ir/module.py
+++ b/llvmlite/ir/module.py
@@ -155,7 +155,13 @@ class Module(object):
             raise NotImplementedError("unknown intrinsic %r with %d types"
                                       % (intrinsic, len(tys)))
 
-        name = '.'.join([intrinsic] + [t.intrinsic_name for t in tys])
+        name = [intrinsic]
+        if intrinsic in ('llvm.memcpy', 'llvm.memset'):
+            name.extend((t.intrinsic_name for t in tys))
+        elif tys:
+            name.append(tys[0].intrinsic_name)
+        name = '.'.join(name)
+
         if name in self.globals:
             return self.globals[name]
 
@@ -172,10 +178,13 @@ class Module(object):
                 fnty = types.FunctionType(tys[0], tys*2)
             else:
                 fnty = types.FunctionType(tys[0], tys)
-        elif len(tys) == 2 and intrinsic == 'llvm.memset':
-            tys = [tys[0], types.IntType(8), tys[1],
-                   types.IntType(32), types.IntType(1)]
-            fnty = types.FunctionType(types.VoidType(), tys)
+        elif len(tys) == 2:
+            if intrinsic == 'llvm.memset':
+                tys = [tys[0], types.IntType(8), tys[1],
+                       types.IntType(32), types.IntType(1)]
+                fnty = types.FunctionType(types.VoidType(), tys)
+            else:
+                fnty = types.FunctionType(tys[0], tys)
         elif len(tys) == 3 and intrinsic in ('llvm.memcpy', 'llvm.memmove'):
             tys = tys + [types.IntType(32), types.IntType(1)]
             fnty = types.FunctionType(types.VoidType(), tys)

--- a/llvmlite/tests/test_ir.py
+++ b/llvmlite/tests/test_ir.py
@@ -170,6 +170,8 @@ class TestFunction(TestBase):
         memset = module.declare_intrinsic('llvm.memset', [pint8, int32])
         memcpy = module.declare_intrinsic('llvm.memcpy', [pint8, pint8, int32])
         assume = module.declare_intrinsic('llvm.assume')
+        _pow = module.declare_intrinsic('llvm.pow', [dbl, dbl])
+        maxnum = module.declare_intrinsic('llvm.maxnum', [dbl, dbl])
         self.check_descr(self.descr(powi).strip(), """\
             declare double @"llvm.powi.f64"(double %".1", i32 %".2")""")
         self.check_descr(self.descr(memset).strip(), """\
@@ -178,6 +180,10 @@ class TestFunction(TestBase):
             declare void @"llvm.memcpy.p0i8.p0i8.i32"(i8* %".1", i8* %".2", i32 %".3", i32 %".4", i1 %".5")""")
         self.check_descr(self.descr(assume).strip(), """\
             declare void @"llvm.assume"(i1 %".1")""")
+        self.check_descr(self.descr(_pow).strip(), """\
+            declare double @"llvm.pow.f64"(double %".1", double %".2")""")
+        self.check_descr(self.descr(maxnum).strip(), """\
+            declare double @"llvm.maxnum.f64"(double %".1", double %".2")""")
 
     def test_redeclare_intrinsic(self):
         module = self.module()


### PR DESCRIPTION
Fixes binary intrinsic (e.g. `llvm.maxnum`) IR generation.

**Note**: I haven't tested e.g. `llvm.convert.from.fp16`.