### PR TITLE
Decimal and Half Precision Float Types

### DIFF
--- a/llvmlite/ir/types.py
+++ b/llvmlite/ir/types.py
@@ -316,7 +316,35 @@ class DoubleType(_BaseFloatType):
         return _format_double(value)
 
 
-for _cls in (FloatType, DoubleType):
+class DecimalType(_BaseFloatType):
+    """
+    The type for 128 bits floats.
+    """
+    null = '0.0'
+    intrinsic_name = 'f128'
+
+    def __str__(self):
+        return 'fp128'
+
+    def format_constant(self, value):
+        return _format_double(value)
+
+
+class HalfPrecisionFloatType(_BaseFloatType):
+    """
+    The type for 16 bits floats.
+    """
+    null = '0.0'
+    intrinsic_name = 'f16'
+
+    def __str__(self):
+        return 'half'
+
+    def format_constant(self, value):
+        return _format_double(value)
+
+
+for _cls in (FloatType, DoubleType, DecimalType, HalfPrecisionFloatType):
     _cls._create_instance()
 
 


### PR DESCRIPTION
I've added support for 16 bits and 128 bits wide floating points, I'm still unsure for the naming so you can comment on that if you wish. There are 2 more types specified in [https://releases.llvm.org/6.0.0/docs/LangRef.html#floating-point-types](LLVM's documentation) (ppc_fp128 and x86_fp80) but I'm unsure of the use cases and if someone wants them.