### PR TITLE
Python 3.7 compat: Properly escape repl in re.sub

### DIFF
--- a/llvmlite/tests/test_ir.py
+++ b/llvmlite/tests/test_ir.py
@@ -46,7 +46,7 @@ class TestBase(TestCase):
             return c
 
         pattern = ''.join(map(escape, pattern))
-        regex = re.sub(r'\s+', r'\s*', pattern)
+        regex = re.sub(r'\s+', r'\\\s*', pattern)
         self.assertRegexpMatches(text, regex)
 
     def assert_ir_line(self, line, mod):

--- a/llvmlite/tests/test_ir.py
+++ b/llvmlite/tests/test_ir.py
@@ -46,7 +46,7 @@ class TestBase(TestCase):
             return c
 
         pattern = ''.join(map(escape, pattern))
-        regex = re.sub(r'\s+', r'\\\s*', pattern)
+        regex = re.sub(r'\s+', r'\\s*', pattern)
         self.assertRegexpMatches(text, regex)
 
     def assert_ir_line(self, line, mod):


### PR DESCRIPTION
With `python -c "import re; print(re.sub(r'\s+',r'\s*','      here are  some   words'))"`

Python 2.7 and 3.6 give:
```
\s*here\s*are\s*some\s*words
```

While Python 3.7 gives:
```
Traceback (most recent call last):
  File "/opt/conda/envs/py37/lib/python3.7/sre_parse.py", line 1021, in parse_template
    this = chr(ESCAPES[this][1])
KeyError: '\\s'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/opt/conda/envs/py37/lib/python3.7/re.py", line 192, in sub
    return _compile(pattern, flags).sub(repl, string, count)
  File "/opt/conda/envs/py37/lib/python3.7/re.py", line 309, in _subx
    template = _compile_repl(template, pattern)
  File "/opt/conda/envs/py37/lib/python3.7/re.py", line 300, in _compile_repl
    return sre_parse.parse_template(repl, pattern)
  File "/opt/conda/envs/py37/lib/python3.7/sre_parse.py", line 1024, in parse_template
    raise s.error('bad escape %s' % this, len(this))
re.error: bad escape \s at position 0
```

From https://docs.python.org/3.7/whatsnew/3.7.html
.. this change in behaviour seems to be due to:
```
Unknown escapes consisting of '\' and an ASCII letter in replacement templates for
re.sub() were deprecated in Python 3.5, and will now cause an error.
```

The URL for this bug is:
https://bugs.python.org/issue27030

And the commit is:
https://github.com/python/cpython/commit/9bd85b83f66d31e39282244e455275bd9cd91bb1