### PR TITLE
Enable Intel SVML-enabled auto-vectorization for all the transcendentals

### DIFF
--- a/conda-recipes/intel-svml.patch
+++ b/conda-recipes/intel-svml.patch
@@ -1,0 +1,807 @@
+diff --git a/include/llvm/Analysis/TargetLibraryInfo.h b/include/llvm/Analysis/TargetLibraryInfo.h
+index d75e783..ad9ed7e 100644
+--- a/include/llvm/Analysis/TargetLibraryInfo.h
++++ b/include/llvm/Analysis/TargetLibraryInfo.h
+@@ -38,6 +38,12 @@ struct VecDesc {
+     NumLibFuncs
+   };
+ 
++enum SVMLAccuracy {
++  SVML_DEFAULT,
++  SVML_HA,
++  SVML_EP
++};
++
+ /// Implementation of the target library information.
+ ///
+ /// This class constructs tables that hold the target library information and
+@@ -150,7 +156,8 @@ public:
+   /// Return true if the function F has a vector equivalent with vectorization
+   /// factor VF.
+   bool isFunctionVectorizable(StringRef F, unsigned VF) const {
+-    return !getVectorizedFunction(F, VF).empty();
++     bool IgnoreMeThere;
++     return !getVectorizedFunction(F, VF, IgnoreMeThere, false).empty();
+   }
+ 
+   /// Return true if the function F has a vector equivalent with any
+@@ -159,7 +166,8 @@ public:
+ 
+   /// Return the name of the equivalent of F, vectorized with factor VF. If no
+   /// such mapping exists, return the empty string.
+-  StringRef getVectorizedFunction(StringRef F, unsigned VF) const;
++  std::string getVectorizedFunction(StringRef F, unsigned VF, bool &FromSVML,
++                                    bool IsFast) const;
+ 
+   /// Return true if the function F has a scalar equivalent, and set VF to be
+   /// the vectorization factor.
+@@ -257,8 +265,9 @@ public:
+   bool isFunctionVectorizable(StringRef F) const {
+     return Impl->isFunctionVectorizable(F);
+   }
+-  StringRef getVectorizedFunction(StringRef F, unsigned VF) const {
+-    return Impl->getVectorizedFunction(F, VF);
++  std::string getVectorizedFunction(StringRef F, unsigned VF, bool &FromSVML,
++                                    bool IsFast) const {
++    return Impl->getVectorizedFunction(F, VF, FromSVML, IsFast);
+   }
+ 
+   /// Tests if the function is both available and a candidate for optimized code
+diff --git a/include/llvm/IR/CMakeLists.txt b/include/llvm/IR/CMakeLists.txt
+index cf75d58..374fd65 100644
+--- a/include/llvm/IR/CMakeLists.txt
++++ b/include/llvm/IR/CMakeLists.txt
+@@ -4,3 +4,7 @@ tablegen(LLVM Attributes.gen -gen-attrs)
+ set(LLVM_TARGET_DEFINITIONS Intrinsics.td)
+ tablegen(LLVM Intrinsics.gen -gen-intrinsic)
+ add_public_tablegen_target(intrinsics_gen)
++
++set(LLVM_TARGET_DEFINITIONS SVML.td)
++tablegen(LLVM SVML.gen -gen-svml)
++add_public_tablegen_target(svml_gen)
+diff --git a/include/llvm/IR/CallingConv.h b/include/llvm/IR/CallingConv.h
+index 850964a..e384aba 100644
+--- a/include/llvm/IR/CallingConv.h
++++ b/include/llvm/IR/CallingConv.h
+@@ -209,6 +209,18 @@ namespace CallingConv {
+     /// which have an "optimized" convention using additional registers.
+     MSP430_BUILTIN = 94,
+ 
++    /// Calling convention used for AMDPAL vertex shader if tessellation is in
++    /// use.
++    AMDGPU_LS = 95,
++
++    /// Calling convention used for AMDPAL shader stage before geometry shader
++    /// if geometry is in use. So either the domain (= tessellation evaluation)
++    /// shader if tessellation is in use, or otherwise the vertex shader.
++    AMDGPU_ES = 96,
++
++    /// Intel_SVML - Calling conventions for Intel Short Math Vector Library
++    Intel_SVML = 97,
++    //
+     /// The highest possible calling convention ID. Must be some 2^k - 1.
+     MaxID = 1023
+   };
+diff --git a/include/llvm/IR/SVML.td b/include/llvm/IR/SVML.td
+new file mode 100644
+index 0000000..f68c086
+--- /dev/null
++++ b/include/llvm/IR/SVML.td
+@@ -0,0 +1,58 @@
++//===-- Intel_SVML.td - Defines SVML call variants ---------*- tablegen -*-===//
++//
++//                     The LLVM Compiler Infrastructure
++//
++// This file is distributed under the University of Illinois Open Source
++// License. See LICENSE.TXT for details.
++//
++//===----------------------------------------------------------------------===//
++//
++// This file is used by TableGen to define the different typs of SVML function
++// variants used with -fveclib=SVML.
++//
++//===----------------------------------------------------------------------===//
++
++class SvmlVariant;
++
++def sin        : SvmlVariant;
++def cos        : SvmlVariant;
++def pow        : SvmlVariant;
++def exp        : SvmlVariant;
++def log        : SvmlVariant;
++def acos       : SvmlVariant;
++def acosh      : SvmlVariant;
++def asin       : SvmlVariant;
++def asinh      : SvmlVariant;
++def atan2      : SvmlVariant;
++def atan       : SvmlVariant;
++def atanh      : SvmlVariant;
++def cbrt       : SvmlVariant;
++def cdfnorm    : SvmlVariant;
++def cdfnorminv : SvmlVariant;
++def ceil       : SvmlVariant;
++def cosd       : SvmlVariant;
++def cosh       : SvmlVariant;
++def erf        : SvmlVariant;
++def erfc       : SvmlVariant;
++def erfcinv    : SvmlVariant;
++def erfinv     : SvmlVariant;
++def exp10      : SvmlVariant;
++def exp2       : SvmlVariant;
++def expm1      : SvmlVariant;
++def floor      : SvmlVariant;
++def fmod       : SvmlVariant;
++def hypot      : SvmlVariant;
++def invsqrt    : SvmlVariant;
++def log10      : SvmlVariant;
++def log1p      : SvmlVariant;
++def log2       : SvmlVariant;
++def logb       : SvmlVariant;
++def nearbyint  : SvmlVariant;
++def rint       : SvmlVariant;
++def round      : SvmlVariant;
++def sind       : SvmlVariant;
++def sinh       : SvmlVariant;
++def sqrt       : SvmlVariant;
++def tan        : SvmlVariant;
++def tanh       : SvmlVariant;
++def trunc      : SvmlVariant;
+diff --git a/lib/Analysis/CMakeLists.txt b/lib/Analysis/CMakeLists.txt
+index 161709a..af17b45 100644
+--- a/lib/Analysis/CMakeLists.txt
++++ b/lib/Analysis/CMakeLists.txt
+@@ -88,4 +88,5 @@ add_llvm_library(LLVMAnalysis
+ 
+   DEPENDS
+   intrinsics_gen
++  svml_gen
+   )
+diff --git a/lib/Analysis/TargetLibraryInfo.cpp b/lib/Analysis/TargetLibraryInfo.cpp
+index 2be5d5c..a1590dc 100644
+--- a/lib/Analysis/TargetLibraryInfo.cpp
++++ b/lib/Analysis/TargetLibraryInfo.cpp
+@@ -50,6 +50,11 @@ static bool hasSinCosPiStret(const Triple &T) {
+   return true;
+ }
+ 
++std::string svmlMangle(StringRef FnName, const bool IsFast) { 
++  std::string FullName = FnName;
++  return IsFast ? FullName : FullName + "_ha";
++}
++
+ /// initialize - Initialize the set of available library functions based on the
+ /// specified target triple.  This should be carefully written so that a missing
+ /// target triple gets a sane set of defaults.
+@@ -1357,93 +1362,9 @@ void TargetLibraryInfoImpl::addVectorizableFunctionsFromVecLib(
+   }
+   case SVML: {
+     const VecDesc VecFuncs[] = {
+-        {"sin", "__svml_sin2", 2},
+-        {"sin", "__svml_sin4", 4},
+-        {"sin", "__svml_sin8", 8},
+-
+-        {"sinf", "__svml_sinf4", 4},
+-        {"sinf", "__svml_sinf8", 8},
+-        {"sinf", "__svml_sinf16", 16},
+-
+-        {"cos", "__svml_cos2", 2},
+-        {"cos", "__svml_cos4", 4},
+-        {"cos", "__svml_cos8", 8},
+-
+-        {"cosf", "__svml_cosf4", 4},
+-        {"cosf", "__svml_cosf8", 8},
+-        {"cosf", "__svml_cosf16", 16},
+-
+-        {"pow", "__svml_pow2", 2},
+-        {"pow", "__svml_pow4", 4},
+-        {"pow", "__svml_pow8", 8},
+-
+-        {"powf", "__svml_powf4", 4},
+-        {"powf", "__svml_powf8", 8},
+-        {"powf", "__svml_powf16", 16},
+-
+-        { "__pow_finite", "__svml_pow2", 2 },
+-        { "__pow_finite", "__svml_pow4", 4 },
+-        { "__pow_finite", "__svml_pow8", 8 },
+-
+-        { "__powf_finite", "__svml_powf4", 4 },
+-        { "__powf_finite", "__svml_powf8", 8 },
+-        { "__powf_finite", "__svml_powf16", 16 },
+-
+-        {"llvm.pow.f64", "__svml_pow2", 2},
+-        {"llvm.pow.f64", "__svml_pow4", 4},
+-        {"llvm.pow.f64", "__svml_pow8", 8},
+-
+-        {"llvm.pow.f32", "__svml_powf4", 4},
+-        {"llvm.pow.f32", "__svml_powf8", 8},
+-        {"llvm.pow.f32", "__svml_powf16", 16},
+-
+-        {"exp", "__svml_exp2", 2},
+-        {"exp", "__svml_exp4", 4},
+-        {"exp", "__svml_exp8", 8},
+-
+-        {"expf", "__svml_expf4", 4},
+-        {"expf", "__svml_expf8", 8},
+-        {"expf", "__svml_expf16", 16},
+-
+-        { "__exp_finite", "__svml_exp2", 2 },
+-        { "__exp_finite", "__svml_exp4", 4 },
+-        { "__exp_finite", "__svml_exp8", 8 },
+-
+-        { "__expf_finite", "__svml_expf4", 4 },
+-        { "__expf_finite", "__svml_expf8", 8 },
+-        { "__expf_finite", "__svml_expf16", 16 },
+-
+-        {"llvm.exp.f64", "__svml_exp2", 2},
+-        {"llvm.exp.f64", "__svml_exp4", 4},
+-        {"llvm.exp.f64", "__svml_exp8", 8},
+-
+-        {"llvm.exp.f32", "__svml_expf4", 4},
+-        {"llvm.exp.f32", "__svml_expf8", 8},
+-        {"llvm.exp.f32", "__svml_expf16", 16},
+-
+-        {"log", "__svml_log2", 2},
+-        {"log", "__svml_log4", 4},
+-        {"log", "__svml_log8", 8},
+-
+-        {"logf", "__svml_logf4", 4},
+-        {"logf", "__svml_logf8", 8},
+-        {"logf", "__svml_logf16", 16},
+-
+-        { "__log_finite", "__svml_log2", 2 },
+-        { "__log_finite", "__svml_log4", 4 },
+-        { "__log_finite", "__svml_log8", 8 },
+-
+-        { "__logf_finite", "__svml_logf4", 4 },
+-        { "__logf_finite", "__svml_logf8", 8 },
+-        { "__logf_finite", "__svml_logf16", 16 },
+-
+-        {"llvm.log.f64", "__svml_log2", 2},
+-        {"llvm.log.f64", "__svml_log4", 4},
+-        {"llvm.log.f64", "__svml_log8", 8},
+-
+-        {"llvm.log.f32", "__svml_logf4", 4},
+-        {"llvm.log.f32", "__svml_logf8", 8},
+-        {"llvm.log.f32", "__svml_logf16", 16},
++#define GET_SVML_VARIANTS
++#include "llvm/IR/SVML.gen"
++#undef GET_SVML_VARIANTS
+     };
+     addVectorizableFunctions(VecFuncs);
+     break;
+@@ -1464,16 +1385,21 @@ bool TargetLibraryInfoImpl::isFunctionVectorizable(StringRef funcName) const {
+   return I != VectorDescs.end() && StringRef(I->ScalarFnName) == funcName;
+ }
+ 
+-StringRef TargetLibraryInfoImpl::getVectorizedFunction(StringRef F,
+-                                                       unsigned VF) const {
++std::string TargetLibraryInfoImpl::getVectorizedFunction(StringRef F,
++                                                         unsigned VF, bool &FromSVML, bool IsFast) const {
++  FromSVML = ClVectorLibrary == SVML;
+   F = sanitizeFunctionName(F);
+   if (F.empty())
+     return F;
+   std::vector<VecDesc>::const_iterator I = std::lower_bound(
+       VectorDescs.begin(), VectorDescs.end(), F, compareWithScalarFnName);
+   while (I != VectorDescs.end() && StringRef(I->ScalarFnName) == F) {
+-    if (I->VectorizationFactor == VF)
++    if (I->VectorizationFactor == VF) {
++      if (FromSVML) {
++        return svmlMangle(I->VectorFnName, IsFast);
++      }
+       return I->VectorFnName;
++    }
+     ++I;
+   }
+   return StringRef();
+diff --git a/lib/AsmParser/LLLexer.cpp b/lib/AsmParser/LLLexer.cpp
+index 90e0d6a..c45aa52 100644
+--- a/lib/AsmParser/LLLexer.cpp
++++ b/lib/AsmParser/LLLexer.cpp
+@@ -587,6 +587,7 @@ lltok::Kind LLLexer::LexIdentifier() {
+   KEYWORD(spir_kernel);
+   KEYWORD(spir_func);
+   KEYWORD(intel_ocl_bicc);
++  KEYWORD(intel_svmlcc);
+   KEYWORD(x86_64_sysvcc);
+   KEYWORD(win64cc);
+   KEYWORD(x86_regcallcc);
+diff --git a/lib/AsmParser/LLParser.cpp b/lib/AsmParser/LLParser.cpp
+index 13679ce..85f5a8a 100644
+--- a/lib/AsmParser/LLParser.cpp
++++ b/lib/AsmParser/LLParser.cpp
+@@ -1654,6 +1654,7 @@ void LLParser::ParseOptionalDLLStorageClass(unsigned &Res) {
+ ///   ::= 'ccc'
+ ///   ::= 'fastcc'
+ ///   ::= 'intel_ocl_bicc'
++///   ::= 'intel_svmlcc'
+ ///   ::= 'coldcc'
+ ///   ::= 'x86_stdcallcc'
+ ///   ::= 'x86_fastcallcc'
+@@ -1711,6 +1712,7 @@ bool LLParser::ParseOptionalCallingConv(unsigned &CC) {
+   case lltok::kw_spir_kernel:    CC = CallingConv::SPIR_KERNEL; break;
+   case lltok::kw_spir_func:      CC = CallingConv::SPIR_FUNC; break;
+   case lltok::kw_intel_ocl_bicc: CC = CallingConv::Intel_OCL_BI; break;
++  case lltok::kw_intel_svmlcc:   CC = CallingConv::Intel_SVML; break;
+   case lltok::kw_x86_64_sysvcc:  CC = CallingConv::X86_64_SysV; break;
+   case lltok::kw_win64cc:        CC = CallingConv::Win64; break;
+   case lltok::kw_webkit_jscc:    CC = CallingConv::WebKit_JS; break;
+diff --git a/lib/AsmParser/LLToken.h b/lib/AsmParser/LLToken.h
+index 0f3707b..19f2532 100644
+--- a/lib/AsmParser/LLToken.h
++++ b/lib/AsmParser/LLToken.h
+@@ -125,6 +125,7 @@ enum Kind {
+   kw_fastcc,
+   kw_coldcc,
+   kw_intel_ocl_bicc,
++  kw_intel_svmlcc,
+   kw_x86_stdcallcc,
+   kw_x86_fastcallcc,
+   kw_x86_thiscallcc,
+diff --git a/lib/IR/AsmWriter.cpp b/lib/IR/AsmWriter.cpp
+index 170bc54..35179cb 100644
+--- a/lib/IR/AsmWriter.cpp
++++ b/lib/IR/AsmWriter.cpp
+@@ -356,6 +356,7 @@ static void PrintCallingConv(unsigned cc, raw_ostream &Out) {
+   case CallingConv::X86_RegCall:   Out << "x86_regcallcc"; break;
+   case CallingConv::X86_VectorCall:Out << "x86_vectorcallcc"; break;
+   case CallingConv::Intel_OCL_BI:  Out << "intel_ocl_bicc"; break;
++  case CallingConv::Intel_SVML:    Out << "intel_svmlcc"; break;
+   case CallingConv::ARM_APCS:      Out << "arm_apcscc"; break;
+   case CallingConv::ARM_AAPCS:     Out << "arm_aapcscc"; break;
+   case CallingConv::ARM_AAPCS_VFP: Out << "arm_aapcs_vfpcc"; break;
+diff --git a/lib/IR/Verifier.cpp b/lib/IR/Verifier.cpp
+index 454a56a..fc11f5e 100644
+--- a/lib/IR/Verifier.cpp
++++ b/lib/IR/Verifier.cpp
+@@ -2010,6 +2010,7 @@ void Verifier::visitFunction(const Function &F) {
+   case CallingConv::Fast:
+   case CallingConv::Cold:
+   case CallingConv::Intel_OCL_BI:
++  case CallingConv::Intel_SVML:
+   case CallingConv::PTX_Kernel:
+   case CallingConv::PTX_Device:
+     Assert(!F.isVarArg(), "Calling convention does not support varargs or "
+diff --git a/lib/Target/X86/X86CallingConv.td b/lib/Target/X86/X86CallingConv.td
+index 2646198..06b8cc7 100644
+--- a/lib/Target/X86/X86CallingConv.td
++++ b/lib/Target/X86/X86CallingConv.td
+@@ -469,12 +469,29 @@ def RetCC_X86_64 : CallingConv<[
+   CCDelegateTo<RetCC_X86_64_C>
+ ]>;
+ 
++// Intel_SVML return-value convention.
++def RetCC_Intel_SVML : CallingConv<[
++  // Vector types are returned in XMM0,XMM1
++  CCIfType<[v4f32, v2f64],
++            CCAssignToReg<[XMM0,XMM1]>>,
++
++  // 256-bit FP vectors
++  CCIfType<[v8f32, v4f64],
++            CCAssignToReg<[YMM0,YMM1]>>,
++
++  // 512-bit FP vectors
++  CCIfType<[v16f32, v8f64],
++            CCAssignToReg<[ZMM0,ZMM1]>>
++]>;
++
+ // This is the return-value convention used for the entire X86 backend.
+ def RetCC_X86 : CallingConv<[
+ 
+   // Check if this is the Intel OpenCL built-ins calling convention
+   CCIfCC<"CallingConv::Intel_OCL_BI", CCDelegateTo<RetCC_Intel_OCL_BI>>,
+ 
++  CCIfCC<"CallingConv::Intel_SVML", CCDelegateTo<RetCC_Intel_SVML>>,
++
+   CCIfSubtarget<"is64Bit()", CCDelegateTo<RetCC_X86_64>>,
+   CCDelegateTo<RetCC_X86_32>
+ ]>;
+@@ -968,6 +985,22 @@ def CC_Intel_OCL_BI : CallingConv<[
+   CCDelegateTo<CC_X86_32_C>
+ ]>;
+ 
++// X86-64 Intel Short Vector Math Library calling convention.
++def CC_Intel_SVML : CallingConv<[
++
++  // The SSE vector arguments are passed in XMM registers.
++  CCIfType<[v4f32, v2f64],
++           CCAssignToReg<[XMM0, XMM1, XMM2]>>,
++
++  // The 256-bit vector arguments are passed in YMM registers.
++  CCIfType<[v8f32, v4f64],
++           CCAssignToReg<[YMM0, YMM1, YMM2]>>,
++
++  // The 512-bit vector arguments are passed in ZMM registers.
++  CCIfType<[v16f32, v8f64],
++           CCAssignToReg<[ZMM0, ZMM1, ZMM2]>>
++]>;
++
+ def CC_X86_32_Intr : CallingConv<[
+   CCAssignToStack<4, 4>
+ ]>;
+@@ -1024,6 +1057,7 @@ def CC_X86_64 : CallingConv<[
+ // This is the argument convention used for the entire X86 backend.
+ def CC_X86 : CallingConv<[
+   CCIfCC<"CallingConv::Intel_OCL_BI", CCDelegateTo<CC_Intel_OCL_BI>>,
++  CCIfCC<"CallingConv::Intel_SVML", CCDelegateTo<CC_Intel_SVML>>,
+   CCIfSubtarget<"is64Bit()", CCDelegateTo<CC_X86_64>>,
+   CCDelegateTo<CC_X86_32>
+ ]>;
+@@ -1130,4 +1164,27 @@ def CSR_SysV64_RegCall_NoSSE : CalleeSavedRegs<(add RBX, RBP, RSP,
+                                                (sequence "R%u", 12, 15))>;
+ def CSR_SysV64_RegCall       : CalleeSavedRegs<(add CSR_SysV64_RegCall_NoSSE,               
+                                                (sequence "XMM%u", 8, 15))>;
+-                                               
++
++// SVML calling convention 
++def CSR_32_Intel_SVML        : CalleeSavedRegs<(add CSR_32_RegCall_NoSSE)>;
++def CSR_32_Intel_SVML_AVX512 : CalleeSavedRegs<(add CSR_32_Intel_SVML,
++                                                K4, K5, K6, K7)>;
++
++def CSR_64_Intel_SVML_NoSSE : CalleeSavedRegs<(add RBX, RSI, RDI, RBP, RSP, R12, R13, R14, R15)>;
++
++def CSR_64_Intel_SVML       : CalleeSavedRegs<(add CSR_64_Intel_SVML_NoSSE,
++                                               (sequence "XMM%u", 8, 15))>;
++def CSR_Win64_Intel_SVML    : CalleeSavedRegs<(add CSR_64_Intel_SVML_NoSSE,
++                                               (sequence "XMM%u", 6, 15))>;
++
++def CSR_64_Intel_SVML_AVX        : CalleeSavedRegs<(add CSR_64_Intel_SVML_NoSSE,
++                                                    (sequence "YMM%u", 8, 15))>;
++def CSR_Win64_Intel_SVML_AVX     : CalleeSavedRegs<(add CSR_64_Intel_SVML_NoSSE,
++                                                    (sequence "YMM%u", 6, 15))>;
++
++def CSR_64_Intel_SVML_AVX512     : CalleeSavedRegs<(add CSR_64_Intel_SVML_NoSSE,
++                                                    (sequence "ZMM%u", 16, 31),
++                                                    K4, K5, K6, K7)>;
++def CSR_Win64_Intel_SVML_AVX512  : CalleeSavedRegs<(add CSR_64_Intel_SVML_NoSSE,
++                                                    (sequence "ZMM%u", 6, 21),
++                                                    K4, K5, K6, K7)>;
+diff --git a/lib/Target/X86/X86ISelLowering.cpp b/lib/Target/X86/X86ISelLowering.cpp
+index 607bc45..2ec2497 100644
+--- a/lib/Target/X86/X86ISelLowering.cpp
++++ b/lib/Target/X86/X86ISelLowering.cpp
+@@ -3168,7 +3168,8 @@ SDValue X86TargetLowering::LowerFormalArguments(
+     // FIXME: Only some x86_32 calling conventions support AVX512.
+     if (Subtarget.hasAVX512() &&
+         (Is64Bit || (CallConv == CallingConv::X86_VectorCall ||
+-                     CallConv == CallingConv::Intel_OCL_BI)))
++                     CallConv == CallingConv::Intel_OCL_BI   ||
++                     CallConv == CallingConv::Intel_SVML)))
+       VecVT = MVT::v16f32;
+     else if (Subtarget.hasAVX())
+       VecVT = MVT::v8f32;
+diff --git a/lib/Target/X86/X86RegisterInfo.cpp b/lib/Target/X86/X86RegisterInfo.cpp
+index 343da25..ebeb059 100644
+--- a/lib/Target/X86/X86RegisterInfo.cpp
++++ b/lib/Target/X86/X86RegisterInfo.cpp
+@@ -315,6 +315,23 @@ X86RegisterInfo::getCalleeSavedRegs(const MachineFunction *MF) const {
+       return CSR_64_Intel_OCL_BI_SaveList;
+     break;
+   }
++  case CallingConv::Intel_SVML: {
++    if (Is64Bit) {
++      if (HasAVX512)
++        return IsWin64 ? CSR_Win64_Intel_SVML_AVX512_SaveList :
++                         CSR_64_Intel_SVML_AVX512_SaveList;
++      if (HasAVX)
++        return IsWin64 ? CSR_Win64_Intel_SVML_AVX_SaveList :
++                         CSR_64_Intel_SVML_AVX_SaveList;
++
++      return IsWin64 ? CSR_Win64_Intel_SVML_SaveList :
++                       CSR_64_Intel_SVML_SaveList;
++    } else { // Is32Bit
++        if (HasAVX512)
++            return CSR_32_Intel_SVML_AVX512_SaveList;
++        return CSR_32_Intel_SVML_SaveList;
++    }
++  }
+   case CallingConv::HHVM:
+     return CSR_64_HHVM_SaveList;
+   case CallingConv::X86_RegCall:
+@@ -431,6 +448,23 @@ X86RegisterInfo::getCallPreservedMask(const MachineFunction &MF,
+       return CSR_64_Intel_OCL_BI_RegMask;
+     break;
+   }
++  case CallingConv::Intel_SVML: {
++    if (Is64Bit) {
++      if (HasAVX512)
++        return IsWin64 ? CSR_Win64_Intel_SVML_AVX512_RegMask :
++                         CSR_64_Intel_SVML_AVX512_RegMask;
++      if (HasAVX)
++        return IsWin64 ? CSR_Win64_Intel_SVML_AVX_RegMask :
++                         CSR_64_Intel_SVML_AVX_RegMask;
++
++      return IsWin64 ? CSR_Win64_Intel_SVML_RegMask :
++                       CSR_64_Intel_SVML_RegMask;
++    } else { // Is32Bit
++        if (HasAVX512)
++            return CSR_32_Intel_SVML_AVX512_RegMask;
++        return CSR_32_Intel_SVML_RegMask;
++    }
++  }
+   case CallingConv::HHVM:
+     return CSR_64_HHVM_RegMask;
+   case CallingConv::X86_RegCall:
+diff --git a/lib/Target/X86/X86Subtarget.h b/lib/Target/X86/X86Subtarget.h
+index 427a000..e4db138 100644
+--- a/lib/Target/X86/X86Subtarget.h
++++ b/lib/Target/X86/X86Subtarget.h
+@@ -595,6 +595,7 @@ public:
+     case CallingConv::X86_ThisCall:
+     case CallingConv::X86_VectorCall:
+     case CallingConv::Intel_OCL_BI:
++    case CallingConv::Intel_SVML:
+       return isTargetWin64();
+     // This convention allows using the Win64 convention on other targets.
+     case CallingConv::Win64:
+diff --git a/lib/Transforms/Vectorize/LoopVectorize.cpp b/lib/Transforms/Vectorize/LoopVectorize.cpp
+index 012b10c..1b6ecef 100644
+--- a/lib/Transforms/Vectorize/LoopVectorize.cpp
++++ b/lib/Transforms/Vectorize/LoopVectorize.cpp
+@@ -4962,6 +4962,7 @@ void InnerLoopVectorizer::vectorizeInstruction(Instruction &I) {
+       }
+ 
+       Function *VectorF;
++      bool FromSVML = false;
+       if (UseVectorIntrinsic) {
+         // Use vector version of the intrinsic.
+         Type *TysForDecl[] = {CI->getType()};
+@@ -4970,7 +4971,10 @@ void InnerLoopVectorizer::vectorizeInstruction(Instruction &I) {
+         VectorF = Intrinsic::getDeclaration(M, ID, TysForDecl);
+       } else {
+         // Use vector version of the library call.
+-        StringRef VFnName = TLI->getVectorizedFunction(FnName, VF);
++        // TEMPORARY. For backporting (down to release 5.0.0) purposes let's use any() from FastMathFlags instead of 
++        // still absent isFast(). It isn't equivalent for full mask but I think it's enough there
++        bool IsFast = CI->getFastMathFlags().any();
++        std::string VFnName = TLI->getVectorizedFunction(FnName, VF, FromSVML, IsFast);
+         assert(!VFnName.empty() && "Vector function name is empty.");
+         VectorF = M->getFunction(VFnName);
+         if (!VectorF) {
+@@ -4989,7 +4993,7 @@ void InnerLoopVectorizer::vectorizeInstruction(Instruction &I) {
+ 
+       if (isa<FPMathOperator>(V))
+         V->copyFastMathFlags(CI);
+-
++      if (FromSVML) V->setCallingConv(CallingConv::Intel_SVML);
+       VectorLoopValueMap.setVectorValue(&I, Part, V);
+       addMetadata(V, &I);
+     }
+diff --git a/test/Transforms/LoopVectorize/X86/svml-calls.ll b/test/Transforms/LoopVectorize/X86/svml-calls.ll
+index 6342a9d..39797c6 100644
+--- a/test/Transforms/LoopVectorize/X86/svml-calls.ll
++++ b/test/Transforms/LoopVectorize/X86/svml-calls.ll
+@@ -182,4 +182,44 @@ for.end:                                          ; preds = %for.body
+   ret void
+ }
+ 
++; CHECK-LABEL: @atan2_finite
++; CHECK: <8 x double> @__svml_atan28
++; CHECK: ret
++
++declare double @__atan2_finite(double, double) local_unnamed_addr #0
++
++define void @atan2_finite([100 x double]* nocapture %varray) local_unnamed_addr #0 {
++entry:
++  br label %for.cond1.preheader
++
++for.cond1.preheader:                              ; preds = %for.inc7, %entry
++  %indvars.iv19 = phi i64 [ 0, %entry ], [ %indvars.iv.next20, %for.inc7 ]
++  %0 = trunc i64 %indvars.iv19 to i32
++  %conv = sitofp i32 %0 to double
++  br label %for.body3
++
++for.body3:                                        ; preds = %for.body3, %for.cond1.preheader
++  %indvars.iv = phi i64 [ 0, %for.cond1.preheader ], [ %indvars.iv.next, %for.body3 ]
++  %indvars.iv.next = add nuw nsw i64 %indvars.iv, 1
++  %1 = trunc i64 %indvars.iv.next to i32
++  %conv4 = sitofp i32 %1 to double
++  %call = tail call fast double @__atan2_finite(double %conv, double %conv4)
++  %arrayidx6 = getelementptr inbounds [100 x double], [100 x double]* %varray, i64 %indvars.iv19, i64 %indvars.iv
++  store double %call, double* %arrayidx6, align 8
++  %exitcond = icmp eq i64 %indvars.iv.next, 100
++  br i1 %exitcond, label %for.inc7, label %for.body3, !llvm.loop !5
++
++for.inc7:                                         ; preds = %for.body3
++  %indvars.iv.next20 = add nuw nsw i64 %indvars.iv19, 1
++  %exitcond21 = icmp eq i64 %indvars.iv.next20, 100
++  br i1 %exitcond21, label %for.end9, label %for.cond1.preheader
++
++for.end9:                                         ; preds = %for.inc7
++  ret void
++}
++
+ attributes #0 = { nounwind readnone }
++
++!5 = distinct !{!5, !6, !7}
++!6 = !{!"llvm.loop.vectorize.width", i32 8}
++!7 = !{!"llvm.loop.vectorize.enable", i1 true}
+diff --git a/utils/TableGen/CMakeLists.txt b/utils/TableGen/CMakeLists.txt
+index b2913af..31602d0 100644
+--- a/utils/TableGen/CMakeLists.txt
++++ b/utils/TableGen/CMakeLists.txt
+@@ -32,6 +32,7 @@ add_tablegen(llvm-tblgen LLVM
+   SearchableTableEmitter.cpp
+   SubtargetEmitter.cpp
+   SubtargetFeatureInfo.cpp
++  SVMLEmitter.cpp
+   TableGen.cpp
+   Types.cpp
+   X86DisassemblerTables.cpp
+diff --git a/utils/TableGen/SVMLEmitter.cpp b/utils/TableGen/SVMLEmitter.cpp
+new file mode 100644
+index 0000000..c80f055
+--- /dev/null
++++ b/utils/TableGen/SVMLEmitter.cpp
+@@ -0,0 +1,114 @@
++//===------ SVMLEmitter.cpp - Generate SVML function variants -------------===//
++//
++//                     The LLVM Compiler Infrastructure
++//
++// This file is distributed under the University of Illinois Open Source
++// License. See LICENSE.TXT for details.
++//
++//===----------------------------------------------------------------------===//
++//
++// This tablegen backend emits the scalar to svml function map for TLI.
++//
++//===----------------------------------------------------------------------===//
++
++#include "CodeGenTarget.h"
++#include "llvm/Support/Format.h"
++#include "llvm/TableGen/Error.h"
++#include "llvm/TableGen/Record.h"
++#include "llvm/TableGen/TableGenBackend.h"
++#include <map>
++#include <vector>
++
++using namespace llvm;
++
++#define DEBUG_TYPE "SVMLVariants"
++#include "llvm/Support/Debug.h"
++
++namespace {
++
++class SVMLVariantsEmitter {
++
++  RecordKeeper &Records;
++
++private:
++  void emitSVMLVariants(raw_ostream &OS);
++
++public:
++  SVMLVariantsEmitter(RecordKeeper &R) : Records(R) {}
++
++  void run(raw_ostream &OS);
++};
++} // End anonymous namespace
++
++/// \brief Emit the set of SVML variant function names.
++// The default is to emit the high accuracy SVML variants until a mechanism is
++// introduced to allow a selection of different variants through precision
++// requirements specified by the user. This code generates mappings to svml
++// that are in the scalar form of llvm intrinsics, math library calls, or the
++// finite variants of math library calls.
++void SVMLVariantsEmitter::emitSVMLVariants(raw_ostream &OS) {
++
++  unsigned MinSinglePrecVL = 4;
++  unsigned MaxSinglePrecVL = 16;
++  unsigned MinDoublePrecVL = 2;
++  unsigned MaxDoublePrecVL = 8;
++
++  Record *SvmlVariantsClass = Records.getClass("SvmlVariant");
++  assert(SvmlVariantsClass &&
++         "SvmlVariant class not found in target description file!");
++
++  OS << "#ifdef GET_SVML_VARIANTS\n";
++
++  for (const auto &D : Records.getDefs()) {
++    std::string SvmlVariantNameStr = D.first;
++    // Single Precision SVML
++    for (unsigned VL = MinSinglePrecVL; VL <= MaxSinglePrecVL; VL *= 2) {
++      // Emit the scalar math library function to svml function entry.
++      OS << "{\"" << SvmlVariantNameStr << "f" << "\", ";
++      OS << "\"" << "__svml_" << SvmlVariantNameStr << "f" << VL << "\", "
++         << VL << "},\n";
++
++      // Emit the scalar intrinsic to svml function entry.
++      OS << "{\"" << "llvm." << SvmlVariantNameStr << ".f32" << "\", ";
++      OS << "\"" << "__svml_" << SvmlVariantNameStr << "f" << VL << "\", "
++         << VL << "},\n";
++
++      // Emit the finite math library function to svml function entry.
++      OS << "{\"__" << SvmlVariantNameStr << "f_finite" << "\", ";
++      OS << "\"" << "__svml_" << SvmlVariantNameStr << "f" << VL << "\", "
++         << VL << "},\n";
++    }
++
++    // Double Precision SVML
++    for (unsigned VL = MinDoublePrecVL; VL <= MaxDoublePrecVL; VL *= 2) {
++      // Emit the scalar math library function to svml function entry.
++      OS << "{\"" << SvmlVariantNameStr << "\", ";
++      OS << "\"" << "__svml_" << SvmlVariantNameStr << VL << "\", " << VL
++         << "},\n";
++
++      // Emit the scalar intrinsic to svml function entry.
++      OS << "{\"" << "llvm." << SvmlVariantNameStr << ".f64" << "\", ";
++      OS << "\"" << "__svml_" << SvmlVariantNameStr << VL << "\", " << VL
++         << "},\n";
++
++      // Emit the finite math library function to svml function entry.
++      OS << "{\"__" << SvmlVariantNameStr << "_finite" << "\", ";
++      OS << "\"" << "__svml_" << SvmlVariantNameStr << VL << "\", "
++         << VL << "},\n";
++    }
++  }
++
++  OS << "#endif // GET_SVML_VARIANTS\n\n";
++}
++
++void SVMLVariantsEmitter::run(raw_ostream &OS) {
++  emitSVMLVariants(OS);
++}
++
++namespace llvm {
++
++void EmitSVMLVariants(RecordKeeper &RK, raw_ostream &OS) {
++  SVMLVariantsEmitter(RK).run(OS);
++}
++
++} // End llvm namespace
+diff --git a/utils/TableGen/TableGen.cpp b/utils/TableGen/TableGen.cpp
+index 00d20f1..cb35a49 100644
+--- a/utils/TableGen/TableGen.cpp
++++ b/utils/TableGen/TableGen.cpp
+@@ -48,6 +48,7 @@ enum ActionType {
+   GenGlobalISel,
+   GenX86EVEX2VEXTables,
+   GenRegisterBank,
++  GenSVMLVariants,
+ };
+ 
+ namespace {
+@@ -100,7 +101,9 @@ namespace {
+                     clEnumValN(GenX86EVEX2VEXTables, "gen-x86-EVEX2VEX-tables",
+                                "Generate X86 EVEX to VEX compress tables"),
+                     clEnumValN(GenRegisterBank, "gen-register-bank",
+-                               "Generate registers bank descriptions")));
++                               "Generate registers bank descriptions"),
++                    clEnumValN(GenSVMLVariants, "gen-svml",
++                               "Generate SVML variant function names")));
+ 
+   cl::OptionCategory PrintEnumsCat("Options for -print-enums");
+   cl::opt<std::string>
+@@ -196,6 +199,9 @@ bool LLVMTableGenMain(raw_ostream &OS, RecordKeeper &Records) {
+   case GenX86EVEX2VEXTables:
+     EmitX86EVEX2VEXTables(Records, OS);
+     break;
++  case GenSVMLVariants:
++    EmitSVMLVariants(Records, OS);
++    break;
+   }
+ 
+   return false;
+diff --git a/utils/TableGen/TableGenBackends.h b/utils/TableGen/TableGenBackends.h
+index 2512997..c70ae68 100644
+--- a/utils/TableGen/TableGenBackends.h
++++ b/utils/TableGen/TableGenBackends.h
+@@ -83,6 +83,7 @@ void EmitSearchableTables(RecordKeeper &RK, raw_ostream &OS);
+ void EmitGlobalISel(RecordKeeper &RK, raw_ostream &OS);
+ void EmitX86EVEX2VEXTables(RecordKeeper &RK, raw_ostream &OS);
+ void EmitRegisterBank(RecordKeeper &RK, raw_ostream &OS);
++void EmitSVMLVariants(RecordKeeper &RK, raw_ostream &OS);
+ 
+ } // End llvm namespace
+ 
+diff --git a/utils/vim/syntax/llvm.vim b/utils/vim/syntax/llvm.vim
+index d047578..7bf92b1 100644
+--- a/utils/vim/syntax/llvm.vim
++++ b/utils/vim/syntax/llvm.vim
+@@ -92,6 +92,7 @@ syn keyword llvmKeyword
+       \ inreg
+       \ inteldialect
+       \ intel_ocl_bicc
++      \ intel_svmlcc
+       \ internal
+       \ linkonce
+       \ linkonce_odr

--- a/conda-recipes/llvmdev/meta.yaml
+++ b/conda-recipes/llvmdev/meta.yaml
@@ -16,6 +16,8 @@ source:
     - ../llvm-elf-relocation.patch
     # http://lists.llvm.org/pipermail/llvm-dev/2016-January/094520.html
     - ../llvm-lto-static.patch   # [win]
+    # Intel SVML optimizations
+    - ../intel-svml.patch
 
 
 build:

--- a/conda-recipes/llvmdev_manylinux1/meta.yaml
+++ b/conda-recipes/llvmdev_manylinux1/meta.yaml
@@ -15,6 +15,8 @@ source:
     - ../llvm-elf-relocation.patch
     # http://lists.llvm.org/pipermail/llvm-dev/2016-January/094520.html
     - ../llvm-lto-static.patch   # [win]
+    # Intel SVML optimizations
+    - ../intel-svml.patch
 
 build:
   number: 0


### PR DESCRIPTION
This patch allows to enable SVML in LLVM correctly on all the platforms and provides a way to choose faster functions by loosing some accuracy via fastmath=True argument in Numba

Credit to @dvnagorny for the LLVM patch