### PR TITLE
Fix docs for the extractvalue instr

### DIFF
--- a/docs/source/user-guide/ir/ir-builder.rst
+++ b/docs/source/user-guide/ir/ir-builder.rst
@@ -410,9 +410,7 @@ Aggregate operations
      :ref:`aggregate value <aggregate-types>` *agg*.
 
      * *index* may be an integer or a sequence of integers.
-     * If *agg* is of an array type, indices can be arbitrary
-       values.
-     * If *agg* is of a struct type, indices must be constant.
+     * Indices must be constant.
 
 * .. method:: IRBuilder.insert_value(agg, value, index, name='')
 


### PR DESCRIPTION
As mentioned in #298, the docs give wrong information about the `extractvalue` instruction (compare with [the LLVM IR Ref](https://llvm.org/docs/LangRef.html#extractvalue-instruction)).