### PR TITLE
Add printing to the bound llvm type

### DIFF
--- a/docs/source/user-guide/binding/index.rst
+++ b/docs/source/user-guide/binding/index.rst
@@ -24,6 +24,7 @@ implement Numba_'s JIT compiler.
    target-information
    modules
    value-references
+   type-references
    execution-engine
    optimization-passes
    analysis-utilities

--- a/docs/source/user-guide/binding/target-information.rst
+++ b/docs/source/user-guide/binding/target-information.rst
@@ -81,8 +81,8 @@ Classes
 
    * .. method:: get_abi_size(type)
 
-        Get the ABI-mandated size of the LLVM *type*, as returned 
-        by :attr:`ValueRef.type`. Returns an integer.
+        Get the ABI-mandated size of a :class:`TypeRef` object. 
+        Returns an integer.
 
    * .. method:: get_pointee_abi_size(type)
 

--- a/docs/source/user-guide/binding/type-references.rst
+++ b/docs/source/user-guide/binding/type-references.rst
@@ -1,0 +1,34 @@
+=================
+Type references
+=================
+
+.. currentmodule:: llvmlite.binding
+
+A type reference wraps an LLVM type. It allows accessing type's name and 
+IR representation. It is also accepted by methods like 
+:meth:`TargetData.get_abi_size`.
+
+The TypeRef class
+------------------
+
+.. class:: TypeRef
+
+A wrapper around an LLVM type. The attributes available are:
+
+* .. attribute:: name
+
+    This type's name, as a string. 
+
+* .. attribute:: is_pointer
+
+    * ``True``---The type is a pointer type
+    * ``False``---The type is not a pointer type
+
+* .. attribute:: element_type
+
+    If the type is a pointer, return the pointed-to type. Raises a
+    ValueError if the type is not a pointer type.
+
+* .. method:: __str__(self)
+
+    Get the string IR representation of the type.

--- a/docs/source/user-guide/binding/value-references.rst
+++ b/docs/source/user-guide/binding/value-references.rst
@@ -81,9 +81,7 @@ The ValueRef class
 
    * .. attribute:: type
 
-        This value's LLVM type. An opaque object is returned that   
-        can be used with, for example, 
-        :meth:`TargetData.get_abi_size`.
+        This value's LLVM type as :class:`TypeRef` object.
 
    * .. attribute:: storage_class
 

--- a/ffi/value.cpp
+++ b/ffi/value.cpp
@@ -38,6 +38,12 @@ LLVMPY_TypeOf(LLVMValueRef Val)
     return LLVMTypeOf(Val);
 }
 
