### PR TITLE
Fix leak on string returning APIs.

### DIFF
--- a/ffi/dylib.cpp
+++ b/ffi/dylib.cpp
@@ -19,12 +19,12 @@ LLVMPY_AddSymbol(const char *name,
 }
 
 API_EXPORT(bool)
-LLVMPY_LoadLibraryPermanently(const char *filename, char **OutError)
+LLVMPY_LoadLibraryPermanently(const char *filename, const char **OutError)
 {
     std::string error;
     bool failed = llvm::sys::DynamicLibrary::LoadLibraryPermanently(filename, &error);
     if (failed) {
-      *OutError = strdup(error.c_str());
+      *OutError = LLVMPY_CreateString(error.c_str());
     }
     return failed;
 }

--- a/ffi/executionengine.cpp
+++ b/ffi/executionengine.cpp
@@ -76,7 +76,7 @@ static
 LLVMExecutionEngineRef
 create_execution_engine(LLVMModuleRef M,
                         LLVMTargetMachineRef TM,
-                        char **OutError
+                        const char **OutError
                         )
 {
     LLVMExecutionEngineRef ee = nullptr;
@@ -91,7 +91,7 @@ create_execution_engine(LLVMModuleRef M,
 
 
     if (!engine)
-        *OutError = strdup(err.c_str());
+        *OutError = LLVMPY_CreateString(err.c_str());
     else
         ee = llvm::wrap(engine);
     return ee;
@@ -100,7 +100,7 @@ create_execution_engine(LLVMModuleRef M,
 API_EXPORT(LLVMExecutionEngineRef)
 LLVMPY_CreateMCJITCompiler(LLVMModuleRef M,
                            LLVMTargetMachineRef TM,
-                           char **OutError)
+                           const char **OutError)
 {
     return create_execution_engine(M, TM, OutError);
 }

--- a/ffi/value.cpp
+++ b/ffi/value.cpp
@@ -253,7 +253,7 @@ LLVMPY_AttributeListIterNext(LLVMAttributeListIteratorRef GI)
     using namespace llvm;
     AttributeListIterator* iter = unwrap(GI);
     if (iter->cur != iter->end) {
-        return strdup((&*iter->cur++)->getAsString().c_str());
+        return LLVMPY_CreateString((&*iter->cur++)->getAsString().c_str());
     } else {
       return NULL;
     }
@@ -265,7 +265,7 @@ LLVMPY_AttributeSetIterNext(LLVMAttributeSetIteratorRef GI)
     using namespace llvm;
     AttributeSetIterator* iter = unwrap(GI);
     if (iter->cur != iter->end) {
-        return strdup((&*iter->cur++)->getAsString().c_str());
+        return LLVMPY_CreateString((&*iter->cur++)->getAsString().c_str());
     } else {
       return NULL;
     }
@@ -389,7 +389,10 @@ LLVMPY_TypeOf(LLVMValueRef Val)
 API_EXPORT(const char *)
 LLVMPY_PrintType(LLVMTypeRef type)
 {
-    return LLVMPrintTypeToString(type);
+    char *str = LLVMPrintTypeToString(type);
+    const char *out = LLVMPY_CreateString(str);
+    LLVMDisposeMessage(str);
+    return out;
 }
 
 API_EXPORT(const char *)
@@ -400,9 +403,9 @@ LLVMPY_GetTypeName(LLVMTypeRef type)
     llvm::Type* unwrapped = llvm::unwrap(type);
     llvm::StructType* ty = llvm::dyn_cast<llvm::StructType>(unwrapped);
     if (ty && !ty->isLiteral()) {
-        return strdup(ty->getStructName().str().c_str());
+        return LLVMPY_CreateString(ty->getStructName().str().c_str());
     }
-    return strdup("");
+    return LLVMPY_CreateString("");
 }
 
 API_EXPORT(bool)
@@ -501,9 +504,9 @@ LLVMPY_GetOpcodeName(LLVMValueRef Val)
     llvm::Value* unwrapped = llvm::unwrap(Val);
     llvm::Instruction* inst = llvm::dyn_cast<llvm::Instruction>(unwrapped);
     if (inst) {
-        return strdup(inst->getOpcodeName());
+        return LLVMPY_CreateString(inst->getOpcodeName());
     }
-    return strdup("");
+    return LLVMPY_CreateString("");
 }
 
 

