### PR TITLE
Fix pickling of IR functions and add tests

### DIFF
--- a/llvmlite/ir/values.py
+++ b/llvmlite/ir/values.py
@@ -525,6 +525,7 @@ class AttributeSet(set):
         for name in args:
             self.add(name)
 
+
     def add(self, name):
         if name not in self._known:
             raise ValueError('unknown attr {!r} for {}'.format(name, self))
@@ -546,9 +547,10 @@ class FunctionAttributes(AttributeSet):
         'sanitize_memory', 'sanitize_thread', 'ssp',
         'sspreg', 'sspstrong', 'uwtable'])
 
-    def __init__(self):
+    def __init__(self, args=()):
         self._alignstack = 0
         self._personality = None
+        super(FunctionAttributes, self).__init__(args)
 
     @property
     def alignstack(self):
@@ -672,10 +674,11 @@ class ArgumentAttributes(AttributeSet):
                         'nocapture', 'nonnull', 'returned', 'signext',
                         'sret', 'zeroext'])
 
-    def __init__(self):
+    def __init__(self, args=()):
         self._align = 0
         self._dereferenceable = 0
         self._dereferenceable_or_null = 0
+        super(ArgumentAttributes, self).__init__(args)
 
     @property
     def align(self):

--- a/llvmlite/ir/values.py
+++ b/llvmlite/ir/values.py
@@ -128,7 +128,7 @@ class Constant(_StrCaching, _StringReferenceCaching, _ConstOpMixin, Value):
         if self.constant is None:
             val = self.type.null
 
-        elif self.constant is Undefined:
+        elif isinstance(self.constant, _Undefined):
             val = "undef"
 
         elif isinstance(self.constant, bytearray):

--- a/llvmlite/tests/test_ir.py
+++ b/llvmlite/tests/test_ir.py
@@ -193,6 +193,12 @@ class TestFunction(TestBase):
         powi2 = module.declare_intrinsic('llvm.powi', [dbl])
         self.assertIs(powi, powi2)
 
+    def test_pickling(self):
+        fn = self.function()
+        data = pickle.dumps(fn, protocol=-1)
+        new_fn = pickle.loads(data)
+        self.assertEqual(str(fn), str(new_fn))
+
 
 class TestIR(TestBase):
 
@@ -465,6 +471,12 @@ class TestGlobalValues(TestBase):
             @"f" = external unnamed_addr addrspace(456) global i32
             @"g" = internal global i32 123, align 16
             """)
+
+    def test_pickle(self):
+        mod = self.module()
+        data = pickle.dumps(mod)
+        new_mod = pickle.loads(data)
+        self.assertEquals(str(mod), str(new_mod))
 
 
 class TestBlock(TestBase):

--- a/llvmlite/tests/test_ir.py
+++ b/llvmlite/tests/test_ir.py
@@ -476,7 +476,7 @@ class TestGlobalValues(TestBase):
         mod = self.module()
         data = pickle.dumps(mod)
         new_mod = pickle.loads(data)
-        self.assertEquals(str(mod), str(new_mod))
+        self.assertEqual(str(mod), str(new_mod))
 
 
 class TestBlock(TestBase):
@@ -1860,6 +1860,13 @@ class TestConstant(TestBase):
         # Invalid number of args
         with self.assertRaises(ValueError):
             ir.Constant(st2, (4, 5, 6))
+
+    def test_undefined_literal_struct_pickling(self):
+        i8 = ir.IntType(8)
+        st = ir.Constant(ir.LiteralStructType([i8, i8]), ir.Undefined)
+        data = pickle.dumps(st)
+        new_st = pickle.loads(data)
+        self.assertEqual(str(st), str(new_st))
 
     def test_type_instantiaton(self):
         """


### PR DESCRIPTION
Pickling of the `ir.Function` instances was broken due to interaction of optional arguments in `AttributeSet` constructor and it's children. This PR also adds a couple of tests for this.