### PR TITLE
Fix undefined behavior bug due to Twine usage in LLVM

### DIFF
--- a/conda-recipes/llvmdev/cfg_test.ll
+++ b/conda-recipes/llvmdev/cfg_test.ll
@@ -1,0 +1,56 @@
+; ModuleID = 'foo'
+source_filename = "<string>"
+target datalayout = "e-m:o-i64:64-f80:128-n8:16:32:64-S128"
+target triple = "x86_64-apple-darwin17.4.0"
+
+@.const.foo = internal constant [4 x i8] c"foo\00"
+@".const.Fatal error: missing _dynfunc.Closure" = internal constant [38 x i8] c"Fatal error: missing _dynfunc.Closure\00"
+@PyExc_RuntimeError = external global i8
+@".const.missing Environment" = internal constant [20 x i8] c"missing Environment\00"
+
+; Function Attrs: norecurse nounwind
+declare i32 @"_ZN8__main__7foo$241Ex"(i64* noalias nocapture %retptr, { i8*, i32 }** noalias nocapture readnone %excinfo, i8* noalias nocapture readnone %env, i64 %arg.x) local_unnamed_addr #0
+
+
+define i8* @"testme"(i8* %py_closure, i8* %py_args, i8* nocapture readnone %py_kws) local_unnamed_addr {
+entry:
+  %.5 = alloca i8*, align 8
+  %.6 = call i32 (i8*, i8*, i64, i64, ...) @PyArg_UnpackTuple(i8* %py_args, i8* getelementptr inbounds ([4 x i8], [4 x i8]* @.const.foo, i64 0, i64 0), i64 1, i64 1, i8** nonnull %.5)
+  %.7 = icmp eq i32 %.6, 0
+  br i1 %.7, label %entry_if, label %entry_endif, !prof !0
+
+entry_if:                                         ; preds = %entry.endif.1.1.endif, %entry
+  ret i8* null
+
+entry_endif:                                      ; preds = %entry
+  %.11 = icmp eq i8* %py_closure, null
+  ret i8* null
+
+}
+
+declare i32 @PyArg_UnpackTuple(i8*, i8*, i64, i64, ...) local_unnamed_addr
+
+; Function Attrs: nounwind
+declare i32 @puts(i8* nocapture readonly) local_unnamed_addr #1
+
+declare void @PyErr_SetString(i8*, i8*) local_unnamed_addr
+
+declare i8* @PyNumber_Long(i8*) local_unnamed_addr
+
+declare i64 @PyLong_AsLongLong(i8*) local_unnamed_addr
+
+declare void @Py_DecRef(i8*) local_unnamed_addr
+
+declare i8* @PyErr_Occurred() local_unnamed_addr
+
+declare i8* @PyLong_FromLongLong(i64) local_unnamed_addr
+
+; Function Attrs: nounwind
+declare void @llvm.stackprotector(i8*, i8**) #1
+
+attributes #0 = { norecurse nounwind }
+attributes #1 = { nounwind }
+
+!0 = !{!"branch_weights", i32 1, i32 9}
+!1 = !{!"branch_weights", i32 9, i32 1}
+

--- a/conda-recipes/llvmdev/meta.yaml
+++ b/conda-recipes/llvmdev/meta.yaml
@@ -1,7 +1,7 @@
 {% set shortversion = "6.0" %}
 {% set version = "6.0.0" %}
 {% set sha256 = "1ff53c915b4e761ef400b803f07261ade637b0c269d99569f18040f3dcee4408" %}
-{% set build_number = "0" %}
+{% set build_number = "1" %}
 
 package:
   name: llvmdev
@@ -51,6 +51,11 @@ requirements:
     - zlib # [not win]
 
 test:
+  requires:
+    - python
+  files:
+    - cfg_test.ll
+    - test_cfg_dot.py
   commands:
     - $PREFIX/bin/llvm-config --libs                         # [not win]
     - $PREFIX/bin/llc -version                               # [not win]
@@ -62,6 +67,9 @@ test:
     - test -f $PREFIX/lib/libLLVMSupport.a                   # [unix]
 
     - test -f $PREFIX/lib/libLLVMCore.a                      # [not win]
+    # Test for ../twine_cfg_undefined_behavior.patch
+    - $PREFIX/bin/opt -dot-cfg cfg_test.ll                   # [not win]
+    - python test_cfg_dot.py                                 # [not win]
 
 about:
   home: http://llvm.org/

--- a/conda-recipes/llvmdev/meta.yaml
+++ b/conda-recipes/llvmdev/meta.yaml
@@ -18,6 +18,8 @@ source:
     - ../intel-svml.patch
     # https://reviews.llvm.org/D44140 Fix LLVM-C symbol export
     - ../0001-Transforms-Add-missing-header-for-InstructionCombini.patch