--- a/llvmlite/binding/ffi.py
+++ b/llvmlite/binding/ffi.py
@@ -149,8 +149,20 @@ class OutputString(object):
     """
     _as_parameter_ = _DeadPointer()
 
-    def __init__(self, owned=True):
-        self._ptr = ctypes.c_char_p(None)
+    @classmethod
+    def from_return(cls, ptr):
+        """Constructing from a pointer returned from C-API.
+        The pointer must be allocated with LLVMPY_CreateString.
+
+        Note
+        ----
+        Because ctypes auto convert *restype* of *c_char_p* into a python
+        string, we must use *c_void_p* to obtain the raw pointer.
+        """
+        return cls(init=ctypes.cast(ptr, ctypes.c_char_p))
+
+    def __init__(self, owned=True, init=None):
+        self._ptr = init if init is not None else ctypes.c_char_p(None)
         self._as_parameter_ = ctypes.byref(self._ptr)
         self._owned = owned
 
@@ -185,6 +197,27 @@ class OutputString(object):
         return bool(self._ptr)
 
     __nonzero__ = __bool__
+
+    @property
+    def bytes(self):
+        """Get the raw bytes of content of the char pointer.
+        """
+        return self._ptr.value
+
+
+def ret_string(ptr):
+    """To wrap string return-value from C-API.
+    """
+    if ptr is not None:
+        return str(OutputString.from_return(ptr))
+
+def ret_bytes(ptr):
+    """To wrap bytes return-value from C-API.
+    """
+    if ptr is not None:
+        return OutputString.from_return(ptr).bytes
+
+
 
 
 class ObjectRef(object):

--- a/llvmlite/binding/ffi.py
+++ b/llvmlite/binding/ffi.py
@@ -151,12 +151,12 @@ class OutputString(object):
 
     @classmethod
     def from_return(cls, ptr):
-        """Constructing from a pointer returned from C-API.
+        """Constructing from a pointer returned from the C-API.
         The pointer must be allocated with LLVMPY_CreateString.
 
         Note
         ----
-        Because ctypes auto convert *restype* of *c_char_p* into a python
+        Because ctypes auto-converts *restype* of *c_char_p* into a python
         string, we must use *c_void_p* to obtain the raw pointer.
         """
         return cls(init=ctypes.cast(ptr, ctypes.c_char_p))

--- a/llvmlite/binding/value.py
+++ b/llvmlite/binding/value.py
@@ -1,4 +1,4 @@
-from ctypes import POINTER, c_char_p, c_int, c_size_t, c_uint, c_bool
+from ctypes import POINTER, c_char_p, c_int, c_size_t, c_uint, c_bool, c_void_p
 import enum
 
 from . import ffi
@@ -51,7 +51,7 @@ class TypeRef(ffi.ObjectRef):
         """
         Get type name
         """
-        return _decode_string(ffi.lib.LLVMPY_GetTypeName(self))
+        return ffi.ret_string(ffi.lib.LLVMPY_GetTypeName(self))
 
     @property
     def is_pointer(self):
@@ -71,7 +71,7 @@ class TypeRef(ffi.ObjectRef):
         return TypeRef(ffi.lib.LLVMPY_GetElementType(self))
 
     def __str__(self):
-        return _decode_string(ffi.lib.LLVMPY_PrintType(self))
+        return ffi.ret_string(ffi.lib.LLVMPY_PrintType(self))
 
 
 class ValueRef(ffi.ObjectRef):
@@ -297,7 +297,7 @@ class ValueRef(ffi.ObjectRef):
         if not self.is_instruction:
             raise ValueError('expected instruction value, got %s'
                              % (self._kind,))
-        return _decode_string(ffi.lib.LLVMPY_GetOpcodeName(self))
+        return ffi.ret_string(ffi.lib.LLVMPY_GetOpcodeName(self))
 
 
 class _ValueIterator(ffi.ObjectRef):
@@ -347,7 +347,7 @@ class _AttributeListIterator(_AttributeIterator):
         self._capi.LLVMPY_DisposeAttributeListIter(self)
 
     def _next(self):
