### PR TITLE
Fix llvmdev build recipe.

### DIFF
--- a/conda-recipes/llvmdev/meta.yaml
+++ b/conda-recipes/llvmdev/meta.yaml
@@ -1,7 +1,7 @@
 {% set shortversion = "6.0" %}
 {% set version = "6.0.0" %}
 {% set sha256 = "1ff53c915b4e761ef400b803f07261ade637b0c269d99569f18040f3dcee4408" %}
-{% set build_number = "2" %}
+{% set build_number = "3" %}
 
 package:
   name: llvmdev
@@ -36,8 +36,8 @@ requirements:
     # at build.sh time
     # Windows needs to build using vs2015_runtime
     # irrespective of python version
-    - {{ compiler('c') }}
-    - {{ compiler('cxx') }}
+    - {{ compiler('c') }} # [unix]
+    - {{ compiler('cxx') }} # [unix]
     - cmake
     # Needed to unpack the source tarball
     - m2w64-xz  # [py27 and win]

--- a/conda-recipes/llvmlite/meta.yaml
+++ b/conda-recipes/llvmlite/meta.yaml
@@ -23,16 +23,18 @@ requirements:
     - python
     # On channel https://anaconda.org/numba/
     - llvmdev 6.0*
-    - vs2015_runtime [win]
+    - vs2015_runtime # [win]
     # The DLL build uses cmake on Windows
-    - cmake          [win]
-    - enum34         [py27]
-    - zlib           [unix] # llvmdev is built with libz compression support
+    - cmake          # [win]
+    - enum34         # [py27]
+    # llvmdev is built with libz compression support
+    - zlib           # [unix]
   run:
     - python
-    - enum34         [py27]
-    - vs2015_runtime [win]
-    - libcxx >=4.0.1 [osx] # osx has dynamically linked libstdc++
+    - enum34         # [py27]
+    - vs2015_runtime # [win]
+    # osx has dynamically linked libstdc++
+    - libcxx >=4.0.1 # [osx]
 
 test:
   imports:

--- a/conda-recipes/llvmlite/meta.yaml
+++ b/conda-recipes/llvmlite/meta.yaml
@@ -14,7 +14,7 @@ build:
 
 requirements:
   build:
-    # We cannot do this on macOS as the llvm-config from the 
+    # We cannot do this on macOS as the llvm-config from the
     # toolchain conflicts with the same from llvmdev, the
     # build.sh deals with it!
     - {{ compiler('c') }}    # [not osx]
@@ -27,10 +27,12 @@ requirements:
     # The DLL build uses cmake on Windows
     - cmake          [win]
     - enum34         [py27]
+    - zlib           [unix] # llvmdev is built with libz compression support
   run:
     - python
     - enum34         [py27]
     - vs2015_runtime [win]
+    - libcxx >=4.0.1 [osx] # osx has dynamically linked libstdc++
 
 test:
   imports:

--- a/ffi/Makefile.linux
+++ b/ffi/Makefile.linux
@@ -6,7 +6,7 @@ CXX_FLTO_FLAGS ?= -flto
 LD_FLTO_FLAGS ?= -flto -Wl,--exclude-libs=ALL
 
 CXXFLAGS = $(LLVM_CXXFLAGS) $(CXX_FLTO_FLAGS)
-LDFLAGS = $(LLVM_LDFLAGS) $(LD_FLTO_FLAGS)
+LDFLAGS = $(LDFLAGS) $(LLVM_LDFLAGS) $(LD_FLTO_FLAGS)
 LIBS = $(LLVM_LIBS)
 INCLUDE = core.h
 SRC = assembly.cpp bitcode.cpp core.cpp initfini.cpp module.cpp value.cpp \

--- a/ffi/Makefile.linux
+++ b/ffi/Makefile.linux
@@ -6,7 +6,7 @@ CXX_FLTO_FLAGS ?= -flto
 LD_FLTO_FLAGS ?= -flto -Wl,--exclude-libs=ALL
 
 CXXFLAGS = $(LLVM_CXXFLAGS) $(CXX_FLTO_FLAGS)
-LDFLAGS = $(LDFLAGS) $(LLVM_LDFLAGS) $(LD_FLTO_FLAGS)
+LDFLAGS := $(LDFLAGS) $(LLVM_LDFLAGS) $(LD_FLTO_FLAGS)
 LIBS = $(LLVM_LIBS)
 INCLUDE = core.h
 SRC = assembly.cpp bitcode.cpp core.cpp initfini.cpp module.cpp value.cpp \

--- a/ffi/Makefile.osx
+++ b/ffi/Makefile.osx
@@ -1,7 +1,7 @@
 
 CXX = clang++ -std=c++11 -stdlib=libc++
 CXXFLAGS = $(LLVM_CXXFLAGS)
-LDFLAGS = $(LLVM_LDFLAGS)
+LDFLAGS =  $(LDFLAGS) $(LLVM_LDFLAGS)
 LIBS = $(LLVM_LIBS)
 INCLUDE = core.h
 SRC = assembly.cpp bitcode.cpp core.cpp initfini.cpp module.cpp value.cpp \

--- a/ffi/Makefile.osx
+++ b/ffi/Makefile.osx
@@ -1,7 +1,7 @@
 
 CXX = clang++ -std=c++11 -stdlib=libc++
 CXXFLAGS = $(LLVM_CXXFLAGS)
-LDFLAGS =  $(LDFLAGS) $(LLVM_LDFLAGS)
+LDFLAGS :=  $(LDFLAGS) $(LLVM_LDFLAGS)
 LIBS = $(LLVM_LIBS)
 INCLUDE = core.h
 SRC = assembly.cpp bitcode.cpp core.cpp initfini.cpp module.cpp value.cpp \


### PR DESCRIPTION
This adds a selector such that windows does not use Anaconda
defined compilers which have a dependency on vc9.