### PR TITLE
llvm lld integration, merge #428

### DIFF
--- a/conda-recipes/llvmdev/meta.yaml
+++ b/conda-recipes/llvmdev/meta.yaml
@@ -1,17 +1,18 @@
 {% set shortversion = "7.0" %}
 {% set version = "7.0.0" %}
-{% set sha256 = "8bc1f844e6cbde1b652c19c1edebc1864456fd9c78b8c1bea038e51b363fe222" %}
-{% set build_number = "0" %}
+{% set sha256_llvm = "8bc1f844e6cbde1b652c19c1edebc1864456fd9c78b8c1bea038e51b363fe222" %}
+{% set sha256_lld = "fbcf47c5e543f4cdac6bb9bbbc6327ff24217cd7eafc5571549ad6d237287f9c" %}
+{% set build_number = "1" %}
 
 package:
   name: llvmdev
   version: {{ version }}
 
 source:
-  fn: llvm-{{ version }}.src.tar.xz
-  url: http://llvm.org/releases/{{ version }}/llvm-{{ version }}.src.tar.xz
-  sha256: {{ sha256 }}
-  patches:
+  - url: http://llvm.org/releases/{{ version }}/llvm-{{ version }}.src.tar.xz
+    fn: llvm-{{ version }}.src.tar.xz
+    sha256: {{ sha256_llvm }}
+    patches:
     # http://lists.llvm.org/pipermail/llvm-dev/2016-January/094520.html
     - ../llvm-lto-static.patch   # [win]
     - ../partial-testing.patch
@@ -28,6 +29,11 @@ source:
     # for details:
     - 0001-RuntimeDyld-Fix-a-bug-in-RuntimeDyld-loadObjectImpl-.patch
     - 0001-RuntimeDyld-Add-test-case-that-was-accidentally-left.patch
+
+  - url: http://releases.llvm.org/{{ version }}/lld-{{ version }}.src.tar.xz
+    fn: lld-{{ version }}.src.tar.xz
+    sha256: {{ sha256_lld }}
+    folder: tools/lld
 
 build:
   number: {{ build_number }}
@@ -85,6 +91,10 @@ test:
     # Test for ../twine_cfg_undefined_behavior.patch
     - $PREFIX/bin/opt -dot-cfg cfg_test.ll                   # [not win]
     - python test_cfg_dot.py                                 # [not win]
+
+    # LLD tests
+    - ld.lld --version                                       # [unix]
+    - lld-link /?                                            # [win]
 
 about:
   home: http://llvm.org/


### PR DESCRIPTION
This merges #428 from @certik (with thanks), with current mainline post LLVM 7.0.0 upgrade. It essentially adds the building of `lld` to the `llvmdev` build. Outstanding effort is needed for the same on wheels. Opening this PR for CI testing.