-        return ffi.lib.LLVMPY_AttributeListIterNext(self)
+        return ffi.ret_bytes(ffi.lib.LLVMPY_AttributeListIterNext(self))
 
 
 class _AttributeSetIterator(_AttributeIterator):
@@ -356,7 +356,7 @@ class _AttributeSetIterator(_AttributeIterator):
         self._capi.LLVMPY_DisposeAttributeSetIter(self)
 
     def _next(self):
-        return ffi.lib.LLVMPY_AttributeSetIterNext(self)
+        return ffi.ret_bytes(ffi.lib.LLVMPY_AttributeSetIterNext(self))
 
 
 class _BlocksIterator(_ValueIterator):
@@ -421,8 +421,9 @@ ffi.lib.LLVMPY_SetValueName.argtypes = [ffi.LLVMValueRef, c_char_p]
 ffi.lib.LLVMPY_TypeOf.argtypes = [ffi.LLVMValueRef]
 ffi.lib.LLVMPY_TypeOf.restype = ffi.LLVMTypeRef
 
+
 ffi.lib.LLVMPY_PrintType.argtypes = [ffi.LLVMTypeRef]
-ffi.lib.LLVMPY_PrintType.restype = c_char_p
+ffi.lib.LLVMPY_PrintType.restype = c_void_p
 
 ffi.lib.LLVMPY_TypeIsPointer.argtypes = [ffi.LLVMTypeRef]
 ffi.lib.LLVMPY_TypeIsPointer.restype = c_bool
@@ -432,7 +433,7 @@ ffi.lib.LLVMPY_GetElementType.restype = ffi.LLVMTypeRef
 
 
 ffi.lib.LLVMPY_GetTypeName.argtypes = [ffi.LLVMTypeRef]
-ffi.lib.LLVMPY_GetTypeName.restype = c_char_p
+ffi.lib.LLVMPY_GetTypeName.restype = c_void_p
 
 ffi.lib.LLVMPY_GetLinkage.argtypes = [ffi.LLVMValueRef]
 ffi.lib.LLVMPY_GetLinkage.restype = c_int
@@ -495,10 +496,10 @@ ffi.lib.LLVMPY_DisposeInstructionsIter.argtypes = [ffi.LLVMInstructionsIterator]
 ffi.lib.LLVMPY_DisposeOperandsIter.argtypes = [ffi.LLVMOperandsIterator]
 
 ffi.lib.LLVMPY_AttributeListIterNext.argtypes = [ffi.LLVMAttributeListIterator]
-ffi.lib.LLVMPY_AttributeListIterNext.restype = c_char_p
+ffi.lib.LLVMPY_AttributeListIterNext.restype = c_void_p
 
 ffi.lib.LLVMPY_AttributeSetIterNext.argtypes = [ffi.LLVMAttributeSetIterator]
-ffi.lib.LLVMPY_AttributeSetIterNext.restype = c_char_p
+ffi.lib.LLVMPY_AttributeSetIterNext.restype = c_void_p
 
 ffi.lib.LLVMPY_BlocksIterNext.argtypes = [ffi.LLVMBlocksIterator]
 ffi.lib.LLVMPY_BlocksIterNext.restype = ffi.LLVMValueRef
@@ -513,4 +514,4 @@ ffi.lib.LLVMPY_OperandsIterNext.argtypes = [ffi.LLVMOperandsIterator]
 ffi.lib.LLVMPY_OperandsIterNext.restype = ffi.LLVMValueRef
 
 ffi.lib.LLVMPY_GetOpcodeName.argtypes = [ffi.LLVMValueRef]
-ffi.lib.LLVMPY_GetOpcodeName.restype = c_char_p
+ffi.lib.LLVMPY_GetOpcodeName.restype = c_void_p


### PR DESCRIPTION
* All string returning C-API must return a `LLVMPY_CreateString` allocated string and the Python side must deallocate using `LLVMPY_DisposeString` or via `OutputString`.
* Added `ret_string` and `ret_bytes` to wrap the string return-value for cleanup.
* All string returning C-API must use `c_void_p` to avoid `ctypes` auto-conversion of `c_char_p` into a python string.  