### PR TITLE
Use native cmake on armv7l

### DIFF
--- a/conda-recipes/llvmdev/meta.yaml
+++ b/conda-recipes/llvmdev/meta.yaml
@@ -40,7 +40,7 @@ requirements:
     # irrespective of python version
     - {{ compiler('c') }} # [unix and not (armv6l or armv7l or aarch64)]
     - {{ compiler('cxx') }} # [unix and not (armv6l or armv7l or aarch64)]
-    - cmake
+    - cmake # [not (armv6l or armv7l)] 
     # Needed to unpack the source tarball
     - m2w64-xz  # [py27 and win]
     # ninja not currently used, bld.bat needs an update


### PR DESCRIPTION
As title, required as toolchain has incompatible conda packages.