### PR TITLE
Add __hash__ to all IR types

### DIFF
--- a/llvmlite/ir/types.py
+++ b/llvmlite/ir/types.py
@@ -95,9 +95,6 @@ class MetaDataType(Type):
     def __eq__(self, other):
         return isinstance(other, MetaDataType)
 
-    def __ne__(self, other):
-        return not isinstance(other, MetaDataType)
-
 
 class LabelType(Type):
     """

--- a/llvmlite/ir/types.py
+++ b/llvmlite/ir/types.py
@@ -95,6 +95,9 @@ class MetaDataType(Type):
     def __eq__(self, other):
         return isinstance(other, MetaDataType)
 
+    def __hash__(self):
+        return hash(MetaDataType)
+
 
 class LabelType(Type):
     """
@@ -130,6 +133,9 @@ class PointerType(Type):
         else:
             return False
 
+    def __hash__(self):
+        return hash(PointerType)
+
     def gep(self, i):
         """
         Resolve the type of the i-th element (for getelementptr lookups).
@@ -153,6 +159,9 @@ class VoidType(Type):
 
     def __eq__(self, other):
         return isinstance(other, VoidType)
+
+    def __hash__(self):
+        return hash(VoidType)
 
 
 class FunctionType(Type):
@@ -183,6 +192,9 @@ class FunctionType(Type):
                     self.args == other.args and self.var_arg == other.var_arg)
         else:
             return False
+
+    def __hash__(self):
+        return hash(FunctionType)
 
 
 class IntType(Type):
@@ -224,6 +236,9 @@ class IntType(Type):
         else:
             return False
 
+    def __hash__(self):
+        return hash(IntType)
+
     def format_constant(self, val):
         if isinstance(val, bool):
             return str(val).lower()
@@ -262,6 +277,9 @@ class _BaseFloatType(Type):
 
     def __eq__(self, other):
         return isinstance(other, type(self))
+
+    def __hash__(self):
+        return hash(type(self))
 
     @classmethod
     def _create_instance(cls):
@@ -356,6 +374,9 @@ class ArrayType(Aggregate):
         if isinstance(other, ArrayType):
             return self.element == other.element and self.count == other.count
 
+    def __hash__(self):
+        return hash(ArrayType)
+
     def gep(self, i):
         """
         Resolve the type of the i-th element (for getelementptr lookups).
@@ -428,6 +449,9 @@ class LiteralStructType(BaseStructType):
         if isinstance(other, LiteralStructType):
             return self.elements == other.elements
 
+    def __hash__(self):
+        return hash(LiteralStructType)
+
 
 class IdentifiedStructType(BaseStructType):
     """
@@ -462,6 +486,9 @@ class IdentifiedStructType(BaseStructType):
     def __eq__(self, other):
         if isinstance(other, IdentifiedStructType):
             return self.name == other.name
+
+    def __hash__(self):
+        return hash(IdentifiedStructType)
 
     def set_body(self, *elems):
         if not self.is_opaque:

--- a/llvmlite/tests/test_ir.py
+++ b/llvmlite/tests/test_ir.py
@@ -1444,6 +1444,10 @@ class TestTypes(TestBase):
         mytype2 = context.get_identified_type("MyType\"")
         self.assertEqual(str(mytype2), "%\"MyType\\22\"")
 
+    def test_hash(self):
+        for typ in filter(self.has_logical_equality, self.assorted_types()):
+            self.assertEqual(hash(typ), hash(copy.copy(typ)))
+
     def test_gep(self):
         def check_constant(tp, i, expected):
             actual = tp.gep(ir.Constant(int32, i))


### PR DESCRIPTION
All of the ir.Types are not hashable in Python 3 because they define their own ``__eq__`` methods. It would be nice for types to be hashable so they could be used in sets or as keys to a dict. This fix is also necessary for correctness under Python 2:
```python
In [12]: a, b = ir.VoidType(), ir.VoidType()

In [13]: a == b
Out[13]: True

In [14]: hash(a) == hash(b)
Out[14]: False
```

Overriding ``__hash__`` on the ``Type`` class doesn't work because
> A class that overrides __eq__() and does not define __hash__() will have its __hash__() implicitly set to None. When the __hash__() method of a class is None, instances of the class will raise an appropriate TypeError when a program attempts to retrieve their hash value, and will also be correctly identified as unhashable when checking isinstance(obj, collections.Hashable).

(from the [``__hash__ docs``](https://docs.python.org/3/reference/datamodel.html#object.__hash__)).

There were a couple possible definitions for the hash functions. I initially considering ``hash(self.__class__)``, but subclasses would make this hash inconsistent with equality. The hashes could be improved to take into account more fields (such as the width of IntType). For the classes with instance caches (IntType and the float types), the hash could just be the address/``id`` of the singleton instance. I chose this implementation for it's simplicity and uniformity over all types.