### PR TITLE
Fixes for LLVM5

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -62,7 +62,7 @@ Compatibility
 
 llvmlite works with Python 2.7 and Python 3.4 or greater.
 
-As of version 0.17.0, llvmlite requires LLVM 4.0.  It does not support earlier
+As of version 0.21.0, llvmlite requires LLVM 5.0.  It does not support earlier
 or later versions of LLVM.
 
 Historical compatibility table:
@@ -70,7 +70,8 @@ Historical compatibility table:
 =================  ========================
 llvmlite versions  compatible LLVM versions
 =================  ========================
-0.17.0 - ...       4.0.x
+0.21.0 - ...       5.0.x
+0.17.0 - 0.20.0    4.0.x
 0.16.0 - 0.17.0    3.9.x
 0.13.0 - 0.15.0    3.8.x
 0.9.0 - 0.12.1     3.7.x

--- a/buildscripts/incremental/setup_conda_environment.cmd
+++ b/buildscripts/incremental/setup_conda_environment.cmd
@@ -17,6 +17,6 @@ conda create -n %CONDA_ENV% -q -y python=%PYTHON% cmake
 
 call activate %CONDA_ENV%
 @rem Install llvmdev
-%CONDA_INSTALL% -c numba llvmdev="4.0*"
+%CONDA_INSTALL% -c numba llvmdev="5.0*"
 @rem Install enum34 for Python < 3.4
 if %PYTHON% LSS 3.4 (%CONDA_INSTALL% enum34)

--- a/buildscripts/incremental/setup_conda_environment.sh
+++ b/buildscripts/incremental/setup_conda_environment.sh
@@ -25,7 +25,7 @@ source activate $CONDA_ENV
 set -v
 
 # Install llvmdev (separate channel, for now)
-$CONDA_INSTALL -c numba llvmdev="4.0*"
+$CONDA_INSTALL -c numba llvmdev="5.0*"
 
 # Install enum34 for Python < 3.4 and PyPy, and install dependencies for
 # building the docs. Sphinx 1.5.4 has a bug.

--- a/conda-recipes/llvmdev/meta.yaml
+++ b/conda-recipes/llvmdev/meta.yaml
@@ -1,11 +1,11 @@
 
-{% set shortversion = "4.0" %}
-{% set version = "4.0.0" %}
-{% set sha256 = "8d10511df96e73b8ff9e7abbfb4d4d432edbdbe965f1f4f07afaf370b8a533be" %}
+{% set shortversion = "5.0" %}
+{% set version = "5.0.0" %}
+{% set sha256 = "e35dcbae6084adcf4abb32514127c5eabd7d63b733852ccdb31e06f1373136da" %}
 
 package:
   name: llvmdev
-  version: "4.0.0"
+  version: "5.0.0"
 
 source:
   url: http://llvm.org/releases/{{ version }}/llvm-{{ version }}.src.tar.xz

--- a/conda-recipes/llvmlite/meta.yaml
+++ b/conda-recipes/llvmlite/meta.yaml
@@ -18,7 +18,7 @@ requirements:
   build:
     - python
     # On channel https://anaconda.org/numba/
-    - llvmdev 4.0*
+    - llvmdev 5.0*
     - vs2015_runtime [win]
     # The DLL build uses cmake on Windows
     - cmake          [win]

--- a/docs/source/admin-guide/install.rst
+++ b/docs/source/admin-guide/install.rst
@@ -45,11 +45,11 @@ Before building, you must have the following:
 
 * On Unix:
 
-  * An LLVM 4.0 build---libraries and header files---available
+  * An LLVM 5.0 build---libraries and header files---available
     somewhere.
 
   * On recent Ubuntu or Debian systems, you may install the
