### PR TITLE
LLVM 6.0.1 build based on RC and fixes for PPC64LE

### DIFF
--- a/conda-recipes/llvmdev/meta.yaml
+++ b/conda-recipes/llvmdev/meta.yaml
@@ -1,7 +1,18 @@
 {% set shortversion = "6.0" %}
+
+{% if ppc64le %}
+
+{% set version = "6.0.1" %}
+{% set sha256 = "b6d6c324f9c71494c0ccaf3dac1f16236d970002b42bb24a6c9e1634f7d0f4e2" %}
+{% set build_number = "0" %}
+
+{% else %}
+
 {% set version = "6.0.0" %}
 {% set sha256 = "1ff53c915b4e761ef400b803f07261ade637b0c269d99569f18040f3dcee4408" %}
 {% set build_number = "4" %}
+
+{% endif %}
 
 package:
   name: llvmdev
@@ -16,8 +27,8 @@ source:
     - ../llvm-lto-static.patch   # [win]
     # Intel SVML optimizations
     - ../D47188-svml.patch
-    # https://reviews.llvm.org/D44140 Fix LLVM-C symbol export
-    - ../0001-Transforms-Add-missing-header-for-InstructionCombini.patch
+    # https://reviews.llvm.org/D44140 Fix LLVM-C symbol export, backport to 6.0.0 from upstream
+    - ../0001-Transforms-Add-missing-header-for-InstructionCombini.patch [ version == '6.0.0' ]
     # undefined behavior bug due to Twine usage
     - ../twine_cfg_undefined_behavior.patch
 
@@ -78,7 +89,7 @@ test:
 
     - opt -S -vector-library=SVML -mcpu=haswell -O3 numba-3016.ll -o out.ll
     - findstr __svml_sin4 out.ll                             # [win]
-    - grep __svml_sin4 out.ll                                # [unix]
+    - grep __svml_sin4 out.ll                                # [unix and x86_64]
 
 about:
   home: http://llvm.org/


### PR DESCRIPTION
This adds in the ability to build from the LLVM 6.0.1 releases (yet
to formally ship). This release is needed for PPC64LE support and
is masked off as such.