### PR TITLE
[rfc] LLVM Vector Type and Operations Support

### DIFF
--- a/llvmlite/ir/builder.py
+++ b/llvmlite/ir/builder.py
@@ -430,7 +430,11 @@ class IRBuilder(object):
         Bitwise integer complement:
             name = ~value
         """
-        return self.xor(value, values.Constant(value.type, -1), name=name)
+        if isinstance(value.type, types.VectorType):
+            rhs = values.Constant(value.type, (-1,) * value.type.count)
+        else:
+            rhs = values.Constant(value.type, -1)
+        return self.xor(value, rhs, name=name)
 
     def neg(self, value, name=''):
         """
@@ -767,6 +771,35 @@ class IRBuilder(object):
         """
         instr = instructions.GEPInstr(self.block, ptr, indices,
                                       inbounds=inbounds, name=name)
+        self._insert(instr)
+        return instr
+
+    # Vector Operations APIs
+
+    def extract_element(self, vector, idx, name=''):
+        """
+        Returns the value at position idx.
+        """
+        instr = instructions.ExtractElement(self.block, vector, idx, name=name)
+        self._insert(instr)
+        return instr
+
+    def insert_element(self, vector, value, idx, name=''):
+        """
+        Returns vector with vector[idx] replaced by value.
+        The result id undefined if the idx is larger or euqal the vector length.
+        """
+        instr = instructions.InsertElement(self.block, vector, value, idx, name=name)
+        self._insert(instr)
+        return instr
+
+    def shuffle_vector(self, vector1, vector2, mask, name=''):
+        """
+        Concatenate vectors and extract elements into new vector.
+        Elements in the combined vector are numbered left to right,
+        starting at 0.
+        """
+        instr = instructions.ShuffleVector(self.block, vector1, vector2, mask, name=name)
         self._insert(instr)
         return instr
 

--- a/llvmlite/ir/instructions.py
+++ b/llvmlite/ir/instructions.py
@@ -6,7 +6,7 @@ from __future__ import print_function, absolute_import
 
 from . import types
 from .values import (Block, Function, Value, NamedValue, Constant,
-                     MetaDataArgument, MetaDataString, AttributeSet)
+                     MetaDataArgument, MetaDataString, AttributeSet, Undefined)
 from ._utils import _HasMetadata
 
 
@@ -310,7 +310,11 @@ class CompareInstr(Instruction):
             if flag not in self.VALID_FLAG:
                 raise ValueError("invalid flag %r for %s" % (flag, self.OPNAME))
         opname = self.OPNAME
-        super(CompareInstr, self).__init__(parent, types.IntType(1),
+        if isinstance(lhs.type, types.VectorType):
+            typ = types.VectorType(types.IntType(1), lhs.type.count)
+        else:
+            typ = types.IntType(1)
+        super(CompareInstr, self).__init__(parent, typ,
                                            opname, [lhs, rhs], flags=flags,
                                            name=name)
         self.op = op
@@ -502,6 +506,66 @@ class PhiInstr(Instruction):
         self.incomings = [((new if val is old else val), blk)
                           for (val, blk) in self.incomings]
 
+class ExtractElement(Instruction):
+    def __init__(self, parent, vector, index, name=''):
+        if not isinstance(vector.type, types.VectorType):
+            raise TypeError("vector needs to be of VectorType.")
+        if not isinstance(index.type, types.IntType):
+            raise TypeError("index needs to be of IntType.")
+        typ = vector.type.elementtype
+        super(ExtractElement, self).__init__(parent, typ, "extractelement",
+                                           [vector, index], name=name)
+
+    def descr(self, buf):
+        operands = ", ".join("{0} {1}".format(
+                   op.type, op.get_reference()) for op in self.operands)
+        buf.append("{opname} {operands}\n".format(
+                   opname = self.opname, operands = operands))
+
+class InsertElement(Instruction):
+    def __init__(self, parent, vector, value, index, name=''):
+        if not isinstance(vector.type, types.VectorType):
+            raise TypeError("vector needs to be of VectorType.")
+        if not value.type == vector.type.elementtype:
+            raise TypeError("value needs to be of type % not %."
+                            % (vector.type.elementtype, value.type))
+        if not isinstance(index.type, types.IntType):
+            raise TypeError("index needs to be of IntType.")
+        typ = vector.type
+        super(InsertElement, self).__init__(parent, typ, "insertelement",
+                                           [vector, value, index], name=name)
+
+    def descr(self, buf):
+        operands = ", ".join("{0} {1}".format(
+                   op.type, op.get_reference()) for op in self.operands)
+        buf.append("{opname} {operands}\n".format(
+                   opname = self.opname, operands = operands))
+
+class ShuffleVector(Instruction):
+    def __init__(self, parent, vector1, vector2, mask, name=''):
+        if not isinstance(vector1.type, types.VectorType):
+            raise TypeError("vector1 needs to be of VectorType.")
+        if vector2 != Undefined:
+            if vector2.type != vector1.type:
+                raise TypeError("vector2 needs to be " +
+                                "Undefined or of the same type as vector1.")
+        if (not isinstance(mask, Constant) or
+            not isinstance(mask.type, types.VectorType) or
+            mask.type.elementtype != types.IntType(32)):
+            raise TypeError("mask needs to be a constant i32 vector.")
+        typ = types.VectorType(vector1.type.elementtype, mask.type.count)
+        index_range = range(vector1.type.count if vector2 == Undefined else 2 * vector1.type.count)
+        if not all(ii.constant in index_range for ii in mask.constant):
+            raise IndexError("mask values need to be in {0}".format(index_range))
+        super(ShuffleVector, self).__init__(parent, typ, "shufflevector",
+                                           [vector1, vector2, mask], name=name)
+
+    def descr(self, buf):
+        buf.append("shufflevector {0} {1}\n".format(
+                   ", ".join("{0} {1}".format(op.type, op.get_reference())
+                             for op in self.operands),
+                   self._stringify_metadata(leading_comma=True),
+                   ))
 
 class ExtractValue(Instruction):
     def __init__(self, parent, agg, indices, name=''):

--- a/llvmlite/ir/values.py
+++ b/llvmlite/ir/values.py
@@ -116,9 +116,7 @@ class Constant(_StrCaching, _StringReferenceCaching, _ConstOpMixin, Value):
         assert isinstance(typ, types.Type)
         assert not isinstance(typ, types.VoidType)
         self.type = typ
-        if isinstance(constant, (list, tuple)):
-            # Recursively wrap aggregate constants
-            constant = typ.wrap_constant_value(constant)
+        constant = typ.wrap_constant_value(constant)
         self.constant = constant
 
     def _to_string(self):


### PR DESCRIPTION
This is not polished enough to be merged, however I would like to know if anyone would be interested in support for LLVM vector types.

https://llvm.org/docs/LangRef.html#vector-type
https://llvm.org/docs/LangRef.html#vector-operations

I'd also appreciate feedback on how to improve the code to more naturally integrate with `llvmlite`.

Is there anyone who wants to test this under `python2`?

If there is enough interest to merge this, I will take the time to write some unittests.