### PR TITLE
Add partial LLVM bindings for object::ObjectFile

### DIFF
--- a/ffi/CMakeLists.txt
+++ b/ffi/CMakeLists.txt
@@ -20,7 +20,7 @@ add_definitions(${LLVM_DEFINITIONS})
 # Define our shared library
 add_library(llvmlite SHARED assembly.cpp bitcode.cpp core.cpp initfini.cpp
             module.cpp value.cpp executionengine.cpp transforms.cpp
-            passmanagers.cpp targets.cpp dylib.cpp linker.cpp)
+            passmanagers.cpp targets.cpp dylib.cpp linker.cpp object_file.cpp)
 
 # Find the libraries that correspond to the LLVM components
 # that we wish to use

--- a/ffi/Makefile.freebsd
+++ b/ffi/Makefile.freebsd
@@ -6,7 +6,7 @@ LIBS = $(LLVM_LIBS)
 INCLUDE = core.h
 SRC = assembly.cpp bitcode.cpp core.cpp initfini.cpp module.cpp value.cpp \
 	executionengine.cpp transforms.cpp passmanagers.cpp targets.cpp dylib.cpp \
-	linker.cpp
+	linker.cpp object_file.cpp
 OUTPUT = libllvmlite.so
 
 all: $(OUTPUT)

--- a/ffi/Makefile.linux
+++ b/ffi/Makefile.linux
@@ -11,7 +11,7 @@ LIBS = $(LLVM_LIBS)
 INCLUDE = core.h
 SRC = assembly.cpp bitcode.cpp core.cpp initfini.cpp module.cpp value.cpp \
 	  executionengine.cpp transforms.cpp passmanagers.cpp targets.cpp dylib.cpp \
-	  linker.cpp
+	  linker.cpp object_file.cpp
 OUTPUT = libllvmlite.so
 
 all: $(OUTPUT)

--- a/ffi/Makefile.osx
+++ b/ffi/Makefile.osx
@@ -6,7 +6,7 @@ LIBS = $(LLVM_LIBS)
 INCLUDE = core.h
 SRC = assembly.cpp bitcode.cpp core.cpp initfini.cpp module.cpp value.cpp \
 	  executionengine.cpp transforms.cpp passmanagers.cpp targets.cpp dylib.cpp \
-	  linker.cpp
+	  linker.cpp object_file.cpp
 OUTPUT = libllvmlite.dylib
 MACOSX_DEPLOYMENT_TARGET ?= 10.9
 

--- a/ffi/object_file.cpp
+++ b/ffi/object_file.cpp
@@ -1,0 +1,86 @@
+#include "core.h"
+
+#include "llvm-c/ExecutionEngine.h"
+#include "llvm-c/Object.h"
+
+#include "llvm/Object/ObjectFile.h"
+
+#include <stdio.h>
+
+// From lib/Object/Object.cpp
+namespace llvm {
+  inline object::section_iterator *unwrap(LLVMSectionIteratorRef SI) {
+    return reinterpret_cast<object::section_iterator*>(SI);
+  }
+
+  inline LLVMSectionIteratorRef
+    wrap(const object::section_iterator *SI) {
+      return reinterpret_cast<LLVMSectionIteratorRef>
+        (const_cast<object::section_iterator*>(SI));
+    }
+
+} // llvm
+
+extern "C" {
+
+API_EXPORT(LLVMObjectFileRef)
+LLVMPY_CreateObjectFile(const char* buf, const size_t n)
+{
+  return LLVMCreateObjectFile(LLVMCreateMemoryBufferWithMemoryRange(buf, n, "", false));
+}
+
+API_EXPORT(void)
+LLVMPY_DisposeObjectFile(LLVMObjectFileRef O)
+{
+  return LLVMDisposeObjectFile(O);
+}
+
+API_EXPORT(LLVMSectionIteratorRef)
+LLVMPY_GetSections(LLVMObjectFileRef O)
+{
+  return LLVMGetSections(O);
+}
+
+API_EXPORT(void)
+LLVMPY_DisposeSectionIterator(LLVMSectionIteratorRef SI)
+{
+  LLVMDisposeSectionIterator(SI);
+}
+
+API_EXPORT(void)
+LLVMPY_MoveToNextSection(LLVMSectionIteratorRef SI)
+{
+  LLVMMoveToNextSection(SI);
+}
+
+API_EXPORT(bool)
+LLVMPY_IsSectionIteratorAtEnd(LLVMObjectFileRef O, LLVMSectionIteratorRef SI)
+{
+  return LLVMIsSectionIteratorAtEnd(O, SI);
+}
+
+API_EXPORT(const char*)
+LLVMPY_GetSectionName(LLVMSectionIteratorRef SI)
+{
+  return LLVMGetSectionName(SI);
+}
+
+API_EXPORT(const char*)
+LLVMPY_GetSectionContents(LLVMSectionIteratorRef SI)
+{
+  return LLVMGetSectionContents(SI);
+}
+
+API_EXPORT(uint64_t)
+LLVMPY_GetSectionSize(LLVMSectionIteratorRef SI)
+{
+  return LLVMGetSectionSize(SI);
+}
+
+API_EXPORT(bool)
+LLVMPY_IsSectionText(LLVMSectionIteratorRef SI)
+{
+  return (*llvm::unwrap(SI))->isText();
+}
+
+} // end extern C