+    # undefined behavior bug due to Twine usage
+    - ../twine_cfg_undefined_behavior.patch
 
 build:
   number: {{ build_number }}

--- a/conda-recipes/llvmdev/test_cfg_dot.py
+++ b/conda-recipes/llvmdev/test_cfg_dot.py
@@ -1,0 +1,5 @@
+with open("cfg.testme.dot") as fin:
+    got = fin.read()
+
+assert '[label="W:1"]' in got
+assert '[label="W:9"]' in got

--- a/conda-recipes/llvmdev_manylinux1/meta.yaml
+++ b/conda-recipes/llvmdev_manylinux1/meta.yaml
@@ -1,12 +1,14 @@
 {% set shortversion = "6.0" %}
 {% set version = "6.0.0" %}
 {% set sha256 = "1ff53c915b4e761ef400b803f07261ade637b0c269d99569f18040f3dcee4408" %}
+{% set build_number = "1" %}
 
 package:
   name: llvmdev
   version: {{ version }}
 
 source:
+  fn: llvm-{{ version }}.src.tar.xz
   url: http://llvm.org/releases/{{ version }}/llvm-{{ version }}.src.tar.xz
   sha256: {{ sha256 }}
   patches:
@@ -16,9 +18,11 @@ source:
     - ../intel-svml.patch
     # https://reviews.llvm.org/D44140 Fix LLVM-C symbol export
     - ../0001-Transforms-Add-missing-header-for-InstructionCombini.patch
+    # undefined behavior bug due to Twine usage
+    - ../twine_cfg_undefined_behavior.patch
 
 build:
-  number: 0
+  number: {{ build_number }}
   string: "manylinux1h{{ PKG_HASH }}"
   script_env:
     - CFLAGS
@@ -35,17 +39,20 @@ requirements:
 
 test:
   commands:
-    - llvm-config --libs   # [not win]
-    - llc -version
+    - $PREFIX/bin/llvm-config --libs                         # [not win]
+    - $PREFIX/bin/llc -version                               # [not win]
 
-    - if not exist %LIBRARY_INC%\\llvm\\Pass.h exit 1          # [win]
-    - if not exist %LIBRARY_LIB%\\LLVMSupport.lib exit 1       # [win]
+    - if not exist %LIBRARY_INC%\\llvm\\Pass.h exit 1        # [win]
+    - if not exist %LIBRARY_LIB%\\LLVMSupport.lib exit 1     # [win]
 
-    - test -f $PREFIX/include/llvm/Pass.h                      # [unix]
-    - test -f $PREFIX/lib/libLLVMSupport.a                     # [unix]
+    - test -f $PREFIX/include/llvm/Pass.h                    # [unix]
+    - test -f $PREFIX/lib/libLLVMSupport.a                   # [unix]
+
+    - test -f $PREFIX/lib/libLLVMCore.a                      # [not win]
 
 about:
   home: http://llvm.org/
+  dev_url: https://github.com/llvm-mirror/llvm
   license: NCSA
   license_file: LICENSE.TXT
   summary: Development headers and libraries for LLVM

--- a/conda-recipes/twine_cfg_undefined_behavior.patch
+++ b/conda-recipes/twine_cfg_undefined_behavior.patch
@@ -1,0 +1,26 @@
+From b42222e01abc1a799c4e421fa26d72d49afe4b99 Mon Sep 17 00:00:00 2001
+From: Siu Kwan Lam <michael.lam.sk@gmail.com>
+Date: Fri, 23 Mar 2018 11:46:45 -0500
+Subject: [PATCH] Patch to fix undefined behavior in cfgprinter
+
+---
+ include/llvm/Analysis/CFGPrinter.h | 3 +--
+ 1 file changed, 1 insertion(+), 2 deletions(-)
+
+diff --git a/include/llvm/Analysis/CFGPrinter.h b/include/llvm/Analysis/CFGPrinter.h
+index 5786769..a4b642b 100644
+--- a/include/llvm/Analysis/CFGPrinter.h
++++ b/include/llvm/Analysis/CFGPrinter.h
+@@ -172,8 +172,7 @@ struct DOTGraphTraits<const Function*> : public DefaultDOTGraphTraits {
+ 
+     // Prepend a 'W' to indicate that this is a weight rather than the actual
+     // profile count (due to scaling).
+-    Twine Attrs = "label=\"W:" + Twine(Weight->getZExtValue()) + "\"";
+-    return Attrs.str();
++    return ("label=\"W:" + Twine(Weight->getZExtValue()) + "\"").str();
+   }
+ };
+ } // End llvm namespace
+-- 
+2.10.1
+


### PR DESCRIPTION
This adds a patch to LLVM source code to fix an undefined behavior bug.  A new test is added for the llvmdev package to verify the patch worked.  Note, the patched code will only affect branch weight printing at WriteCFG during CFG DOT file generation.