### PR TITLE
Add support for LLVM fence instruction

### DIFF
--- a/llvmlite/ir/builder.py
+++ b/llvmlite/ir/builder.py
@@ -872,6 +872,15 @@ class IRBuilder(object):
         fn = self.module.declare_intrinsic("llvm.assume")
         return self.call(fn, [cond])
 
+    def fence(self, ordering, targetscope=None, name=''):
+        """
+        Add a memory barrier, preventing certain reorderings of load and/or store accesses with
+        respect to other processors and devices.
+        """
+        inst = instructions.Fence(self.block, ordering, targetscope, name=name)
+        self._insert(inst)
+        return inst
+
     @_uniop_intrinsic("llvm.bswap")
     def bswap(self, cond):
         """

--- a/llvmlite/ir/instructions.py
+++ b/llvmlite/ir/instructions.py
@@ -676,3 +676,34 @@ class LandingPadInstr(Instruction):
                               clauses=''.join(["\n      {0}".format(clause)
                                                for clause in self.clauses]),
                               ))
+
+class Fence(Instruction):
+    """
+    The `fence` instruction.
+
+    As of LLVM 5.0.1:
+
+    fence [syncscope("<target-scope>")] <ordering>  ; yields void
+    """
+
+    VALID_FENCE_ORDERINGS = {"acquire", "release", "acq_rel", "seq_cst"}
+
+    def __init__(self, parent, ordering, targetscope=None, name=''):
+        super(Fence, self).__init__(parent, types.VoidType(), "fence", (), name=name)
+        if ordering not in self.VALID_FENCE_ORDERINGS:
+            raise ValueError("Invalid fence ordering \"{0}\"! Should be one of {1}."
+                             .format(ordering, ", ".join(self.VALID_FENCE_ORDERINGS)))
+        self.ordering = ordering
+        self.targetscope = targetscope
+
+    def descr(self, buf):
+        if self.targetscope is None:
+            syncscope = ""
+        else:
+            syncscope = 'syncscope("{0}") '.format(self.targetscope)
+
+        fmt = "fence {syncscope}{ordering}\n"
+        buf.append(fmt.format(syncscope=syncscope,
+                              ordering=self.ordering,
+                              ))
+


### PR DESCRIPTION
The `fence` instructions are useful for shared-memory scenarios on weak-memory-model machines like PowerPC and ARM.

More specifically, it is necessary to use fences to render safe Numba's reference count increment/decrement.

We add here an `llvmlite.ir.instructions.Fence` instruction and a method `IRBuilder.fence(targetscope, ordering, name='')`.

The legal values of `targetscope` are `None`, `"singlethread"` and other target-specific supported values.

The legal values of `ordering` are `"acquire"`, `"release"`, `"acq_rel"` and `"seq_cst"`.