### PR TITLE
Truncate long label names when adding label suffix.

### DIFF
--- a/llvmlite/ir/builder.py
+++ b/llvmlite/ir/builder.py
@@ -134,6 +134,22 @@ def _castop(opname, cls=instructions.CastInstr):
     return wrap
 
 
+def _label_suffix(label, suffix):
+    """Returns (label + suffix) or a truncated version if it's too long.
+    Parameters
+    ----------
+    label : str
+        Label name
+    suffix : str
+        Label suffix
+    """
+    if len(label) > 50:
+        nhead = 25
+        return ''.join([label[:nhead], '..', suffix])
+    else:
+        return label + suffix
+
+
 class IRBuilder(object):
     def __init__(self, block=None):
         self._block = block
@@ -245,8 +261,8 @@ class IRBuilder(object):
         for LLVM's optimizers to account for that.
         """
         bb = self.basic_block
-        bbif = self.append_basic_block(name=bb.name + '.if')
-        bbend = self.append_basic_block(name=bb.name + '.endif')
+        bbif = self.append_basic_block(name=_label_suffix(bb.name, '.if'))
+        bbend = self.append_basic_block(name=_label_suffix(bb.name, '.endif'))
         br = self.cbranch(pred, bbif, bbend)
         if likely is not None:
             br.set_weights([99, 1] if likely else [1, 99])
@@ -273,9 +289,9 @@ class IRBuilder(object):
                     # emit instructions for when the predicate is false
         """
         bb = self.basic_block
-        bbif = self.append_basic_block(name=bb.name + '.if')
-        bbelse = self.append_basic_block(name=bb.name + '.else')
-        bbend = self.append_basic_block(name=bb.name + '.endif')
+        bbif = self.append_basic_block(name=_label_suffix(bb.name, '.if'))
+        bbelse = self.append_basic_block(name=_label_suffix(bb.name, '.else'))
+        bbend = self.append_basic_block(name=_label_suffix(bb.name, '.endif'))
         br = self.cbranch(pred, bbif, bbelse)
         if likely is not None:
             br.set_weights([99, 1] if likely else [1, 99])

--- a/llvmlite/tests/test_ir.py
+++ b/llvmlite/tests/test_ir.py
@@ -1518,6 +1518,34 @@ class TestBuilderMisc(TestBase):
                 br label %"one.endif"
             """)
 
+
+    def test_if_then_long_label(self):
+        full_label = 'Long'*20
+        block = self.block(name=full_label)
+        builder = ir.IRBuilder(block)
+        z = ir.Constant(int1, 0)
+        a = builder.add(z, z, 'a')
+        with builder.if_then(a) as bbend:
+            b = builder.add(z, z, 'b')
+            with builder.if_then(b) as bbend:
+                c = builder.add(z, z, 'c')
+        builder.ret_void()
+        self.check_func_body(builder.function, """\
+            {full_label}:
+                %"a" = add i1 0, 0
+                br i1 %"a", label %"{label}.if", label %"{label}.endif"
+            {label}.if:
+                %"b" = add i1 0, 0
+                br i1 %"b", label %"{label}.if.if", label %"{label}.if.endif"
+            {label}.endif:
+                ret void
+            {label}.if.if:
+                %"c" = add i1 0, 0
+                br label %"{label}.if.endif"
+            {label}.if.endif:
+                br label %"{label}.endif"
+            """.format(full_label=full_label, label=full_label[:25] + '..'))
+
     def test_if_then_likely(self):
         def check(likely):
             block = self.block(name='one')


### PR DESCRIPTION
Fixes #453.
Also the long label names are not useful anyway.

Label names will now be truncated when too long.  The cutoff point is picked arbitrarily.