### PR TITLE
Remove temporary code to make cross compilation work.

### DIFF
--- a/conda-recipes/llvmdev/build.sh
+++ b/conda-recipes/llvmdev/build.sh
@@ -4,11 +4,6 @@
 
 set -x
 
-# this is so we can cross compile on linux 64 -> linux 32
-if [[ $(uname) == Linux ]]; then
-    export _PYTHON_SYSCONFIGDATA_NAME="_sysconfigdata_x86_64_conda_cos6_linux_gnu"
-fi
-
 if [[ $(uname) == Darwin ]]; then
   ${SYS_PREFIX}/bin/conda create -y -p ${SRC_DIR}/bootstrap clangxx_osx-64
   export PATH=${SRC_DIR}/bootstrap/bin:${PATH}


### PR DESCRIPTION
This removes temporary code needed to make linux64->linux32 cross
compilation work, the fix is now upstream so this can be removed.