### PR TITLE
Fix the behavior of module.get_global

### DIFF
--- a/llvmlite/ir/module.py
+++ b/llvmlite/ir/module.py
@@ -135,7 +135,7 @@ class Module(object):
         """
         Get a global value by name.
         """
-        return self.globals.get(name)
+        return self.globals[name]
 
     def add_global(self, globalvalue):
         """

--- a/llvmlite/tests/test_ir.py
+++ b/llvmlite/tests/test_ir.py
@@ -412,7 +412,8 @@ class TestGlobalValues(TestBase):
         globdouble = ir.GlobalVariable(mod, ir.DoubleType(), 'globdouble')
         self.assertEqual(mod.get_global('foo'), foo)
         self.assertEqual(mod.get_global('globdouble'), globdouble)
-        self.assertIsNone(mod.get_global('kkk'))
+        with self.assertRaises(KeyError):
+            mod.get_global('kkk')
         # Globals should have a useful repr()
         self.assertEqual(repr(globdouble),
                          "<ir.GlobalVariable 'globdouble' of type 'double*'>")


### PR DESCRIPTION
Fix the behavior of module.get_global to keep consistency with the document.
Document says: 

> Get the global value (a GlobalValue) with the given name. KeyError is raised if it doesn’t exist.

But actually `dict.get` will never raise an `KeyError`. `OrderedDict` is a subclass of `dict`.

See:
https://docs.python.org/2/library/stdtypes.html#dict.get
https://docs.python.org/3/library/stdtypes.html#dict.get
