### PR TITLE
Recipe fixes for Conda Build 3

### DIFF
--- a/conda-recipes/llvmlite/bld.bat
+++ b/conda-recipes/llvmlite/bld.bat
@@ -5,8 +5,8 @@ set CMAKE_PREFIX_PATH=%LIBRARY_PREFIX%
 @rem Ensure there are no build leftovers (CMake can complain)
 if exist ffi\build rmdir /S /Q ffi\build
 
-python -S setup.py install
+%PYTHON% -S setup.py install
 if errorlevel 1 exit 1
 
-python runtests.py
+%PYTHON% runtests.py
 if errorlevel 1 exit 1

--- a/conda-recipes/llvmlite/build.sh
+++ b/conda-recipes/llvmlite/build.sh
@@ -30,5 +30,5 @@ export PYTHONNOUSERSITE=1
 # Enables static linking of stdlibc++
 export LLVMLITE_CXX_STATIC_LINK=1
 
-python setup.py build --force
-python setup.py install
+$PYTHON setup.py build --force
+$PYTHON setup.py install

--- a/conda-recipes/llvmlite/meta.yaml
+++ b/conda-recipes/llvmlite/meta.yaml
@@ -19,13 +19,13 @@ requirements:
     # build.sh deals with it!
     - {{ compiler('c') }}    # [not osx]
     - {{ compiler('cxx') }}  # [not osx]
+    # The DLL build uses cmake on Windows
+    - cmake          # [win]
   host:
     - python
     # On channel https://anaconda.org/numba/
     - llvmdev 6.0*
     - vs2015_runtime # [win]
-    # The DLL build uses cmake on Windows
-    - cmake          # [win]
     - enum34         # [py27]
     # llvmdev is built with libz compression support
     - zlib           # [unix]


### PR DESCRIPTION
Newer versions of Conda Build are more stricter about the build/host split.