### PR TITLE
Fix wheel build

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -117,6 +117,9 @@ if bdist_wheel:
                 path = os.path.join('llvmlite', 'binding', fn)
                 if not os.path.isfile(path):
                     raise RuntimeError("missing {}".format(path))
+            self.distribution.package_data.update({
+                "llvmlite.binding": get_library_files(),
+            })
             # Run wheel build command
             bdist_wheel.run(self)
 

--- a/setup.py
+++ b/setup.py
@@ -112,9 +112,12 @@ if bdist_wheel:
     class LLvmliteBDistWheel(bdist_wheel):
         def run(self):
             from llvmlite.utils import get_library_files
-            self.distribution.package_data = {
-                "llvmlite.binding": get_library_files(),
-            }
+            # Hack to ensure the binding file exist when running wheel build
+            for fn in get_library_files():
+                path = os.path.join('llvmlite', 'binding', fn)
+                if not os.path.isfile(path):
+                    raise RuntimeError("missing {}".format(path))
+            # Run wheel build command
             bdist_wheel.run(self)
 
 


### PR DESCRIPTION
Previously, it has to depend on user running `build_ext —inplace` before doing `bdist_wheel`.

Here we patch the `bdist_wheel` command ~~~to  include the library files, a pattern used for other command as well.~~~ to detect that the library files do exist.

To build wheels, run

```bash
python setup.py build      
python setup.py bdist_wheel
```

