### PR TITLE
Remove unnecessary verify in module linkage

### DIFF
--- a/llvmlite/binding/linker.py
+++ b/llvmlite/binding/linker.py
@@ -4,8 +4,6 @@ from . import ffi
 
 
 def link_modules(dst, src):
-    dst.verify()
-    src.verify()
     with ffi.OutputString() as outerr:
         err = ffi.lib.LLVMPY_LinkModules(dst, src, outerr)
         # The underlying module was destroyed


### PR DESCRIPTION
We should let user run the verification instead of doing it in linkage.
