### PR TITLE
LLVM 7 changed memset intrinsic signature, adjust it

### DIFF
--- a/llvmlite/ir/module.py
+++ b/llvmlite/ir/module.py
@@ -179,7 +179,7 @@ class Module(object):
         elif len(tys) == 2:
             if intrinsic == 'llvm.memset':
                 tys = [tys[0], types.IntType(8), tys[1],
-                       types.IntType(32), types.IntType(1)]
+                    types.IntType(1)]
                 fnty = types.FunctionType(types.VoidType(), tys)
             elif intrinsic in {'llvm.cttz', 'llvm.ctlz'}:
                 tys = [tys[0], types.IntType(1)]

--- a/llvmlite/ir/module.py
+++ b/llvmlite/ir/module.py
@@ -188,7 +188,7 @@ class Module(object):
                 _error()
         elif len(tys) == 3:
             if intrinsic in ('llvm.memcpy', 'llvm.memmove'):
-                tys = tys + [types.IntType(32), types.IntType(1)]
+                tys = tys + [types.IntType(1)]
                 fnty = types.FunctionType(types.VoidType(), tys)
             elif intrinsic == 'llvm.fma':
                 tys = [tys[0]] * 3

--- a/llvmlite/tests/test_ir.py
+++ b/llvmlite/tests/test_ir.py
@@ -198,7 +198,7 @@ class TestFunction(TestBase):
         self.check_descr(self.descr(memset).strip(), """\
             declare void @"llvm.memset.p0i8.i32"(i8* %".1", i8 %".2", i32 %".3", i1 %".4")""")
         self.check_descr(self.descr(memcpy).strip(), """\
-            declare void @"llvm.memcpy.p0i8.p0i8.i32"(i8* %".1", i8* %".2", i32 %".3", i32 %".4", i1 %".5")""")
+            declare void @"llvm.memcpy.p0i8.p0i8.i32"(i8* %".1", i8* %".2", i32 %".3", i1 %".4")""")
         self.check_descr(self.descr(assume).strip(), """\
             declare void @"llvm.assume"(i1 %".1")""")
 

--- a/llvmlite/tests/test_ir.py
+++ b/llvmlite/tests/test_ir.py
@@ -196,7 +196,7 @@ class TestFunction(TestBase):
         self.check_descr(self.descr(powi).strip(), """\
             declare double @"llvm.powi.f64"(double %".1", i32 %".2")""")
         self.check_descr(self.descr(memset).strip(), """\
-            declare void @"llvm.memset.p0i8.i32"(i8* %".1", i8 %".2", i32 %".4", i1 %".5")""")
+            declare void @"llvm.memset.p0i8.i32"(i8* %".1", i8 %".2", i32 %".3", i1 %".4")""")
         self.check_descr(self.descr(memcpy).strip(), """\
             declare void @"llvm.memcpy.p0i8.p0i8.i32"(i8* %".1", i8* %".2", i32 %".3", i32 %".4", i1 %".5")""")
         self.check_descr(self.descr(assume).strip(), """\

--- a/llvmlite/tests/test_ir.py
+++ b/llvmlite/tests/test_ir.py
@@ -196,7 +196,7 @@ class TestFunction(TestBase):
         self.check_descr(self.descr(powi).strip(), """\
             declare double @"llvm.powi.f64"(double %".1", i32 %".2")""")
         self.check_descr(self.descr(memset).strip(), """\
-            declare void @"llvm.memset.p0i8.i32"(i8* %".1", i8 %".2", i32 %".3", i32 %".4", i1 %".5")""")
+            declare void @"llvm.memset.p0i8.i32"(i8* %".1", i8 %".2", i32 %".4", i1 %".5")""")
         self.check_descr(self.descr(memcpy).strip(), """\
             declare void @"llvm.memcpy.p0i8.p0i8.i32"(i8* %".1", i8* %".2", i32 %".3", i32 %".4", i1 %".5")""")
         self.check_descr(self.descr(assume).strip(), """\


### PR DESCRIPTION
Since LLVM 7 memset doesn't take an alignment as a third parameter and respects first argument's alignment instead, see https://releases.llvm.org/7.0.0/docs/LangRef.html#llvm-memset-intrinsics

Also fixes `memcpy` which has experienced the same change between 6 and 7.