### PR TITLE
Add get_element_offset to TargetData

### DIFF
--- a/docs/source/user-guide/binding/target-information.rst
+++ b/docs/source/user-guide/binding/target-information.rst
@@ -4,11 +4,11 @@ Target information
 
 .. currentmodule:: llvmlite.binding
 
-Target information allows you to inspect and modify aspects of 
-the code generation, such as which CPU is targeted or what 
+Target information allows you to inspect and modify aspects of
+the code generation, such as which CPU is targeted or what
 optimization level is desired.
 
-Minimal use of this module would be to create a 
+Minimal use of this module would be to create a
 :class:`TargetMachine` for later use in code generation.
 
 EXAMPLE::
@@ -22,23 +22,23 @@ Functions
 
 * .. function:: get_default_triple()
 
-     Return a string representing the default target triple that 
-     LLVM is configured to produce code for. This represents the 
+     Return a string representing the default target triple that
+     LLVM is configured to produce code for. This represents the
      host's architecture and platform.
 
 * .. function:: get_process_triple()
 
-     Return a target triple suitable for generating code for the 
+     Return a target triple suitable for generating code for the
      current process.
 
-     EXAMPLE: The default triple from ``get_default_triple()`` 
-     is not suitable when LLVM is compiled for 32-bit, but the 
+     EXAMPLE: The default triple from ``get_default_triple()``
+     is not suitable when LLVM is compiled for 32-bit, but the
      process is executing in 64-bit mode.
 
 * .. function:: get_object_format(triple=None)
 
-     Get the object format for the given *triple* string, or the 
-     default triple if ``None``. Returns a string such as 
+     Get the object format for the given *triple* string, or the
+     default triple if ``None``. Returns a string such as
      ``"ELF"``, ``"COFF"`` or ``"MachO"``.
 
 * .. function:: get_host_cpu_name()
@@ -48,26 +48,26 @@ Functions
 
 * .. function:: get_host_cpu_features()
 
-     Return a dictionary-like object indicating the CPU features 
-     for the current architecture and whether they are enabled 
+     Return a dictionary-like object indicating the CPU features
+     for the current architecture and whether they are enabled
      for this CPU.
 
-     The key-value pairs contain the feature name 
-     as a string and a boolean indicating whether the feature is 
+     The key-value pairs contain the feature name
+     as a string and a boolean indicating whether the feature is
      available.
 
-     The returned value is an instance of the 
-     ``FeatureMap`` class, which adds a new method 
-     ``.flatten()`` for returning a string suitable for use 
-     as the ``features`` argument to 
+     The returned value is an instance of the
+     ``FeatureMap`` class, which adds a new method
+     ``.flatten()`` for returning a string suitable for use
+     as the ``features`` argument to
      :meth:`Target.create_target_machine()`.
 
-     If LLVM has not implemented this feature or it fails to get 
+     If LLVM has not implemented this feature or it fails to get
      the information, a ``RuntimeError`` exception is raised.
 
 * .. function:: create_target_data(data_layout)
 
-     Create a :class:`TargetData` representing the given 
+     Create a :class:`TargetData` representing the given
      *data_layout* string.
 
 Classes
@@ -75,27 +75,31 @@ Classes
 
 .. class:: TargetData
 
-   Provides functionality around a given data layout. It 
-   specifies how the different types are to be represented in 
+   Provides functionality around a given data layout. It
+   specifies how the different types are to be represented in
    memory. Use :func:`create_target_data` to instantiate.
 
    * .. method:: get_abi_size(type)
 
-        Get the ABI-mandated size of a :class:`TypeRef` object. 
+        Get the ABI-mandated size of a :class:`TypeRef` object.
         Returns an integer.
 
    * .. method:: get_pointee_abi_size(type)
 
-        Similar to :meth:`get_abi_size`, but assumes that *type* is 
-        an LLVM pointer type and returns the ABI-mandated size of 
-        the type pointed to. This is useful for a global 
-        variable, whose type is really a pointer to the declared 
+        Similar to :meth:`get_abi_size`, but assumes that *type* is
+        an LLVM pointer type and returns the ABI-mandated size of
+        the type pointed to. This is useful for a global
+        variable, whose type is really a pointer to the declared
         type.
 
    * .. method:: get_pointee_abi_alignment(type)
 
