### PR TITLE
Fix typo in irbuilder documentation

### DIFF
--- a/docs/source/user-guide/ir/ir-builder.rst
+++ b/docs/source/user-guide/ir/ir-builder.rst
@@ -218,7 +218,7 @@ Integer
 
      Integer subtract *rhs* from *lhs*.
 
-* .. method:: IRBuilder.sadd_with_overflow(lhs, rhs, name='', flags=())
+* .. method:: IRBuilder.ssub_with_overflow(lhs, rhs, name='', flags=())
 
      Integer subtract *rhs* from *lhs*. A
      ``{ result, overflow bit }`` structure is returned.


### PR DESCRIPTION
IRBuilder documentation mentions IRBuilder.sadd_with_overflow two times. But should IRBuilder.ssub_with_overflow the second time.