-    ``llvm-4.0-dev`` package, if it is available.
+    ``llvm-5.0-dev`` package, if it is available.
 
   * If building LLVM on Ubuntu, the linker may report an error
     if the development version of ``libedit`` is not installed. If

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -301,5 +301,5 @@ texinfo_documents = [
 # Example configuration for intersphinx: refer to the Python standard library.
 intersphinx_mapping = {
     'python': ('https://docs.python.org/3', None),
-    'llvm': ('http://llvm.org/releases/4.0.0/docs', None),
+    'llvm': ('http://llvm.org/releases/5.0.0/docs', None),
     }

--- a/docs/source/user-guide/binding/execution-engine.rst
+++ b/docs/source/user-guide/binding/execution-engine.rst
@@ -54,24 +54,6 @@ The ExecutionEngine class
         Make sure all modules owned by the execution engine are
         fully processed and usable for execution.
 
-   * .. method:: get_pointer_to_function(gv)
-
-        CAUTION: This method is deprecated. Use
-        :meth:`ExecutionEngine.get_function_address` and
-        :meth:`ExecutionEngine.get_global_value_address` instead.
-
-        Return the address of the function value *gv*, as an
-        integer. The value should have been looked up on one of
-        the modules owned by the execution engine.
-
-        NOTE: This method may implicitly generate code for the
-        object being looked up.
-
-        This method is formerly an alias to
-        ``get_pointer_to_global()``, which is now removed
-        because it returns an invalid address in MCJIT when
-        given a non-function global value.
-
    * .. method:: get_function_address(name)
 
         Return the address of the function *name* as an integer.

--- a/docs/source/user-guide/binding/execution-engine.rst
+++ b/docs/source/user-guide/binding/execution-engine.rst
@@ -57,11 +57,13 @@ The ExecutionEngine class
    * .. method:: get_function_address(name)
 
         Return the address of the function *name* as an integer.
+        It's a fatal error in LLVM if the symbol of *name* doesn't exist.
 
    * .. method:: get_global_value_address(name)
 
         Return the address of the global value *name* as an
         integer.
+        It's a fatal error in LLVM if the symbol of *name* doesn't exist.
 
    * .. method:: remove_module(module)
 

--- a/docs/source/user-guide/ir/index.rst
+++ b/docs/source/user-guide/ir/index.rst
@@ -7,18 +7,18 @@ IR layer---llvmlite.ir
 .. module:: llvmlite.ir
    :synopsis: Classes for building the LLVM intermediate representation of functions.
 
-The :mod:`llvmlite.ir` module contains classes and utilities to 
-build the LLVM 
-:ref:`intermediate representation <intermediate representation>` 
+The :mod:`llvmlite.ir` module contains classes and utilities to
+build the LLVM
+:ref:`intermediate representation <intermediate representation>`
 (IR) of native functions.
 
-The provided APIs may sometimes look like LLVM's C++ APIs, but 
-they never call into LLVM, unless otherwise noted. Instead, they 
+The provided APIs may sometimes look like LLVM's C++ APIs, but
+they never call into LLVM, unless otherwise noted. Instead, they
 construct a pure Python representation of the IR.
 
 To use this module, you should be familiar with the concepts
 in the `LLVM Language Reference
-<http://llvm.org/releases/4.0.0/docs/LangRef.html>`_.
+<http://llvm.org/releases/5.0.0/docs/LangRef.html>`_.
 
 .. toctree::
    :maxdepth: 1

--- a/ffi/build.py
+++ b/ffi/build.py
@@ -52,7 +52,7 @@ def find_win32_generator():
     # compatible with, the one which was used to compile LLVM... cmake
     # seems a bit lacking here.
     cmake_dir = os.path.join(here_dir, 'dummy')
-    # LLVM 4.0 needs VS 2015 minimum.
+    # LLVM 4.0+ needs VS 2015 minimum.
     for generator in ['Visual Studio 14 2015']:
         if is_64bit:
             generator += ' Win64'
@@ -95,9 +95,9 @@ def main_posix(kind, library_ext):
 
     out = out.decode('latin1')
     print(out)
-    if not out.startswith('4.0.'):
+    if not out.startswith('5.0.'):
         msg = (
-            "Building llvmlite requires LLVM 4.0.x. Be sure to "
+            "Building llvmlite requires LLVM 5.0.x. Be sure to "
             "set LLVM_CONFIG to the right executable path.\n"
             "Read the documentation at http://llvmlite.pydata.org/ for more "
             "information about building llvmlite.\n"

--- a/ffi/executionengine.cpp
+++ b/ffi/executionengine.cpp
@@ -93,12 +93,6 @@ LLVMPY_CreateMCJITCompiler(LLVMModuleRef M,
     return create_execution_engine(M, TM, OutError);
 }
 
-API_EXPORT(void *)
-LLVMPY_GetPointerToGlobal(LLVMExecutionEngineRef EE,
-                          LLVMValueRef Global)
-{
-    return LLVMGetPointerToGlobal(EE, Global);
-}
 
 API_EXPORT(uint64_t)
 LLVMPY_GetGlobalValueAddress(LLVMExecutionEngineRef EE,

--- a/ffi/value.cpp
+++ b/ffi/value.cpp
@@ -74,11 +74,18 @@ LLVMPY_GetDLLStorageClass(LLVMValueRef Val)
     return (int)LLVMGetDLLStorageClass(Val);
 }
 
+API_EXPORT(unsigned)
+LLVMPY_GetEnumAttributeKindForName(const char *name, size_t len)
+{
+    /* zero is returned if no match */
+    return LLVMGetEnumAttributeKindForName(name, len);
+}
+
 API_EXPORT(void)
-LLVMPY_AddFunctionAttr(LLVMValueRef Fn, int Attr)
+LLVMPY_AddFunctionAttr(LLVMValueRef Fn, unsigned AttrKind)
 {
     LLVMContextRef ctx = LLVMGetModuleContext(LLVMGetGlobalParent(Fn));
-    LLVMAttributeRef attr_ref = LLVMCreateEnumAttribute(ctx, Attr, 0);
+    LLVMAttributeRef attr_ref = LLVMCreateEnumAttribute(ctx, AttrKind, 0);
     LLVMAddAttributeAtIndex(Fn, LLVMAttributeReturnIndex, attr_ref);
 }
 

--- a/llvmlite/binding/executionengine.py
+++ b/llvmlite/binding/executionengine.py
@@ -57,14 +57,6 @@ class ExecutionEngine(ffi.ObjectRef):
         module._owned = True
         ffi.ObjectRef.__init__(self, ptr)
 
-    def get_pointer_to_function(self, gv):
-        warnings.warn(".get_pointer_to_function() is deprecated.  Use "
-                      ".get_function_address() instead.", DeprecationWarning)
-        ptr = ffi.lib.LLVMPY_GetPointerToGlobal(self, gv)
-        if ptr is None:
-            raise ValueError("Cannot find given global value %r" % (gv.name))
-        return ptr
-
     def get_function_address(self, name):
         """
         Return the address of the function named *name* as an integer.
@@ -244,10 +236,6 @@ ffi.lib.LLVMPY_AddModule.argtypes = [
     ffi.LLVMExecutionEngineRef,
     ffi.LLVMModuleRef
 ]
-
-ffi.lib.LLVMPY_GetPointerToGlobal.argtypes = [ffi.LLVMExecutionEngineRef,
-                                              ffi.LLVMValueRef]
-ffi.lib.LLVMPY_GetPointerToGlobal.restype = c_void_p
 
 ffi.lib.LLVMPY_AddGlobalMapping.argtypes = [ffi.LLVMExecutionEngineRef,
                                             ffi.LLVMValueRef,

--- a/llvmlite/binding/executionengine.py
+++ b/llvmlite/binding/executionengine.py
@@ -60,20 +60,18 @@ class ExecutionEngine(ffi.ObjectRef):
     def get_function_address(self, name):
         """
         Return the address of the function named *name* as an integer.
+
+        It's a fatal error in LLVM if the symbol of *name* doesn't exist.
         """
-        ptr = ffi.lib.LLVMPY_GetFunctionAddress(self, name.encode("ascii"))
-        if ptr is None:
-            raise ValueError("Cannot find given function %s" % name)
-        return ptr
+        return ffi.lib.LLVMPY_GetFunctionAddress(self, name.encode("ascii"))
 
     def get_global_value_address(self, name):
         """
         Return the address of the global value named *name* as an integer.
+
+        It's a fatal error in LLVM if the symbol of *name* doesn't exist.
         """
-        ptr = ffi.lib.LLVMPY_GetGlobalValueAddress(self, name.encode("ascii"))
-        if ptr is None:
-            raise ValueError("Cannot find given global value %s" % name)
-        return ptr
+        return ffi.lib.LLVMPY_GetGlobalValueAddress(self, name.encode("ascii"))
 
     def add_global_mapping(self, gv, addr):
         # XXX unused?

--- a/llvmlite/binding/value.py
+++ b/llvmlite/binding/value.py
@@ -1,4 +1,3 @@
-import warnings
 from ctypes import POINTER, c_char_p, c_int, c_size_t, c_uint
 import enum
 

--- a/llvmlite/binding/value.py
+++ b/llvmlite/binding/value.py
@@ -1,5 +1,5 @@
-
-from ctypes import POINTER, c_char_p, c_int
+import warnings
+from ctypes import POINTER, c_char_p, c_int, c_size_t, c_uint
 import enum
 
 from . import ffi
@@ -26,37 +26,6 @@ class Linkage(enum.IntEnum):
     common = 14
     linker_private = 15
     linker_private_weak = 16
-
-
-class Attribute(enum.Enum):
-    # The LLVMAttribute enum from llvm-c/Core.h
-
-    zext = 1 << 0
-    sext = 1 << 1
-    noreturn = 1 << 2
-    inreg = 1 << 3
-    structret = 1 << 4
-    nounwind = 1 << 5
-    noalias = 1 << 6
-    byval = 1 << 7
-    nest = 1 << 8
-    readnone = 1 << 9
-    readonly = 1 << 10
-    noinline = 1 << 11
-    alwaysinline = 1 << 12
-    optimizeforsize = 1 << 13
-    stackprotect = 1 << 14
-    stackprotectreq = 1 << 15
-
-    nocapture = 1 << 21
-    noredzone = 1 << 22
-    noimplicitfloat = 1 << 23
-    naked = 1 << 24
-    inlinehint = 1 << 25
-
-    returnstwice = 1 << 29
-    uwtable = 1 << 30
-    nonlazybind = 1 << 31
 
 
 class Visibility(enum.IntEnum):
@@ -134,11 +103,19 @@ class ValueRef(ffi.ObjectRef):
         ffi.lib.LLVMPY_SetDLLStorageClass(self, value)
 
     def add_function_attribute(self, attr):
-        """Only works on function value"""
-        # XXX unused?
-        if not isinstance(attr, Attribute):
-            attr = Attribute[attr]
-        ffi.lib.LLVMPY_AddFunctionAttr(self, attr.value)
+        """Only works on function value
+
+        Parameters
+        -----------
+        attr : str
+            attribute name
+        """
+        attrname = str(attr)
+        attrval = ffi.lib.LLVMPY_GetEnumAttributeKindForName(
+            _encode_string(attrname), len(attrname))
+        if attrval == 0:
+            raise ValueError('no such attribute {!r}'.format(attrname))
+        ffi.lib.LLVMPY_AddFunctionAttr(self, attrval)
 
     @property
     def type(self):
@@ -190,7 +167,10 @@ ffi.lib.LLVMPY_GetDLLStorageClass.restype = c_int
 
 ffi.lib.LLVMPY_SetDLLStorageClass.argtypes = [ffi.LLVMValueRef, c_int]
 
-ffi.lib.LLVMPY_AddFunctionAttr.argtypes = [ffi.LLVMValueRef, c_int]
+ffi.lib.LLVMPY_GetEnumAttributeKindForName.argtypes = [c_char_p, c_size_t]
+ffi.lib.LLVMPY_GetEnumAttributeKindForName.restype = c_uint
+
+ffi.lib.LLVMPY_AddFunctionAttr.argtypes = [ffi.LLVMValueRef, c_uint]
 
 ffi.lib.LLVMPY_IsDeclaration.argtypes = [ffi.LLVMValueRef]
 ffi.lib.LLVMPY_IsDeclaration.restype = c_int

--- a/llvmlite/tests/test_binding.py
+++ b/llvmlite/tests/test_binding.py
@@ -297,7 +297,7 @@ class TestMisc(BaseTest):
 
     def test_version(self):
         major, minor, patch = llvm.llvm_version_info
-        self.assertEqual((major, minor), (4, 0))
+        self.assertEqual((major, minor), (5, 0))
         self.assertIn(patch, range(10))
 
     def test_check_jit_execution(self):
@@ -750,7 +750,11 @@ class TestValueRef(BaseTest):
     def test_add_function_attribute(self):
         mod = self.module()
         fn = mod.get_function("sum")
-        fn.add_function_attribute("zext")
+        fn.add_function_attribute("nocapture")
+        with self.assertRaises(ValueError) as raises:
+            fn.add_function_attribute("zext")
+        self.assertEqual(str(raises.exception), "no such attribute 'zext'")
+
 
     def test_module(self):
         mod = self.module()


### PR DESCRIPTION
Based on #306 

This updates llvmlite for the changes in LLVM 5:

* Fix C-API get attribute usage.
* Remove the deprecated get_pointer_to_function since it behavior is unexpected.
