### PR TITLE
Normalize replace_* behaviour and add docs

### DIFF
--- a/docs/source/user-guide/ir/values.rst
+++ b/docs/source/user-guide/ir/values.rst
@@ -346,6 +346,10 @@ Use the helper methods on the :class:`IRBuilder` class.
         Add an instruction-specific metadata *name* pointing to the
         given metadata *node*---an :class:`MDValue`.
 
+   * .. method:: replace_usage(old, new)
+
+        Replace the operand *old* with the other instruction *new*.
+
    * .. attribute:: function
 
         The function that contains this instruction.

--- a/llvmlite/ir/_utils.py
+++ b/llvmlite/ir/_utils.py
@@ -37,6 +37,12 @@ class NameScope(object):
 
 class _StrCaching(object):
 
+    def _clear_string_cache(self):
+        try:
+            del self.__cached_str
+        except AttributeError:
+            pass
+
     def __str__(self):
         try:
             return self.__cached_str

--- a/llvmlite/ir/instructions.py
+++ b/llvmlite/ir/instructions.py
@@ -44,6 +44,7 @@ class Instruction(NamedValue, _HasMetadata):
             for op in self.operands:
                 ops.append(new if op is old else op)
             self.operands = tuple(ops)
+            self._clear_string_cache()
 
     def __repr__(self):
         return "<ir.%s %r of type '%s', opname %r, operands %r>" % (

--- a/llvmlite/ir/values.py
+++ b/llvmlite/ir/values.py
@@ -800,6 +800,7 @@ class Block(NamedValue):
                 instr.replace_usage(old, new)
 
 
+
 class BlockAddress(Value):
     """
     The address of a basic block.

--- a/llvmlite/tests/test_ir.py
+++ b/llvmlite/tests/test_ir.py
@@ -489,6 +489,12 @@ class TestBlock(TestBase):
         d = builder.sub(a, b, 'd')
         builder.mul(d, b, 'e')
         f = ir.Instruction(block, a.type, 'sdiv', (c, b), 'f')
+        self.check_block(block, """\
+            my_block:
+                %"c" = add i32 %".1", %".2"
+                %"d" = sub i32 %".1", %".2"
+                %"e" = mul i32 %"d", %".2"
+            """)
         block.replace(d, f)
         self.check_block(block, """\
             my_block:
@@ -635,6 +641,24 @@ class TestBuildInstructions(TestBase):
             my_block:
                 %"c" = sub i32 0, %".1"
                 %"d" = xor i32 %".2", -1
+            """)
+
+    def replace_operand(self):
+        block = self.block(name='my_block')
+        builder = ir.IRBuilder(block)
+        a, b = builder.function.args[:2]
+        undef1 = ir.Constant(ir.IntType(32), ir.Undefined)
+        undef2 = ir.Constant(ir.IntType(32), ir.Undefined)
+        c = builder.add(undef1, undef2, 'c')
+        self.check_block(block, """\
+            my_block:
+                %"c" = add i32 undef, undef
+            """)
+        c.replace_usage(undef1, a)
+        c.replace_usage(undef2, b)
+        self.check_block(block, """\
+            my_block:
+                %"c" = add i32 %".1", %".2"
             """)
 
     def test_integer_comparisons(self):

--- a/llvmlite/tests/test_ir.py
+++ b/llvmlite/tests/test_ir.py
@@ -643,7 +643,7 @@ class TestBuildInstructions(TestBase):
                 %"d" = xor i32 %".2", -1
             """)
 
-    def replace_operand(self):
+    def test_replace_operand(self):
         block = self.block(name='my_block')
         builder = ir.IRBuilder(block)
         a, b = builder.function.args[:2]


### PR DESCRIPTION
#420 got me looking: the `replace_usage` doesn't have any documentation. Also there seem to be confusing behavior caused by instruction representation caching. 

This PR adds a couple of tests and a short description of `replace_usage` to the docs.