### PR TITLE
Ensuring threadsafety in concurrent usage of LLVM C-API

### DIFF
--- a/llvmlite/binding/ffi.py
+++ b/llvmlite/binding/ffi.py
@@ -32,8 +32,8 @@ LLVMSectionIteratorRef = _make_opaque_ref("LLVMSectionIterator")
 
 
 class _lib_wrapper(object):
-    """Wrap the libllvmlite with a lock such that only one thread is
-    accessing it at a time.
+    """Wrap libllvmlite with a lock such that only one thread may access it at
+    a time.
 
     This class duck-types a CDLL.
     """
@@ -42,7 +42,7 @@ class _lib_wrapper(object):
     def __init__(self, lib):
         self._lib = lib
         self._fntab = {}
-        # The recursive lock is needed for callbacks that re-enter
+        # The reentrant lock is needed for callbacks that re-enter
         # the Python interpreter.
         self._lock = threading.RLock()
 
@@ -74,7 +74,7 @@ class _lib_wrapper(object):
 
 
 class _lib_fn_wrapper(object):
-    """Wraps and duck-type a ctypes.CFUNCTYPE to provide
+    """Wraps and duck-types a ctypes.CFUNCTYPE to provide
     automatic locking when the wrapped function is called.
 
     TODO: we can add methods to mark the function as threadsafe

--- a/llvmlite/binding/ffi.py
+++ b/llvmlite/binding/ffi.py
@@ -34,36 +34,73 @@ LLVMSectionIteratorRef = _make_opaque_ref("LLVMSectionIterator")
 class _lib_wrapper(object):
     """Wrap the libllvmlite with a lock such that only one thread is
     accessing it at a time.
+
+    This class duck-types a CDLL.
     """
     __slots__ = ['_lib', '_fntab', '_lock']
 
     def __init__(self, lib):
         self._lib = lib
         self._fntab = {}
+        # The recursive lock is needed for callbacks that re-enter
+        # the Python interpreter.
         self._lock = threading.RLock()
 
     def __getattr__(self, name):
         try:
             return self._fntab[name]
         except KeyError:
+            # Lazily wraps new functions as they are requested
             cfn = getattr(self._lib, name)
             wrapped = _lib_fn_wrapper(self._lock, cfn)
             self._fntab[name] = wrapped
             return wrapped
 
+    @property
+    def _name(self):
+        """The name of the library passed in the CDLL constructor.
+
+        For duck-typing a ctypes.CDLL
+        """
+        return self._lib._name
+
+    @property
+    def _handle(self):
+        """The system handle used to access the library.
+
+        For duck-typing a ctypes.CDLL
+        """
+        return self._lib._handle
+
 
 class _lib_fn_wrapper(object):
+    """Wraps and duck-type a ctypes.CFUNCTYPE to provide
+    automatic locking when the wrapped function is called.
+
+    TODO: we can add methods to mark the function as threadsafe
+          and remove the locking-step on call when marked.
+    """
     __slots__ = ['_lock', '_cfn']
 
     def __init__(self, lock, cfn):
         self._lock = lock
         self._cfn = cfn
 
-    def __setattr__(self, name, value):
-        if name in ['argtypes', 'restype']:
-            return setattr(self._cfn, name, value)
-        else:
-            return object.__setattr__(self, name, value)
+    @property
+    def argtypes(self):
+        return self._cfn.argtypes
+
+    @argtypes.setter
+    def argtypes(self, argtypes):
+        self._cfn.argtypes = argtypes
+
+    @property
+    def restype(self):
+        return self._cfn.restype
+
+    @restype.setter
+    def restype(self, restype):
+        self._cfn.restype = restype
 
     def __call__(self, *args, **kwargs):
         with self._lock:


### PR DESCRIPTION
~~~(don't merge this until 0.21.0 is released.)~~~

Various race-condition issues had been revealed in the numba testsuite and hacks were made to temporarily workaround the issues.  This patch provides a proper solution to the threadsafety problem by employing a lock on all LLVM C-API calls.  

LLVM uses a LLVMContext to store shared data.  By isolating LLVMContext and disallowing sharing of LLVMContext among threads, threadsafety issues could be avoided.  However, the current llvmlite API does not expose LLVMContext creation and the APIs assume a single global context.  So, we must ensure that the LLVM APIs will not be concurrently used.  By using a global lock for all LLVM API, it can keep the llvmlite API simple and safe.  Later when we discover certain LLVM APIs to be threadsafe, we can disable the lock on them individually.
  