### PR TITLE
Allow instructions to be removed from blocks

### DIFF
--- a/llvmlite/ir/builder.py
+++ b/llvmlite/ir/builder.py
@@ -218,10 +218,12 @@ class IRBuilder(object):
 
     def remove(self, instr):
         """Remove the given instruction."""
-        self._block.instructions.remove(instr)
+        idx = self._block.instructions.index(instr)
+        del self._block.instructions[idx]
         if self._block.terminator == instr:
             self._block.terminator = None
-        self._anchor = min(self._anchor, len(self._block.instructions))
+        if self._anchor > idx:
+            self._anchor -= 1
 
     @contextlib.contextmanager
     def goto_block(self, block):

--- a/llvmlite/ir/builder.py
+++ b/llvmlite/ir/builder.py
@@ -216,6 +216,13 @@ class IRBuilder(object):
         """
         return self.function.append_basic_block(name)
 
+    def remove(self, instr):
+        """Remove the given instruction."""
+        self._block.instructions.remove(instr)
+        if self._block.terminator == instr:
+            self._block.terminator = None
+        self._anchor = min(self._anchor, len(self._block.instructions))
+
     @contextlib.contextmanager
     def goto_block(self, block):
         """

--- a/llvmlite/tests/test_ir.py
+++ b/llvmlite/tests/test_ir.py
@@ -1706,6 +1706,29 @@ class TestBuilderMisc(TestBase):
             three:
             """)
 
+    def test_instruction_removal(self):
+        func = self.function()
+        builder = ir.IRBuilder()
+        blk = func.append_basic_block(name='entry')
+        builder.position_at_end(blk)
+        k = ir.Constant(int32, 1234)
+        a = builder.add(k, k, 'a')
+        retvoid = builder.ret_void()
+        self.assertTrue(blk.is_terminated)
+        builder.remove(retvoid)
+        self.assertFalse(blk.is_terminated)
+        b = builder.mul(a, a, 'b')
+        c = builder.add(b, b, 'c')
+        builder.remove(c)
+        builder.ret_void()
+        self.assertTrue(blk.is_terminated)
+        self.check_block(blk, """\
+            entry:
+                %"a" = add i32 1234, 1234
+                %"b" = mul i32 %"a", %"a"
+                ret void
+        """)
+
     def test_metadata(self):
         block = self.block(name='my_block')
         builder = ir.IRBuilder(block)


### PR DESCRIPTION
Small change that allows instructions to be removed from a Block after adding them. Includes test.