### PR TITLE
Add pass through gcc flags for llvmdev

### DIFF
--- a/conda-recipes/llvmdev/meta.yaml
+++ b/conda-recipes/llvmdev/meta.yaml
@@ -18,6 +18,10 @@ source:
 
 build:
   number: 0
+  script_env:
+    - CFLAGS
+    - CXXFLAGS
+    - PY_VCRUNTIME_REDIST
 
 requirements:
   build:


### PR DESCRIPTION
As title, for 32bit builds.