### PR TITLE
Mark date for 0.30 release date in the changelog

### DIFF
--- a/CHANGE_LOG
+++ b/CHANGE_LOG
@@ -1,5 +1,5 @@
-v0.30.0 (RC1: Sept 30, 2019)
-----------------------------
+v0.30.0 (Oct 9, 2019)
+---------------------
 
 This release adds support for half-precision float and schedules the
 deprecation of memset/memcpy accepting 5 arguments (cf. LLVM change).


### PR DESCRIPTION
as title