-        Similar to :meth:`get_pointee_abi_size`, but returns the 
+        Similar to :meth:`get_pointee_abi_size`, but returns the
         ABI-mandated alignment rather than the ABI size.
+
+   * .. method:: get_element_offset(type, position)
+
+        Computes the byte offset of the struct element at position.
 
 .. class:: Target
 
@@ -104,14 +108,14 @@ Classes
 
    * .. classmethod:: from_triple(triple)
 
-        Create a new :class:`Target` instance for the given 
+        Create a new :class:`Target` instance for the given
         *triple* string denoting the target platform.
 
    * .. classmethod:: from_default_triple()
 
-        Create a new :class:`Target` instance for the default 
-        platform that LLVM is configured to produce code for. 
-        This is equivalent to calling 
+        Create a new :class:`Target` instance for the default
+        platform that LLVM is configured to produce code for.
+        This is equivalent to calling
         ``Target.from_triple(get_default_triple())``.
 
    The following attributes and methods are available:
@@ -133,25 +137,25 @@ Classes
    * .. method:: create_target_machine(cpu='', features='', \
           opt=2, reloc='default', codemodel='jitdefault')
 
-        Create a new :class:`TargetMachine` instance for this 
-        target and with the given options: 
+        Create a new :class:`TargetMachine` instance for this
+        target and with the given options:
 
-        * *cpu* is an optional CPU name to specialize for.  
-        * *features* is a comma-separated list of target-specific 
-          features to enable or disable.  
-        * *opt* is the optimization level, from 0 to 3.  
-        * *reloc* is the relocation model.  
-        * *codemodel* is the code model.  
+        * *cpu* is an optional CPU name to specialize for.
+        * *features* is a comma-separated list of target-specific
+          features to enable or disable.
+        * *opt* is the optimization level, from 0 to 3.
+        * *reloc* is the relocation model.
+        * *codemodel* is the code model.
 
-        The defaults for reloc and codemodel are appropriate for 
+        The defaults for reloc and codemodel are appropriate for
         JIT compilation.
 
-        TIP: To list the available CPUs and features for a 
+        TIP: To list the available CPUs and features for a
         target, run the command ``llc -mcpu=help``.
 
 .. class:: TargetMachine
 
-   Holds all the settings necessary for proper code generation, 
+   Holds all the settings necessary for proper code generation,
    including target information and compiler options. Instantiate
    using :meth:`Target.create_target_machine`.
 
@@ -162,40 +166,40 @@ Classes
 
    * .. method:: emit_object(module)
 
-        Represent the compiled *module*---a :class:`ModuleRef` 
-        instance---as a code object that is suitable for use 
+        Represent the compiled *module*---a :class:`ModuleRef`
+        instance---as a code object that is suitable for use
         with the platform's linker. Returns a bytestring.
 
    * .. method:: set_asm_verbosity(is_verbose)
 
-        Set whether this target machine emits assembly with 
-        human-readable comments, such as those describing control 
+        Set whether this target machine emits assembly with
+        human-readable comments, such as those describing control
         flow or debug information.
 
    * .. method:: emit_assembly(module)
 
-        Return a string representing the compiled *module*'s native 
-        assembler. You must first call 
+        Return a string representing the compiled *module*'s native
+        assembler. You must first call
         :func:`initialize_native_asmprinter()`.
 
    * .. attribute:: target_data
 
-        The :class:`TargetData` associated with this target 
+        The :class:`TargetData` associated with this target
         machine.
 
 
 .. class:: FeatureMap
 
-   Stores processor feature information in a dictionary-like 
-   object. This class extends ``dict`` and adds only the 
+   Stores processor feature information in a dictionary-like
+   object. This class extends ``dict`` and adds only the
    ``.flatten()`` method.
 
    .. method:: flatten(sort=True)
 
