### PR TITLE
Fix gep method call on Constant objects

### DIFF
--- a/llvmlite/ir/values.py
+++ b/llvmlite/ir/values.py
@@ -161,6 +161,12 @@ class Constant(_StrCaching, _StringReferenceCaching, _ConstOpMixin, Value):
         tys = [el.type for el in elems]
         return cls(types.LiteralStructType(tys), elems)
 
+    @property
+    def addrspace(self):
+        if not isinstance(self.type, types.PointerType):
+            raise TypeError("Only pointer constant have address spaces")
+        return self.type.addrspace
+
     def __eq__(self, other):
         if isinstance(other, Constant):
             return str(self) == str(other)

--- a/llvmlite/tests/test_ir.py
+++ b/llvmlite/tests/test_ir.py
@@ -1907,8 +1907,13 @@ class TestConstant(TestBase):
         self.assertEqual(str(c),
             'getelementptr ({float, i1}, {float, i1}* @"myconstant", i32 0, i32 1)')
         self.assertEqual(c.type, ir.PointerType(int1))
-        const = ir.Constant(tp.as_pointer(), None)
-        c2  = const.gep([ir.Constant(int32, 0)])
+
+        const = ir.Constant(tp, None)
+        with self.assertRaises(TypeError):
+            c_wrong = const.gep([ir.Constant(int32, 0)])
+
+        const_ptr = ir.Constant(tp.as_pointer(), None)
+        c2  = const_ptr.gep([ir.Constant(int32, 0)])
         self.assertEqual(str(c2),
             'getelementptr ({float, i1}, {float, i1}* null, i32 0)')
         self.assertEqual(c.type, ir.PointerType(int1))

--- a/llvmlite/tests/test_ir.py
+++ b/llvmlite/tests/test_ir.py
@@ -1907,6 +1907,12 @@ class TestConstant(TestBase):
         self.assertEqual(str(c),
             'getelementptr ({float, i1}, {float, i1}* @"myconstant", i32 0, i32 1)')
         self.assertEqual(c.type, ir.PointerType(int1))
+        const = ir.Constant(tp.as_pointer(), None)
+        c2  = const.gep([ir.Constant(int32, 0)])
+        self.assertEqual(str(c2),
+            'getelementptr ({float, i1}, {float, i1}* null, i32 0)')
+        self.assertEqual(c.type, ir.PointerType(int1))
+
 
     def test_gep_addrspace_globalvar(self):
         m = self.module()


### PR DESCRIPTION
Constant pointer objects provide a `gep` method. Unfortunately, it doesn't work on them, since it expects an attribute `addrspace` to be present.

This PR adds a `addrspace` property to `Constant` class and a test to check if it works properly.