### PR TITLE
Add another thread for RPi builds.

### DIFF
--- a/conda-recipes/llvmdev/build.sh
+++ b/conda-recipes/llvmdev/build.sh
@@ -71,7 +71,7 @@ cmake -G'Unix Makefiles'     \
 
 ARCH=`uname -m`
 if [ $ARCH == 'armv7l' ]; then # RPi need thread count throttling
-    make -j1 VERBOSE=1
+    make -j2 VERBOSE=1
 else
     make -j${CPU_COUNT} VERBOSE=1
 fi


### PR DESCRIPTION
This adds another thread for LLVM building, RPi3B+ can handle it.