-      Returns a string representation of the stored information 
+      Returns a string representation of the stored information
       that is suitable for use in the ``features`` argument of
       :meth:`Target.create_target_machine()`.
-      
-      If the ``sort`` keyword argument is 
-      ``True``---the default---the features are sorted by name 
+
+      If the ``sort`` keyword argument is
+      ``True``---the default---the features are sorted by name
       to give a stable ordering between Python sessions.

--- a/ffi/targets.cpp
+++ b/ffi/targets.cpp
@@ -119,6 +119,15 @@ LLVMPY_ABISizeOfType(LLVMTargetDataRef TD, LLVMTypeRef Ty)
 }
 
 API_EXPORT(long long)
+LLVMPY_OffsetOfElement(LLVMTargetDataRef TD, LLVMTypeRef Ty, int Element)
+{
+    llvm::Type *tp = llvm::unwrap(Ty);
+    if (!tp->isStructTy())
+        return -1;
+    return (long long) LLVMOffsetOfElement(TD, Ty, Element);
+}
+
+API_EXPORT(long long)
 LLVMPY_ABISizeOfElementType(LLVMTargetDataRef TD, LLVMTypeRef Ty)
 {
     llvm::Type *tp = llvm::unwrap(Ty);

--- a/llvmlite/binding/targets.py
+++ b/llvmlite/binding/targets.py
@@ -133,6 +133,18 @@ class TargetData(ffi.ObjectRef):
         """
         return ffi.lib.LLVMPY_ABISizeOfType(self, ty)
 
+    def get_element_offset(self, ty, position):
+        """
+        Get byte offset of type's ty element at the given position
+        """
+
+        offset = ffi.lib.LLVMPY_OffsetOfElement(self, ty, position)
+        if offset == -1:
+            raise ValueError("Could not determined offset of {}th "
+                    "element of the type '{}'. Is it a struct type?".format(
+                    position, str(ty)))
+        return offset
+
     def get_pointee_abi_size(self, ty):
         """
         Get ABI size of pointee type of LLVM pointer type *ty*.
@@ -342,6 +354,11 @@ ffi.lib.LLVMPY_DisposeTargetData.argtypes = [
 ffi.lib.LLVMPY_ABISizeOfType.argtypes = [ffi.LLVMTargetDataRef,
                                          ffi.LLVMTypeRef]
 ffi.lib.LLVMPY_ABISizeOfType.restype = c_longlong
+
+ffi.lib.LLVMPY_OffsetOfElement.argtypes = [ffi.LLVMTargetDataRef,
+                                           ffi.LLVMTypeRef,
+                                           c_int]
+ffi.lib.LLVMPY_OffsetOfElement.restype = c_longlong
 
 ffi.lib.LLVMPY_ABISizeOfElementType.argtypes = [ffi.LLVMTargetDataRef,
                                                 ffi.LLVMTypeRef]

--- a/llvmlite/tests/test_binding.py
+++ b/llvmlite/tests/test_binding.py
@@ -916,6 +916,26 @@ class TestTargetData(BaseTest):
         glob = self.glob()
         self.assertEqual(td.get_abi_size(glob.type), 8)
 
+    def test_get_pointee_abi_size(self):
+        td = self.target_data()
+
+        glob = self.glob()
+        self.assertEqual(td.get_pointee_abi_size(glob.type), 4)
+
+        glob = self.glob("glob_struct")
+        self.assertEqual(td.get_pointee_abi_size(glob.type), 24)
+
+    def test_get_struct_element_offset(self):
+        td = self.target_data()
+        glob = self.glob("glob_struct")
+
+        with self.assertRaises(ValueError):
+            td.get_element_offset(glob.type, 0)
+
+        struct_type = glob.type.element_type
+        self.assertEqual(td.get_element_offset(struct_type, 0), 0)
+        self.assertEqual(td.get_element_offset(struct_type, 1), 8)
+
 
 class TestTargetMachine(BaseTest):
 


### PR DESCRIPTION
`LLVMOffsetOfElement` is useful when working with structs from a compiled module. This PR exposes this functionality in python.