--- a/llvmlite/binding/__init__.py
+++ b/llvmlite/binding/__init__.py
@@ -14,3 +14,4 @@ from .targets import *
 from .transforms import *
 from .value import *
 from .analysis import *
+from .object_file import *

--- a/llvmlite/binding/executionengine.py
+++ b/llvmlite/binding/executionengine.py
@@ -5,7 +5,7 @@ from ctypes import (POINTER, c_char_p, c_bool, c_void_p,
                     py_object, Structure)
 import warnings
 
-from . import ffi, targets
+from . import ffi, targets, object_file
 
 
 # Just check these weren't optimized out of the DLL.
@@ -282,6 +282,7 @@ class _ObjectCacheData(Structure):
         ('buf_ptr', c_void_p),
         ('buf_len', c_size_t),
         ]
+
 
 _ObjectCacheNotifyFunc = CFUNCTYPE(None, py_object,
                                    POINTER(_ObjectCacheData))

--- a/llvmlite/binding/ffi.py
+++ b/llvmlite/binding/ffi.py
@@ -26,6 +26,8 @@ LLVMMemoryBufferRef = _make_opaque_ref("LLVMMemoryBuffer")
 LLVMGlobalsIterator = _make_opaque_ref("LLVMGlobalsIterator")
 LLVMFunctionsIterator = _make_opaque_ref("LLVMFunctionsIterator")
 LLVMObjectCacheRef = _make_opaque_ref("LLVMObjectCache")
+LLVMObjectFileRef = _make_opaque_ref("LLVMObjectFile")
+LLVMSectionIteratorRef = _make_opaque_ref("LLVMSectionIterator")
 
 
 _lib_dir = os.path.dirname(__file__)

--- a/llvmlite/binding/object_file.py
+++ b/llvmlite/binding/object_file.py
@@ -50,7 +50,7 @@ ffi.lib.LLVMPY_GetSectionName.argtypes = [ffi.LLVMSectionIteratorRef]
 ffi.lib.LLVMPY_GetSectionName.restype  = c_char_p
 
 ffi.lib.LLVMPY_GetSectionSize.argtypes = [ffi.LLVMSectionIteratorRef]
-ffi.lib.LLVMPY_GetSectionSize.restype  = c_ulonglong
+ffi.lib.LLVMPY_GetSectionSize.restype  = c_uint64
 
 ffi.lib.LLVMPY_GetSectionContents.argtypes = [ffi.LLVMSectionIteratorRef]
 ffi.lib.LLVMPY_GetSectionContents.restype  = c_char_p

