### PR TITLE
Build C files separately on Linux and support parallel make

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 *.pyc
 *.pyd
+*.o
 *.so
 *.dylib
 *.dll

--- a/ffi/Makefile.linux
+++ b/ffi/Makefile.linux
@@ -5,21 +5,27 @@ CXX ?= g++
 CXX_FLTO_FLAGS ?= -flto
 LD_FLTO_FLAGS ?= -flto -Wl,--exclude-libs=ALL
 
-CXXFLAGS = $(LLVM_CXXFLAGS) $(CXX_FLTO_FLAGS)
+# -fPIC is required when compiling objects for a shared library
+CXX_FPIC_FLAGS ?= -fPIC
+
+CXXFLAGS = $(LLVM_CXXFLAGS) $(CXX_FLTO_FLAGS) $(CXX_FPIC_FLAGS)
 LDFLAGS = $(LLVM_LDFLAGS) $(LD_FLTO_FLAGS)
 LIBS = $(LLVM_LIBS)
 INCLUDE = core.h
-SRC = assembly.cpp bitcode.cpp core.cpp initfini.cpp module.cpp value.cpp \
-	  executionengine.cpp transforms.cpp passmanagers.cpp targets.cpp dylib.cpp \
-	  linker.cpp object_file.cpp
+OBJ = assembly.o bitcode.o core.o initfini.o module.o value.o \
+	  executionengine.o transforms.o passmanagers.o targets.o dylib.o \
+	  linker.o object_file.o
 OUTPUT = libllvmlite.so
 
 all: $(OUTPUT)
 
-$(OUTPUT): $(SRC) $(INCLUDE)
+.cpp.o: $(INCLUDE)
+	$(CXX) -c $(CXXFLAGS) $< -o $@
+
+$(OUTPUT): $(OBJ)
 	# static-libstdc++ avoids runtime dependencies on a
 	# particular libstdc++ version.
-	$(CXX) $(CXX_STATIC_LINK) -shared $(CXXFLAGS) $(SRC) -o $(OUTPUT) $(LDFLAGS) $(LIBS)
+	$(CXX) $(CXX_STATIC_LINK) -shared $(CXXFLAGS) $(OBJ) -o $(OUTPUT) $(LDFLAGS) $(LIBS)
 
 clean:
-	rm -rf test $(OUTPUT)
+	rm -rf test $(OUTPUT) $(OBJ)

--- a/ffi/build.py
+++ b/ffi/build.py
@@ -120,7 +120,8 @@ def main_posix(kind, library_ext):
         os.environ['CXX_STATIC_LINK'] = "-static-libstdc++"
 
     makefile = "Makefile.%s" % (kind,)
-    subprocess.check_call(['make', '-f', makefile])
+    makeopts = os.environ.get('LLVMLITE_MAKEOPTS', '').split()
+    subprocess.check_call(['make', '-f', makefile] + makeopts)
     shutil.copy('libllvmlite' + library_ext, target_dir)
 
 

--- a/ffi/build.py
+++ b/ffi/build.py
@@ -6,6 +6,7 @@ Build script for the shared library providing the C ABI bridge to LLVM.
 from __future__ import print_function
 
 from ctypes.util import find_library
+import multiprocessing
 import os
 import subprocess
 import shutil
@@ -120,7 +121,11 @@ def main_posix(kind, library_ext):
         os.environ['CXX_STATIC_LINK'] = "-static-libstdc++"
 
     makefile = "Makefile.%s" % (kind,)
-    makeopts = os.environ.get('LLVMLITE_MAKEOPTS', '').split()
+    try:
+        default_makeopts = "-j%d" % (multiprocessing.cpu_count(),)
+    except NotImplementedError:
+        default_makeopts = ""
+    makeopts = os.environ.get('LLVMLITE_MAKEOPTS', default_makeopts).split()
     subprocess.check_call(['make', '-f', makefile] + makeopts)
     shutil.copy('libllvmlite' + library_ext, target_dir)
 

--- a/setup.py
+++ b/setup.py
@@ -113,7 +113,8 @@ class LlvmliteClean(clean):
                 remove_tree(path, dry_run=self.dry_run)
             else:
                 for fname in files:
-                    if fname.endswith('.pyc') or fname.endswith('.so'):
+                    if (fname.endswith('.pyc') or fname.endswith('.so')
+                            or fname.endswith('.o')):
                         fpath = os.path.join(path, fname)
                         os.remove(fpath)
                         log.info("removing '%s'", fpath)


### PR DESCRIPTION
Change the Linux Makefile to build each source file separately instead of using one big `$(CXX)` invocation and support using parallel make. This is cleaner, and makes it possible to utilize parallel make on multi-core CPUs as well as distcc.