### PR TITLE
Add shutdown detection to ObjectRef __del__ method.

### DIFF
--- a/llvmlite/binding/ffi.py
+++ b/llvmlite/binding/ffi.py
@@ -165,7 +165,8 @@ class OutputString(object):
         # Avoid errors trying to rely on globals and modules at interpreter
         # shutdown.
         if not _is_shutting_down():
-            self.close()
+            if self.close is not None:
+                self.close()
 
     def __str__(self):
         if self._ptr is None:
@@ -239,9 +240,10 @@ class ObjectRef(object):
     def __exit__(self, exc_type, exc_val, exc_tb):
         self.close()
 
-    def __del__(self):
-        if self.close is not None:
-            self.close()
+    def __del__(self, _is_shutting_down=_is_shutting_down):
+        if not _is_shutting_down():
+            if self.close is not None:
+                self.close()
 
     def __bool__(self):
         return bool(self._ptr)


### PR DESCRIPTION
On older Pythons (<3.4) the shutdown sequence sets globals etc
to None to help gc. This means that the calling of a global as
part of `__del__` as occurs in `ffi::ObjectRef` leads to error
messages like:
`Exception TypeError: "'NoneType' object is not callable" in...`

Using the already existing shutdown detection mechanism in the
`__del__` it's possible to avoid calling the global and as a
result stops these message/calling None. The LLVM object will
leak either way, at least this way is leaks quietly.

Fixes #350
Fixes numba/numba#2818