+API_EXPORT(const char *)
+LLVMPY_PrintType(LLVMTypeRef type)
+{
+    return LLVMPrintTypeToString(type);
+}
+
 API_EXPORT(void)
 LLVMPY_SetLinkage(LLVMValueRef Val, int Linkage)
 {

--- a/ffi/value.cpp
+++ b/ffi/value.cpp
@@ -2,6 +2,8 @@
 #include "llvm-c/Core.h"
 #include "core.h"
 
+#include <iostream>
+
 // the following is needed for WriteGraph()
 #include "llvm/Analysis/CFGPrinter.h"
 
@@ -42,6 +44,36 @@ API_EXPORT(const char *)
 LLVMPY_PrintType(LLVMTypeRef type)
 {
     return LLVMPrintTypeToString(type);
+}
+
+API_EXPORT(const char *)
+LLVMPY_GetTypeName(LLVMTypeRef type)
+{
+    // try to convert to a struct type, works for other derived
+    // types too
+    llvm::Type* unwrapped = llvm::unwrap(type);
+    llvm::StructType* ty = llvm::dyn_cast<llvm::StructType>(unwrapped);
+    if (ty && !ty->isLiteral()) {
+        return strdup(ty->getStructName().str().c_str());
+    }
+    return strdup("");
+}
+
+API_EXPORT(bool)
+LLVMPY_TypeIsPointer(LLVMTypeRef type)
+{
+    return llvm::unwrap(type)->isPointerTy();
+}
+
+API_EXPORT(LLVMTypeRef)
+LLVMPY_GetElementType(LLVMTypeRef type)
+{
+    llvm::Type* unwrapped = llvm::unwrap(type);
+    llvm::PointerType* ty = llvm::dyn_cast<llvm::PointerType>(unwrapped);
+    if (ty != nullptr) {
+        return llvm::wrap(ty->getElementType());
+    }
+    return nullptr;
 }
 
 API_EXPORT(void)

--- a/llvmlite/binding/value.py
+++ b/llvmlite/binding/value.py
@@ -63,10 +63,6 @@ class ValueRef(ffi.ObjectRef):
             ffi.lib.LLVMPY_PrintValueToString(self, outstr)
             return str(outstr)
 
-    @staticmethod
-    def printType(ty):
-        return _decode_string(ffi.lib.LLVMPY_PrintType(ty))
-
     @property
     def module(self):
         """

--- a/llvmlite/binding/value.py
+++ b/llvmlite/binding/value.py
@@ -48,14 +48,24 @@ class TypeRef(ffi.ObjectRef):
     """
     @property
     def name(self):
+        """
+        Get type name
+        """
         return _decode_string(ffi.lib.LLVMPY_GetTypeName(self))
 
     @property
     def is_pointer(self):
+        """
+        Returns true is the type is a pointer type.
+        """
         return ffi.lib.LLVMPY_TypeIsPointer(self)
 
     @property
     def element_type(self):
+        """
+        Returns the pointed-to type. When the type is not a pointer,
+        raises exception.
+        """
         if not self.is_pointer:
             raise ValueError("Type {} is not a pointer".format(self))
         return TypeRef(ffi.lib.LLVMPY_GetElementType(self))

--- a/llvmlite/binding/value.py
+++ b/llvmlite/binding/value.py
@@ -1,4 +1,4 @@
-from ctypes import POINTER, c_char_p, c_int, c_size_t, c_uint
+from ctypes import POINTER, c_char_p, c_int, c_size_t, c_uint, c_bool
 import enum
 
 from . import ffi
@@ -46,6 +46,20 @@ class StorageClass(enum.IntEnum):
 class TypeRef(ffi.ObjectRef):
     """A weak reference to a LLVM type
     """
+    @property
+    def name(self):
+        return _decode_string(ffi.lib.LLVMPY_GetTypeName(self))
+
+    @property
+    def is_pointer(self):
+        return ffi.lib.LLVMPY_TypeIsPointer(self)
+
+    @property
+    def element_type(self):
+        if not self.is_pointer:
+            raise ValueError("Type {} is not a pointer".format(self))
+        return TypeRef(ffi.lib.LLVMPY_GetElementType(self))
+
     def __str__(self):
         return _decode_string(ffi.lib.LLVMPY_PrintType(self))
 
@@ -160,6 +174,16 @@ ffi.lib.LLVMPY_TypeOf.restype = ffi.LLVMTypeRef
 
 ffi.lib.LLVMPY_PrintType.argtypes = [ffi.LLVMTypeRef]
 ffi.lib.LLVMPY_PrintType.restype = c_char_p
+
+ffi.lib.LLVMPY_TypeIsPointer.argtypes = [ffi.LLVMTypeRef]
+ffi.lib.LLVMPY_TypeIsPointer.restype = c_bool
+
+ffi.lib.LLVMPY_GetElementType.argtypes = [ffi.LLVMTypeRef]
+ffi.lib.LLVMPY_GetElementType.restype = ffi.LLVMTypeRef
+
+
+ffi.lib.LLVMPY_GetTypeName.argtypes = [ffi.LLVMTypeRef]
+ffi.lib.LLVMPY_GetTypeName.restype = c_char_p
 
 ffi.lib.LLVMPY_GetLinkage.argtypes = [ffi.LLVMValueRef]
 ffi.lib.LLVMPY_GetLinkage.restype = c_int

--- a/llvmlite/binding/value.py
+++ b/llvmlite/binding/value.py
@@ -43,6 +43,13 @@ class StorageClass(enum.IntEnum):
     dllexport = 2
 
 
+class TypeRef(ffi.ObjectRef):
+    """A weak reference to a LLVM type
+    """
+    def __str__(self):
+        return _decode_string(ffi.lib.LLVMPY_PrintType(self))
+
+
 class ValueRef(ffi.ObjectRef):
     """A weak reference to a LLVM value.
     """
@@ -55,6 +62,10 @@ class ValueRef(ffi.ObjectRef):
         with ffi.OutputString() as outstr:
             ffi.lib.LLVMPY_PrintValueToString(self, outstr)
             return str(outstr)
+
+    @staticmethod
+    def printType(ty):
+        return _decode_string(ffi.lib.LLVMPY_PrintType(ty))
 
     @property
     def module(self):
@@ -122,7 +133,7 @@ class ValueRef(ffi.ObjectRef):
         This value's LLVM type.
         """
         # XXX what does this return?
-        return ffi.lib.LLVMPY_TypeOf(self)
+        return TypeRef(ffi.lib.LLVMPY_TypeOf(self))
 
     @property
     def is_declaration(self):
@@ -150,6 +161,9 @@ ffi.lib.LLVMPY_SetValueName.argtypes = [ffi.LLVMValueRef, c_char_p]
 
 ffi.lib.LLVMPY_TypeOf.argtypes = [ffi.LLVMValueRef]
 ffi.lib.LLVMPY_TypeOf.restype = ffi.LLVMTypeRef
+
+ffi.lib.LLVMPY_PrintType.argtypes = [ffi.LLVMTypeRef]
+ffi.lib.LLVMPY_PrintType.restype = c_char_p
 
 ffi.lib.LLVMPY_GetLinkage.argtypes = [ffi.LLVMValueRef]
 ffi.lib.LLVMPY_GetLinkage.restype = c_int

--- a/llvmlite/ir/types.py
+++ b/llvmlite/ir/types.py
@@ -256,11 +256,13 @@ def _as_float(value):
     """
     return struct.unpack('f', struct.pack('f', value))[0]
 
+
 def _format_float_as_hex(value, packfmt, unpackfmt, numdigits):
     raw = struct.pack(packfmt, float(value))
     intrep = struct.unpack(unpackfmt, raw)[0]
     out = '{{0:#{0}x}}'.format(numdigits).format(intrep)
     return out
+
 
 def _format_double(value):
     """

--- a/llvmlite/tests/test_binding.py
+++ b/llvmlite/tests/test_binding.py
@@ -794,7 +794,23 @@ class TestValueRef(BaseTest):
         mod = self.module()
         glob = mod.get_global_variable("glob")
         tp = glob.type
-        self.assertIsInstance(tp, ffi.LLVMTypeRef)
+        self.assertIsInstance(tp, llvm.TypeRef)
+
+    def test_type_printing_variable(self):
+        mod = self.module()
+        glob = mod.get_global_variable("glob")
+        tp = glob.type
+        self.assertEqual(str(tp), 'i32*')
+
+    def test_type_printing_function(self):
+        mod = self.module()
+        fn = mod.get_function("sum")
+        self.assertEqual(str(fn.type), "i32 (i32, i32)*")
+
+    def test_type_printing_struct(self):
+        mod = self.module()
+        st = mod.get_global_variable("glob_struct")
+        self.assertEqual(str(st.type), "{ i64, [2 x i64] }*")
 
     def test_close(self):
         glob = self.glob()

--- a/llvmlite/tests/test_binding.py
+++ b/llvmlite/tests/test_binding.py
@@ -807,7 +807,7 @@ class TestValueRef(BaseTest):
         self.assertEqual(tp.name, "")
         st = mod.get_global_variable("glob_struct")
         self.assertRegex(st.type.element_type.name,
-            r"struct\.glob_type\.[\d]+")
+            r"struct\.glob_type(\.[\d]+)?")
 
     def test_type_printing_variable(self):
         mod = self.module()
@@ -825,9 +825,9 @@ class TestValueRef(BaseTest):
         st = mod.get_global_variable("glob_struct")
         self.assertTrue(st.type.is_pointer)
         self.assertRegex(str(st.type),
-                r'\%struct\.glob_type\.[\d]+\*')
+                r'\%struct\.glob_type(\.[\d]+)?\*')
         self.assertRegex(str(st.type.element_type),
-                r"\%struct\.glob_type\.[\d]+ = type { i64, \[2 x i64\] }")
+                r"\%struct\.glob_type(\.[\d]+)? = type { i64, \[2 x i64\] }")
 
     def test_close(self):
         glob = self.glob()

--- a/llvmlite/tests/test_binding.py
+++ b/llvmlite/tests/test_binding.py
@@ -39,11 +39,12 @@ def no_de_locale():
 asm_sum = r"""
     ; ModuleID = '<string>'
     target triple = "{triple}"
+    %struct.glob_type = type {{ i64, [2 x i64]}}
 
     @glob = global i32 0
     @glob_b = global i8 0
     @glob_f = global float 1.5
-    @glob_struct = global {{ i64, [2 x i64]}} {{i64 0, [2 x i64] [i64 0, i64 0]}}
+    @glob_struct = global %struct.glob_type {{i64 0, [2 x i64] [i64 0, i64 0]}}
 
     define i32 @sum(i32 %.1, i32 %.2) {{
       %.3 = add i32 %.1, %.2
@@ -450,7 +451,8 @@ class TestModuleRef(BaseTest):
         dest = self.module()
         src = self.module(asm_mul)
         dest.link_in(src)
-        self.assertEqual(sorted(f.name for f in dest.functions), ["mul", "sum"])
+        self.assertEqual(
+            sorted(f.name for f in dest.functions), ["mul", "sum"])
         dest.get_function("mul")
         dest.close()
         with self.assertRaises(ctypes.ArgumentError):
@@ -460,7 +462,8 @@ class TestModuleRef(BaseTest):
         dest = self.module()
         src2 = self.module(asm_mul)
         dest.link_in(src2, preserve=True)
-        self.assertEqual(sorted(f.name for f in dest.functions), ["mul", "sum"])
+        self.assertEqual(
+            sorted(f.name for f in dest.functions), ["mul", "sum"])
         dest.close()
         self.assertEqual(sorted(f.name for f in src2.functions), ["mul"])
         src2.get_function("mul")
@@ -493,7 +496,14 @@ class TestModuleRef(BaseTest):
     def test_bitcode_roundtrip(self):
         bc = self.module().as_bitcode()
         mod = llvm.parse_bitcode(bc)
-        self.assertEqual(mod.as_bitcode(), bc)
+        bc2 = mod.as_bitcode()
+        mod2 = llvm.parse_bitcode(bc2)
+        bc3 = mod2.as_bitcode()
+        open("/tmp/bc1.bc", 'wb').write(bc)
+        open("/tmp/bc2.bc", 'wb').write(bc2)
+        open("/tmp/bc3.bc", 'wb').write(bc3)
+        self.assertEqual(bc2, bc3)
+
         mod.get_function("sum")
         mod.get_global_variable("glob")
 
@@ -784,7 +794,6 @@ class TestValueRef(BaseTest):
             fn.add_function_attribute("zext")
         self.assertEqual(str(raises.exception), "no such attribute 'zext'")
 
-
     def test_module(self):
         mod = self.module()
         glob = mod.get_global_variable("glob")
@@ -795,6 +804,15 @@ class TestValueRef(BaseTest):
         glob = mod.get_global_variable("glob")
         tp = glob.type
         self.assertIsInstance(tp, llvm.TypeRef)
+
+    def test_type_name(self):
+        mod = self.module()
+        glob = mod.get_global_variable("glob")
+        tp = glob.type
+        self.assertEqual(tp.name, "")
+        st = mod.get_global_variable("glob_struct")
+        self.assertRegex(st.type.element_type.name,
+            r"struct\.glob_type\.[\d]+")
 
     def test_type_printing_variable(self):
         mod = self.module()
@@ -810,7 +828,11 @@ class TestValueRef(BaseTest):
     def test_type_printing_struct(self):
         mod = self.module()
         st = mod.get_global_variable("glob_struct")
-        self.assertEqual(str(st.type), "{ i64, [2 x i64] }*")
+        self.assertTrue(st.type.is_pointer)
+        self.assertRegex(str(st.type),
+                r'\%struct\.glob_type\.[\d]+\*')
+        self.assertRegex(str(st.type.element_type),
+                r"\%struct\.glob_type\.[\d]+ = type { i64, \[2 x i64\] }")
 
     def test_close(self):
         glob = self.glob()
@@ -1136,19 +1158,19 @@ class TestGlobalConstructors(TestMCJit):
         # test issue #303
         # (https://github.com/numba/llvmlite/issues/303)
         mod = self.module(asm_global_ctors)
-        ee  = self.jit(mod)
+        ee = self.jit(mod)
         ee.finalize_object()
 
         ee.run_static_constructors()
 
         # global variable should have been initialized
         ptr_addr = ee.get_global_value_address("A")
-        ptr_t    = ctypes.POINTER(ctypes.c_int32)
-        ptr      = ctypes.cast(ptr_addr, ptr_t)
+        ptr_t = ctypes.POINTER(ctypes.c_int32)
+        ptr = ctypes.cast(ptr_addr, ptr_t)
         self.assertEqual(ptr.contents.value, 10)
 
         foo_addr = ee.get_function_address("foo")
-        foo      = ctypes.CFUNCTYPE(ctypes.c_int32)(foo_addr)
+        foo = ctypes.CFUNCTYPE(ctypes.c_int32)(foo_addr)
         self.assertEqual(foo(), 12)
 
         ee.run_static_destructors()
@@ -1221,6 +1243,7 @@ class TestInlineAsm(BaseTest):
         asm = tm.emit_assembly(m)
         self.assertIn('nop', asm)
 
+
 class TestObjectFile(BaseTest):
     def test_object_file(self):
         target_machine = self.target_machine()
@@ -1237,6 +1260,7 @@ class TestObjectFile(BaseTest):
                 self.assertTrue(len(s.data()) > 0)
                 break
         self.assertTrue(has_text)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/llvmlite/tests/test_binding.py
+++ b/llvmlite/tests/test_binding.py
@@ -66,6 +66,7 @@ asm_sum2 = r"""
 asm_mul = r"""
     ; ModuleID = '<string>'
     target triple = "{triple}"
+    @mul_glob = global i32 0
 
     define i32 @mul(i32 %.1, i32 %.2) {{
       %.3 = mul i32 %.1, %.2
@@ -494,18 +495,12 @@ class TestModuleRef(BaseTest):
         self.assertIn("Invalid bitcode signature", str(cm.exception))
 
     def test_bitcode_roundtrip(self):
-        bc = self.module().as_bitcode()
+        bc = self.module(asm=asm_mul).as_bitcode()
         mod = llvm.parse_bitcode(bc)
-        bc2 = mod.as_bitcode()
-        mod2 = llvm.parse_bitcode(bc2)
-        bc3 = mod2.as_bitcode()
-        open("/tmp/bc1.bc", 'wb').write(bc)
-        open("/tmp/bc2.bc", 'wb').write(bc2)
-        open("/tmp/bc3.bc", 'wb').write(bc3)
-        self.assertEqual(bc2, bc3)
+        self.assertEqual(mod.as_bitcode(), bc)
 
-        mod.get_function("sum")
-        mod.get_global_variable("glob")
+        mod.get_function("mul")
+        mod.get_global_variable("mul_glob")
 
     def test_cloning(self):
         m = self.module()

--- a/llvmlite/tests/test_binding.py
+++ b/llvmlite/tests/test_binding.py
@@ -447,7 +447,6 @@ class TestModuleRef(BaseTest):
         funcs = list(it)
         self.assertEqual(len(funcs), 1)
         self.assertEqual(funcs[0].name, "sum")
-
     def test_link_in(self):
         dest = self.module()
         src = self.module(asm_mul)
@@ -806,8 +805,8 @@ class TestValueRef(BaseTest):
         tp = glob.type
         self.assertEqual(tp.name, "")
         st = mod.get_global_variable("glob_struct")
-        self.assertRegex(st.type.element_type.name,
-            r"struct\.glob_type(\.[\d]+)?")
+        self.assertIsNotNone(re.match(r"struct\.glob_type(\.[\d]+)?",
+            st.type.element_type.name))
 
     def test_type_printing_variable(self):
         mod = self.module()
@@ -824,10 +823,11 @@ class TestValueRef(BaseTest):
         mod = self.module()
         st = mod.get_global_variable("glob_struct")
         self.assertTrue(st.type.is_pointer)
-        self.assertRegex(str(st.type),
-                r'\%struct\.glob_type(\.[\d]+)?\*')
-        self.assertRegex(str(st.type.element_type),
-                r"\%struct\.glob_type(\.[\d]+)? = type { i64, \[2 x i64\] }")
+        self.assertIsNotNone(re.match(r'%struct\.glob_type(\.[\d]+)?\*',
+                    str(st.type)))
+        self.assertIsNotNone(re.match(
+            r"%struct\.glob_type(\.[\d]+)? = type { i64, \[2 x i64\] }",
+            str(st.type.element_type)))
 
     def test_close(self):
         glob = self.glob()


### PR DESCRIPTION
The `LLVMPY_TypeRef` class is a completely opaque type right now. This adds a thin wrapper which prints the LLVM IR representation of the LLVM Type.

If this change is ok, I'll adjust the documentation, too.

I have one further PR prepared which allows extracting `TypeRef`s from a `ModuleRef`, similar to the `get_function` and `functions`. I'd like to wait for the feedback on this PR first, though.

My envisioned use case is making the interop with external modules easier. Let say I've compiled some C code to a `c.ll` file. I'd like to use functions and structs defined there from a module created with `llvmlite`. Right now I'd have to manually forward declare everything. With these changes I can pretty much automate everything.