### PR TITLE
Allow TestDependencies to match other valid library file names

### DIFF
--- a/llvmlite/tests/test_binding.py
+++ b/llvmlite/tests/test_binding.py
@@ -160,7 +160,7 @@ class TestDependencies(BaseTest):
         out, _ = p.communicate()
         self.assertEqual(0, p.returncode)
         # Parse library dependencies
-        lib_pat = re.compile(r'^([-_a-zA-Z0-9]+)\.so(?:\.\d+)?$')
+        lib_pat = re.compile(r'^([-_a-zA-Z0-9]+)\.so(?:\.\d+){0,3}$')
         deps = set()
         for line in out.decode().splitlines():
             parts = line.split()


### PR DESCRIPTION
As mentioned in [issue #208](https://github.com/numba/llvmlite/issues/208), this unit tests forbids valid library file names, like `libname.so.3.8` and `libname.so.3.8.1`.  This modifies the regular expression to allowed those sorts of file names.