### PR TITLE
Fix building with conda-build on win32

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -174,5 +174,7 @@ setup(name='llvmlite',
       install_requires=install_requires,
       license="BSD",
       cmdclass=cmdclass,
-      ext_modules=[ext_stub],
+      # The `ext_stub` is only needed for making bdist_wheel
+      # thinks this package has compiled code.
+      ext_modules=[ext_stub] if bdist_wheel else [],
       )


### PR DESCRIPTION
Having `ext_stub` somehow break conda-build but it is needed for wheel build.  The fix is to hide it when we are not building wheels.