### PR TITLE
Add SVML detection and a function to declare support.

### DIFF
--- a/CHANGE_LOG
+++ b/CHANGE_LOG
@@ -1,8 +1,9 @@
 v0.23.2
 -------
 
-This is a bug fix release to assist in addressing a critical bug in Numba:
-https://github.com/numba/numba/issues/3006
+This is a bug fix release to assist in addressing a critical Numba issue that
+can affect users who download llvmlite packages from sources other than PyPI
+(pip), Anaconda, or Intel Python: https://github.com/numba/numba/issues/3006
 
 Support for SVML is now detected at compile time and baked into a function that
 is exposed by llvmlite. This function can be queried at runtime to find out if

--- a/CHANGE_LOG
+++ b/CHANGE_LOG
@@ -1,3 +1,19 @@
+v0.23.2
+-------
+
+This is a bug fix release to assist in addressing a critical bug in Numba:
+https://github.com/numba/numba/issues/3006
+
+Support for SVML is now detected at compile time and baked into a function that
+is exposed by llvmlite. This function can be queried at runtime to find out if
+SVML is supported by the LLVM that llvmlite was compiled against, code
+generation paths can then be adjusted accordingly.
+
+The following PRs are closed in this release:
+
+* PR #361: Add SVML detection and a function to declare support. 
+
+
 v0.23.1
 -------
 
@@ -6,6 +22,7 @@ fix a couple of problems with the build recipes for llvmdev (on which llvmlite
 relies).
 
 The following PRs are closed in this release:
+
 * PR #353: PR Fix llvmdev build recipe.
 * PR #348: llvmdev: enhancements to conda recipe
 

--- a/ffi/CMakeLists.txt
+++ b/ffi/CMakeLists.txt
@@ -4,6 +4,8 @@ cmake_minimum_required(VERSION 2.8.8)
 # This will define the name of the solution file in the build directory
 project(llvmlite_ffi)
 
+include(CheckIncludeFiles)
+
 find_package(LLVM REQUIRED CONFIG)
 
 message(STATUS "Found LLVM ${LLVM_PACKAGE_VERSION}")
@@ -16,6 +18,18 @@ message(STATUS "Using LLVMConfig.cmake in: ${LLVM_DIR}")
 
 include_directories(${LLVM_INCLUDE_DIRS})
 add_definitions(${LLVM_DEFINITIONS})
+
+# Look for SVML
+set(CMAKE_REQUIRED_INCLUDES ${LLVM_INCLUDE_DIRS})
+
+CHECK_INCLUDE_FILES("llvm/IR/SVML.gen" HAVE_SVML)
+if(HAVE_SVML)
+    message(STATUS "SVML found")
+    add_definitions(-DHAVE_SVML)
+else()
+    message(STATUS "SVML not found")
+endif()
+
 
 # Define our shared library
 add_library(llvmlite SHARED assembly.cpp bitcode.cpp core.cpp initfini.cpp

--- a/ffi/build.py
+++ b/ffi/build.py
@@ -113,6 +113,16 @@ def main_posix(kind, library_ext):
     # on OSX cxxflags has null bytes at the end of the string, remove them
     cxxflags = cxxflags.replace('\0', '')
     cxxflags = cxxflags.split() + ['-fno-rtti', '-g']
+
+    # look for SVML
+    include_dir = run_llvm_config(llvm_config, ['--includedir']).strip()
+    svml_indicator = os.path.join(include_dir, 'llvm', 'IR', 'SVML.gen')
+    if os.path.isfile(svml_indicator):
+        cxxflags = cxxflags + ['-DHAVE_SVML']
+        print('SVML detected')
+    else:
+        print('SVML not detected')
+
     os.environ['LLVM_CXXFLAGS'] = ' '.join(cxxflags)
 
     ldflags = run_llvm_config(llvm_config, ["--ldflags"])

--- a/ffi/targets.cpp
+++ b/ffi/targets.cpp
@@ -309,6 +309,17 @@ LLVMPY_DisposeMemoryBuffer(LLVMMemoryBufferRef MB)
     return LLVMDisposeMemoryBuffer(MB);
 }
 
+API_EXPORT(int)
+LLVMPY_HasSVMLSupport(void)
+{
+#ifdef HAVE_SVML
+    return 1;
+#else
+    return 0;
+#endif
+}
+
+
 /*
 
 If needed:

--- a/llvmlite/binding/targets.py
+++ b/llvmlite/binding/targets.py
@@ -301,6 +301,15 @@ class TargetMachine(ffi.ObjectRef):
             ffi.lib.LLVMPY_GetTargetMachineTriple(self, out)
             return str(out)
 
+def has_svml():
+    """
+    Returns True if SVML was enabled at FFI support compile time.
+    """
+    if ffi.lib.LLVMPY_HasSVMLSupport() == 0:
+        return False
+    else:
+        return True
+
 
 # ============================================================================
 # FFI
@@ -400,3 +409,6 @@ ffi.lib.LLVMPY_CreateTargetMachineData.argtypes = [
     ffi.LLVMTargetMachineRef,
 ]
 ffi.lib.LLVMPY_CreateTargetMachineData.restype = ffi.LLVMTargetDataRef
+
+ffi.lib.LLVMPY_HasSVMLSupport.argtypes = []
+ffi.lib.LLVMPY_HasSVMLSupport.restype = c_int


### PR DESCRIPTION
This adds detection of SVML support in a LLVM build at compile
time. This is then exposed such that it can be queried at run time
from Python in a manner that is suitable for use in the SVML
initialisation and detection sequence.

Closes #3006
Fixes #2998