### PR TITLE
Add cttz and ctlz to irbuilder docs.

### DIFF
--- a/docs/source/user-guide/ir/ir-builder.rst
+++ b/docs/source/user-guide/ir/ir-builder.rst
@@ -205,6 +205,11 @@ Integer
 
      Arithmetic, signed, right-shift *lhs* by *rhs* bits.
 
+* .. method:: IRBuilder.cttz(value, flag)
+
+     Counts trailing zero bits in *value*. Boolean *flag* indicates whether the
+     result is defined for ``0``.
+
 * .. method:: IRBuilder.add(lhs, rhs, name='', flags=())
 
      Integer add *lhs* and *rhs*.

--- a/docs/source/user-guide/ir/ir-builder.rst
+++ b/docs/source/user-guide/ir/ir-builder.rst
@@ -210,6 +210,11 @@ Integer
      Counts trailing zero bits in *value*. Boolean *flag* indicates whether the
      result is defined for ``0``.
 
+* .. method:: IRBuilder.ctlz(value, flag)
+
+     Counts leading zero bits in *value*. Boolean *flag* indicates whether the
+     result is defined for ``0``.
+
 * .. method:: IRBuilder.add(lhs, rhs, name='', flags=())
 
      Integer add *lhs* and *rhs*.

--- a/llvmlite/ir/builder.py
+++ b/llvmlite/ir/builder.py
@@ -1024,7 +1024,8 @@ class IRBuilder(object):
     @_uniop_intrinsic_with_flag("llvm.cttz")
     def cttz(self, cond, flag):
         """
-        Counts the number of trailing zeros in a variable.
+        Counts trailing zero bits in *value*. Boolean *flag* indicates whether
+        the result is defined for ``0``.
         """
 
     @_triop_intrinsic("llvm.fma")

--- a/llvmlite/ir/builder.py
+++ b/llvmlite/ir/builder.py
@@ -1018,7 +1018,8 @@ class IRBuilder(object):
     @_uniop_intrinsic_with_flag("llvm.ctlz")
     def ctlz(self, cond, flag):
         """
-        Counts the number of leading zeros in a variable.
+        Counts leading zero bits in *value*. Boolean *flag* indicates whether
+        the result is defined for ``0``.
         """
 
     @_uniop_intrinsic_with_flag("llvm.cttz")


### PR DESCRIPTION
Added `cttz` intrinsic to sphinx docs.

Should this be kept consistent with the doc-string? I think it would be useful if the doc-string had information about the flag as well.