### PR TITLE
Guard against close being None in ObjectRef.__del__

### DIFF
--- a/llvmlite/binding/ffi.py
+++ b/llvmlite/binding/ffi.py
@@ -239,7 +239,8 @@ class ObjectRef(object):
         self.close()
 
     def __del__(self):
-        self.close()
+        if self.close is not None:
+            self.close()
 
     def __bool__(self):
         return bool(self._ptr)
@@ -249,4 +250,3 @@ class ObjectRef(object):
     # XXX useful?
     def __hash__(self):
         return hash(ctypes.cast(self._ptr, ctypes.c_void_p).value)
-


### PR DESCRIPTION
This can happen if it is called at interpreter shutdown.

Partial fix to #350 (I didn't try to fix any other `__del__` methods).