### PR TITLE
Fix setup.py for Python2.7

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,8 +21,6 @@ if os.environ.get('READTHEDOCS', None) == 'True':
     sys.exit("setup.py disabled on readthedocs: called with %s"
              % (sys.argv,))
 
-from llvmlite.utils import get_library_files
-
 import versioneer
 
 versioneer.VCS = 'git'
@@ -63,6 +61,7 @@ class LlvmliteBuildExt(build_ext):
         spawn(cmd, dry_run=self.dry_run)
         # HACK: this makes sure the library file (which is large) is only
         # included in binary builds, not source builds.
+        from llvmlite.utils import get_library_files
         self.distribution.package_data = {
             "llvmlite.binding": get_library_files(),
         }
@@ -72,6 +71,7 @@ class LlvmliteInstall(install):
     # Ensure install see the libllvmlite shared library
     # This seems to only be necessary on OSX.
     def run(self):
+        from llvmlite.utils import get_library_files
         self.distribution.package_data = {
             "llvmlite.binding": get_library_files(),
         }


### PR DESCRIPTION
`python setup.py build` in a `Python2.7` environment without `enum34` installed fails

Steps to reproduce:
```
conda create -n llvm_27 python=2.7 -y
source activate llvm_27
python setup.py build
```

Error:
```
Traceback (most recent call last):
  File "setup.py", line 24, in <module>
    from llvmlite.utils import get_library_files
  File "...", line 6, in <module>
    raise ImportError("could not find the 'enum' module; please install "
ImportError: could not find the 'enum' module; please install it using e.g. 'pip install enum34'
```

Moving the `import`s inside the `distutils.command`s they're used in makes sure the import doesn't happen until after the packages in `install_requires` have been installed.

Fixes https://github.com/numba/llvmlite/issues/194