### PR TITLE
Add a CallAsmInstr instruction

### DIFF
--- a/llvmlite/ir/builder.py
+++ b/llvmlite/ir/builder.py
@@ -729,6 +729,21 @@ class IRBuilder(object):
         self._insert(inst)
         return inst
 
+    def asm(self, reg_size, asm, modifiers, has_sideeffects, args, name=''):
+        """
+        Inline assembler
+        """
+        inst = instructions.CallAsmInstr(self.block, reg_size, asm, modifiers,
+                                      has_sideeffects, args, name)
+        self._insert(inst)
+        return inst
+
+    def load_reg(self, reg_size, reg_name, name=''):
+        return self.asm(reg_size, "", "={%s},~{dirflag},~{fpsr},~{flags}" % reg_name, False, [], name)
+
+    def store_reg(self, v, reg_size, reg_name, name=''):
+        return self.asm(reg_size, "", "{%s},~{dirflag},~{fpsr},~{flags}" % reg_name, True, [v], name)
+
     def invoke(self, fn, args, normal_to, unwind_to, name='', cconv=None, tail=False):
         inst = instructions.InvokeInstr(self.block, fn, args, normal_to, unwind_to, name=name,
                                         cconv=cconv)

--- a/llvmlite/ir/instructions.py
+++ b/llvmlite/ir/instructions.py
@@ -123,6 +123,29 @@ class CallInstr(Instruction):
     def descr(self, buf):
         self._descr(buf, add_metadata=True)
 
+class CallAsmInstr(Instruction):
+    def __init__(self, parent, reg_size, asm, modifiers, has_sideeffects, args, name=''):
+        ret_type = types.VoidType() if has_sideeffects else types.IntType(reg_size)
+        self.asm = asm
+        self.modifiers = modifiers
+        super(CallAsmInstr, self).__init__(parent, ret_type,
+                                        "call", args, name=name)
+
+    def _descr(self, buf, add_metadata):
+        args = ', '.join(['{0} {1}'.format(a.type, a.get_reference())
+                          for a in self.operands])
+        buf.append('{0} {1} asm "{2}", "{3}"({4}) {5}\n'.format(
+            self.opname,
+            str(self.type),
+            self.asm,
+            self.modifiers,
+            args,
+            self._stringify_metadata(leading_comma=True) if add_metadata else ""
+            ))
+
+    def descr(self, buf):
+        self._descr(buf, add_metadata=True)
+
 
 class InvokeInstr(CallInstr):
     def __init__(self, parent, func, args, normal_to, unwind_to, name='', cconv=None):


### PR DESCRIPTION
This enable supports for inline assembly.
Also add two helper functions in the builder:
 * store_reg: store an LLVM value into a specific register
 * load_reg: set an LLVM value as the value inside a register

I've tested it under x86 32/64 bits and Aarch64. There might be issues with other assemblers!