--- a/llvmlite/binding/object_file.py
+++ b/llvmlite/binding/object_file.py
@@ -1,0 +1,59 @@
+from . import ffi
+from ctypes import c_bool, c_char_p, c_size_t, c_ulonglong, string_at
+
+class SectionIteratorRef(ffi.ObjectRef):
+    def name(self):
+        return ffi.lib.LLVMPY_GetSectionName(self)
+    def is_text(self):
+        return ffi.lib.LLVMPY_IsSectionText(self)
+    def size(self):
+        return ffi.lib.LLVMPY_GetSectionSize(self)
+    def data(self):
+        return string_at(ffi.lib.LLVMPY_GetSectionContents(self), self.size())
+    def is_end(self, object_file):
+        return ffi.lib.LLVMPY_IsSectionIteratorAtEnd(object_file, self)
+    def next(self):
+        ffi.lib.LLVMPY_MoveToNextSection(self)
+    def _dispose(self):
+        ffi.lib.LLVMPY_DisposeSectionIterator(self)
+
+class ObjectFileRef(ffi.ObjectRef):
+    @classmethod
+    def from_data(cls, data):
+        return cls(ffi.lib.LLVMPY_CreateObjectFile(data, len(data)))
+
+    def sections(self):
+        it = SectionIteratorRef(ffi.lib.LLVMPY_GetSections(self))
+        while not it.is_end(self):
+            yield it
+            it.next()
+
+    def _dispose(self):
+        ffi.lib.LLVMPY_DisposeObjectFile(self)
+
+ffi.lib.LLVMPY_CreateObjectFile.argtypes = [c_char_p, c_size_t]
+ffi.lib.LLVMPY_CreateObjectFile.restype  = ffi.LLVMObjectFileRef
+
+ffi.lib.LLVMPY_DisposeObjectFile.argtypes = [ffi.LLVMObjectFileRef]
+
+ffi.lib.LLVMPY_GetSections.argtypes = [ffi.LLVMObjectFileRef]
+ffi.lib.LLVMPY_GetSections.restype  = ffi.LLVMSectionIteratorRef
+
+ffi.lib.LLVMPY_DisposeSectionIterator.argtypes = [ffi.LLVMSectionIteratorRef]
+
+ffi.lib.LLVMPY_MoveToNextSection.argtypes = [ffi.LLVMSectionIteratorRef]
+
+ffi.lib.LLVMPY_IsSectionIteratorAtEnd.argtypes = [ffi.LLVMObjectFileRef, ffi.LLVMSectionIteratorRef]
+ffi.lib.LLVMPY_IsSectionIteratorAtEnd.restype = c_bool
+
+ffi.lib.LLVMPY_GetSectionName.argtypes = [ffi.LLVMSectionIteratorRef]
+ffi.lib.LLVMPY_GetSectionName.restype  = c_char_p
+
+ffi.lib.LLVMPY_GetSectionSize.argtypes = [ffi.LLVMSectionIteratorRef]
+ffi.lib.LLVMPY_GetSectionSize.restype  = c_ulonglong
+
+ffi.lib.LLVMPY_GetSectionContents.argtypes = [ffi.LLVMSectionIteratorRef]
+ffi.lib.LLVMPY_GetSectionContents.restype  = c_char_p
+
+ffi.lib.LLVMPY_IsSectionText.argtypes = [ffi.LLVMSectionIteratorRef]
+ffi.lib.LLVMPY_IsSectionText.restype  = c_bool

--- a/llvmlite/binding/object_file.py
+++ b/llvmlite/binding/object_file.py
@@ -1,5 +1,5 @@
 from . import ffi
-from ctypes import c_bool, c_char_p, c_size_t, c_ulonglong, string_at
+from ctypes import c_bool, c_char_p, c_size_t, c_ulonglong, string_at, c_uint64
 
 class SectionIteratorRef(ffi.ObjectRef):
     def name(self):

--- a/llvmlite/tests/test_binding.py
+++ b/llvmlite/tests/test_binding.py
@@ -1105,6 +1105,22 @@ class TestInlineAsm(BaseTest):
         asm = tm.emit_assembly(m)
         self.assertIn('nop', asm)
 
+class TestObjectFile(BaseTest):
+    def test_object_file(self):
+        target_machine = self.target_machine()
+        mod = self.module()
+        obj_bin = target_machine.emit_object(mod)
+        obj = llvm.ObjectFileRef.from_data(obj_bin)
+        # Check that we have a text section, and that she has a name and data
+        has_text = False
+        for s in obj.sections():
+            if s.is_text():
+                has_text = True
+                self.assertIsNotNone(s.name())
+                self.assertTrue(s.size() > 0)
+                self.assertTrue(len(s.data()) > 0)
+                break
+        self.assertTrue(has_text)
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
It misses the symbols API, but that's still a start!
