### PR TITLE
Add all function/return value attributes from LLVM 3.9

### DIFF
--- a/llvmlite/ir/values.py
+++ b/llvmlite/ir/values.py
@@ -666,6 +666,36 @@ class ArgumentAttributes(AttributeSet):
                         'nocapture', 'nonnull', 'returned', 'signext',
                         'sret', 'zeroext'])
 
+    def __init__(self):
+        self._dereferenceable = 0
+        self._dereferenceable_or_null = 0
+
+    @property
+    def dereferenceable(self):
+        return self._dereferenceable
+
+    @dereferenceable.setter
+    def dereferenceable(self, val):
+        assert isinstance(val, six.integer_types) and val >= 0
+        self._dereferenceable = val
+
+    @property
+    def dereferenceable_or_null(self):
+        return self._dereferenceable_or_null
+
+    @dereferenceable_or_null.setter
+    def dereferenceable_or_null(self, val):
+        assert isinstance(val, six.integer_types) and val >= 0
+        self._dereferenceable_or_null = val
+
+    def _to_list(self):
+        attrs = sorted(self)
+        if self.dereferenceable:
+            attrs.append('dereferenceable({0:d})'.format(self.dereferenceable))
+        if self.dereferenceable_or_null:
+            attrs.append('dereferenceable_or_null({0:d})'.format(self.dereferenceable_or_null))
+        return attrs
+
 
 class _BaseArgument(NamedValue):
     def __init__(self, parent, typ, name=''):
@@ -687,8 +717,9 @@ class Argument(_BaseArgument):
     """
 
     def __str__(self):
-        if self.attributes:
-            return "{0} {1} {2}".format(self.type, ' '.join(self.attributes),
+        attrs = self.attributes._to_list()
+        if attrs:
+            return "{0} {1} {2}".format(self.type, ' '.join(attrs),
                                         self.get_reference())
         else:
             return "{0} {1}".format(self.type, self.get_reference())
@@ -700,8 +731,9 @@ class ReturnValue(_BaseArgument):
     """
 
     def __str__(self):
-        if self.attributes:
-            return "{0} {1}".format(' '.join(self.attributes), self.type)
+        attrs = self.attributes._to_list()
+        if attrs:
+            return "{0} {1}".format(' '.join(attrs), self.type)
         else:
             return str(self.type)
 

--- a/llvmlite/ir/values.py
+++ b/llvmlite/ir/values.py
@@ -667,8 +667,18 @@ class ArgumentAttributes(AttributeSet):
                         'sret', 'zeroext'])
 
     def __init__(self):
+        self._align = 0
         self._dereferenceable = 0
         self._dereferenceable_or_null = 0
+
+    @property
+    def align(self):
+        return self._align
+
+    @align.setter
+    def align(self, val):
+        assert isinstance(val, six.integer_types) and val >= 0
+        self._align = val
 
     @property
     def dereferenceable(self):
@@ -690,6 +700,8 @@ class ArgumentAttributes(AttributeSet):
 
     def _to_list(self):
         attrs = sorted(self)
+        if self.align:
+            attrs.append('align {0:d}'.format(self.align))
         if self.dereferenceable:
             attrs.append('dereferenceable({0:d})'.format(self.dereferenceable))
         if self.dereferenceable_or_null:

--- a/llvmlite/tests/test_ir.py
+++ b/llvmlite/tests/test_ir.py
@@ -135,11 +135,12 @@ class TestFunction(TestBase):
         func.args[0].add_attribute("zeroext")
         func.args[1].attributes.dereferenceable = 5
         func.args[1].attributes.dereferenceable_or_null = 10
+        func.args[3].attributes.align = 4
         func.args[3].add_attribute("nonnull")
         func.return_value.add_attribute("noalias")
         asm = self.descr(func).strip()
         self.assertEqual(asm,
-            """declare noalias i32 @"my_func"(i32 zeroext %".1", i32 dereferenceable(5) dereferenceable_or_null(10) %".2", double %".3", i32* nonnull %".4")"""
+            """declare noalias i32 @"my_func"(i32 zeroext %".1", i32 dereferenceable(5) dereferenceable_or_null(10) %".2", double %".3", i32* nonnull align 4 %".4")"""
             )
 
     def test_function_metadata(self):

--- a/llvmlite/tests/test_ir.py
+++ b/llvmlite/tests/test_ir.py
@@ -133,11 +133,13 @@ class TestFunction(TestBase):
         # Now with parameter attributes
         func = self.function()
         func.args[0].add_attribute("zeroext")
+        func.args[1].attributes.dereferenceable = 5
+        func.args[1].attributes.dereferenceable_or_null = 10
         func.args[3].add_attribute("nonnull")
         func.return_value.add_attribute("noalias")
         asm = self.descr(func).strip()
         self.assertEqual(asm,
-            """declare noalias i32 @"my_func"(i32 zeroext %".1", i32 %".2", double %".3", i32* nonnull %".4")"""
+            """declare noalias i32 @"my_func"(i32 zeroext %".1", i32 dereferenceable(5) dereferenceable_or_null(10) %".2", double %".3", i32* nonnull %".4")"""
             )
 
     def test_function_metadata(self):


### PR DESCRIPTION
... except the Swift ones since those seem useless.