### PR TITLE
Add InlineAsm helpers in the builder

### DIFF
--- a/docs/source/ir/builder.rst
+++ b/docs/source/ir/builder.rst
@@ -550,6 +550,24 @@ Inline assembler
    Add an inline assembler call instruction. This is used for instance in
    :meth:`load_reg` and :meth:`store_reg`.
 
+   Arguments:
+     * *asm* is the inline assembler, i.e.: `̀ "mov $2, $0\nadd $1, $0"`` (x86
+       inline ASM uses the AT&T syntax)
+     * *constraint* defines the input/output constraints, i.e: ``=r,r,r``
+     * *args* is the list of arguments, as IR values, according to the contraits
+     * *side_effect* (boolean), whether this instruction has side effects not
+       visible in the constraint list
+     * *name* optional name of a possible LLVM value
+
+   For more information about these parameters, see the official LLVM
+   documentation here:
+   http://llvm.org/docs/LangRef.html#inline-asm-constraint-string.
+
+   Example that adds two 64-bit values on x86 would be::
+
+      fty = FunctionType(IntType(64), [IntType(64),IntType(64)])
+      add = asm(fty, "mov $2, $0\nadd $1, $0", "=r,r,r", [arg_0,arg_1], False, "asm_add")
+
 .. method:: IRBuilder.load_reg(reg_type, reg_name, name='')
 
     Load a register value into an LLVM value.

--- a/docs/source/ir/builder.rst
+++ b/docs/source/ir/builder.rst
@@ -542,6 +542,29 @@ Exception handling
    that the landing pad did not catch the exception after all (perhaps
    because it only performed cleanup).
 
+Inline assembler
+''''''''''''''''
+
+.. method:: IRBuilder.asm(ftype, asm, constraint, args, side_effect, name='')
+
+   Add an inline assembler call instruction. This is used for instance in
+   :meth:`load_reg` and :meth:`store_reg`.
+
+.. method:: IRBuilder.load_reg(reg_type, reg_name, name='')
+
+    Load a register value into an LLVM value.
+
+    Example to get the value of ``RAX``::
+
+      load_reg(IntType(64), "rax")
+
+.. method:: IRBuilder.store_reg(value, reg_type, reg_name, name='')
+
+    Store an LLVM value inside a register
+
+    Example to store ``0xAAAAAAAAAAAAAAAA`` into ``RAX``::
+
+      store_reg(Constant(IntType(64), 0xAAAAAAAAAAAAAAAA), IntType(64), "rax")
 
 Miscellaneous
 '''''''''''''

--- a/llvmlite/ir/builder.py
+++ b/llvmlite/ir/builder.py
@@ -729,6 +729,29 @@ class IRBuilder(object):
         self._insert(inst)
         return inst
 
+    def asm(self, ftype, asm, constraint, args, side_effect, name=''):
+        """
+        Inline assembler.
+        """
+        asm = instructions.InlineAsm(ftype, asm, constraint, side_effect)
+        return self.call(asm, args, name)
+
+    def load_reg(self, reg_type, reg_name, name=''):
+        """
+        Load a register value into an LLVM value.
+          Example: v = load_reg(IntType(32), "eax")
+        """
+        ftype = types.FunctionType(reg_type, [])
+        return self.asm(ftype, "", "={%s}" % reg_name, [], False, name)
+
+    def store_reg(self, value, reg_type, reg_name, name=''):
+        """
+        Store an LLVM value inside a register
+          Example: store_reg(Constant(IntType(32), 0xAAAAAAAA), IntType(32), "eax")
+        """
+        ftype = types.FunctionType(types.VoidType(), [reg_type])
+        return self.asm(ftype, "", "{%s}" % reg_name, [value], True, name)
+
     def invoke(self, fn, args, normal_to, unwind_to, name='', cconv=None, tail=False):
         inst = instructions.InvokeInstr(self.block, fn, args, normal_to, unwind_to, name=name,
                                         cconv=cconv)

--- a/llvmlite/ir/instructions.py
+++ b/llvmlite/ir/instructions.py
@@ -123,7 +123,6 @@ class CallInstr(Instruction):
     def descr(self, buf):
         self._descr(buf, add_metadata=True)
 
-
 class InvokeInstr(CallInstr):
     def __init__(self, parent, func, args, normal_to, unwind_to, name='', cconv=None):
         assert isinstance(normal_to, Block)

--- a/llvmlite/tests/test_ir.py
+++ b/llvmlite/tests/test_ir.py
@@ -357,6 +357,38 @@ class TestIR(TestBase):
         self.assertInText(pat, str(mod))
         self.assert_valid_ir(mod)
 
+    def test_builder_asm(self):
+        mod = self.module()
+        foo = ir.Function(mod, ir.FunctionType(ir.VoidType(), []), 'foo')
+        builder = ir.IRBuilder(foo.append_basic_block(''))
+        asmty = ir.FunctionType(int32, [int32])
+        builder.asm(asmty, "mov $1, $2", "=r,r", [int32(123)], side_effect=True)
+        builder.ret_void()
+        pat = 'call i32 asm sideeffect "mov $1, $2", "=r,r" ( i32 123 )'
+        self.assertInText(pat, str(mod))
+        self.assert_valid_ir(mod)
+
+    def test_builder_load_reg(self):
+        mod = self.module()
+        foo = ir.Function(mod, ir.FunctionType(ir.VoidType(), []), 'foo')
+        builder = ir.IRBuilder(foo.append_basic_block(''))
+        asmty = ir.FunctionType(int32, [int32])
+        builder.load_reg(ir.IntType(64), "rax")
+        builder.ret_void()
+        pat = 'call i64 asm "", "={rax}"'
+        self.assertInText(pat, str(mod))
+        self.assert_valid_ir(mod)
+
+    def test_builder_store_reg(self):
+        mod = self.module()
+        foo = ir.Function(mod, ir.FunctionType(ir.VoidType(), []), 'foo')
+        builder = ir.IRBuilder(foo.append_basic_block(''))
+        asmty = ir.FunctionType(ir.VoidType(), [int32])
+        builder.store_reg(int64(123), ir.IntType(64), "rax")
+        builder.ret_void()
+        pat = 'call void asm sideeffect "", "{rax}" ( i64 123 )'
+        self.assertInText(pat, str(mod))
+        self.assert_valid_ir(mod)
 
 class TestGlobalValues(TestBase):
 


### PR DESCRIPTION
Add three helper functions in the builder:
- asm: create a call to an inline assembler object
- store_reg: store an LLVM value into a specific register
- load_reg: set an LLVM value as the value inside a register

The previous pull request was non-sense since there already is an InlineAsm instruction...
