### PR TITLE
Disable static linking of libstdc++ by default.

### DIFF
--- a/conda-recipes/llvmlite/build.sh
+++ b/conda-recipes/llvmlite/build.sh
@@ -7,6 +7,8 @@ if [ -n "$MACOSX_DEPLOYMENT_TARGET" ]; then
 fi
 
 export PYTHONNOUSERSITE=1
+# Enables static linking of stdlibc++
+export LLVMLITE_CXX_STATIC_LINK=1
 
 python setup.py build --force
 python setup.py install

--- a/conda-recipes/llvmlite/run_test.py
+++ b/conda-recipes/llvmlite/run_test.py
@@ -1,3 +1,6 @@
+import os
 from llvmlite.tests import main
 
+# Enable tests for distribution only
+os.environ['LLVMLITE_DIST_TEST'] = '1'
 main()

--- a/ffi/Makefile.linux
+++ b/ffi/Makefile.linux
@@ -19,7 +19,7 @@ all: $(OUTPUT)
 $(OUTPUT): $(SRC) $(INCLUDE)
 	# static-libstdc++ avoids runtime dependencies on a
 	# particular libstdc++ version.
-	$(CXX) -static-libstdc++ -shared $(CXXFLAGS) $(SRC) -o $(OUTPUT) $(LDFLAGS) $(LIBS)
+	$(CXX) $(CXX_STATIC_LINK) -shared $(CXXFLAGS) $(SRC) -o $(OUTPUT) $(LDFLAGS) $(LIBS)
 
 clean:
 	rm -rf test $(OUTPUT)

--- a/ffi/build.py
+++ b/ffi/build.py
@@ -129,6 +129,9 @@ def main_posix(kind, library_ext):
 
     ldflags = run_llvm_config(llvm_config, ["--ldflags"])
     os.environ['LLVM_LDFLAGS'] = ldflags.strip()
+    # static link libstdc++ for portability
+    if int(os.environ.get('LLVMLITE_CXX_STATIC_LINK', 0)):
+        os.environ['CXX_STATIC_LINK'] = "-static-libstdc++"
 
     makefile = "Makefile.%s" % (kind,)
     subprocess.check_call(['make', '-f', makefile])

--- a/llvmlite/tests/test_binding.py
+++ b/llvmlite/tests/test_binding.py
@@ -163,6 +163,7 @@ class TestDependencies(BaseTest):
     """
 
     @unittest.skipUnless(sys.platform.startswith('linux'), "Linux-specific test")
+    @unittest.skipUnless(os.environ.get('LLVMLITE_DIST_TEST'), "Distribution-specific test")
     def test_linux(self):
         lib_path = ffi.lib._name
         env = os.environ.copy()


### PR DESCRIPTION
(Fix #249)

Only enable it for distribution build in the conda recipe.
User can still override with LLVMLITE_CXX_STATIC_LINK.