### PR TITLE
Add variables to pass through when doing conda-build

### DIFF
--- a/conda-recipes/llvmlite/meta.yaml
+++ b/conda-recipes/llvmlite/meta.yaml
@@ -9,6 +9,10 @@ source:
 
 build:
   number: {{ environ.get('GIT_DESCRIBE_NUMBER', 0) }}
+  script_env:
+    - CFLAGS
+    - CXXFLAGS
+    - PY_VCRUNTIME_REDIST
 
 requirements:
   build:


### PR DESCRIPTION
CFLAGS, CXXFLAGS and PY_VCRUNTIME_REDIST need to be passed
through to conda-build so that 32 bit cross compilation works.