### PR TITLE
Depend on enum34 using PEP 508 environment markers

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -158,11 +158,8 @@ packages = ['llvmlite',
             'llvmlite.tests',
             ]
 
-install_requires = []
-setup_requires = []
-if sys.version_info < (3, 4):
-    install_requires.append('enum34')
-    setup_requires.append('enum34')
+install_requires = ['enum34; python_version < "3.4"']
+setup_requires = ['enum34; python_version < "3.4"']
 
 
 with open('README.rst') as f:


### PR DESCRIPTION
The recommended way to specify dependencies specific to a python
version is to use environment markers.

One downside of using if statements to specify dependencies is that it
can break applications using package managers like pipenv or poetry,
where the version of python running setup.py is not necessarily the
same verion of python being deployed.

It would certainly be fair to blame this on the package managers
themselves, but given the PEP and the fact that other packages have
solved this in the same way, I think it's worth fixing on this end.

See:
* https://www.python.org/dev/peps/pep-0508/#environment-markers
* https://github.com/hynek/argon2_cffi/issues/48
* https://github.com/hynek/argon2_cffi/commit/8eed81aa