### PR TITLE
fix for block labels which contain "interesting" characters

### DIFF
--- a/llvmlite/ir/values.py
+++ b/llvmlite/ir/values.py
@@ -6,6 +6,7 @@ Instructions are in the instructions module.
 from __future__ import print_function, absolute_import
 
 import string
+import re
 
 from .. import six
 from . import types, _utils
@@ -16,7 +17,7 @@ _VALID_CHARS = (frozenset(map(ord, string.ascii_letters)) |
                 frozenset(map(ord, string.digits)) |
                 frozenset(map(ord, ' !#$%&\'()*+,-./:;<=>?@[]^_`{|}~')))
 
-_IDENTIFIER_CHARS = frozenset(string.ascii_letters + string.digits + '$._-')
+_SIMPLE_IDENTIFIER_RE = re.compile(r"[-a-zA-Z$._][-a-zA-Z$._0-9]*")
 
 
 def _escape_string(text, _map={}):
@@ -812,7 +813,7 @@ class Block(NamedValue):
         # regex do not need to be quoted: [%@][-a-zA-Z$._][-a-zA-Z$._0-9]*
         # Otherwise, the identifier must be quoted and escaped.
         name = self.name
-        if name[:1].isdigit() or not frozenset(name).issubset(_IDENTIFIER_CHARS):
+        if not _SIMPLE_IDENTIFIER_RE.fullmatch(name):
             name = name.replace('\\', '\\5c').replace('"', '\\22')
             name = '"{0}"'.format(name)
         return name

--- a/llvmlite/ir/values.py
+++ b/llvmlite/ir/values.py
@@ -17,7 +17,7 @@ _VALID_CHARS = (frozenset(map(ord, string.ascii_letters)) |
                 frozenset(map(ord, string.digits)) |
                 frozenset(map(ord, ' !#$%&\'()*+,-./:;<=>?@[]^_`{|}~')))
 
-_SIMPLE_IDENTIFIER_RE = re.compile(r"[-a-zA-Z$._][-a-zA-Z$._0-9]*")
+_SIMPLE_IDENTIFIER_RE = re.compile(r"[-a-zA-Z$._][-a-zA-Z$._0-9]*$")
 
 
 def _escape_string(text, _map={}):
@@ -813,7 +813,7 @@ class Block(NamedValue):
         # regex do not need to be quoted: [%@][-a-zA-Z$._][-a-zA-Z$._0-9]*
         # Otherwise, the identifier must be quoted and escaped.
         name = self.name
-        if not _SIMPLE_IDENTIFIER_RE.fullmatch(name):
+        if not _SIMPLE_IDENTIFIER_RE.match(name):
             name = name.replace('\\', '\\5c').replace('"', '\\22')
             name = '"{0}"'.format(name)
         return name


### PR DESCRIPTION
llvm will fail to parse the IR from a module if it contains a block with an "interesting" label (i.e. one which is not alphanumeric). These labels need to be quoted and escaped.

Rather than failing with a mysterious parse error, this allows llvmlite to accept the full space of strings as block labels.

(My use case is that the labels were b64 encoded hashes of AST structures. The b64 alphabet includes +, =, and /, which would randomly cause llvmlite to puke).