### PR TITLE
Miscalled method and missing parameter in the documentation

### DIFF
--- a/docs/source/user-guide/ir/ir-builder.rst
+++ b/docs/source/user-guide/ir/ir-builder.rst
@@ -556,7 +556,7 @@ The following methods are all :ref:`terminators <terminator>`:
      To add non-default targets, use the
      :meth:`~SwitchInstr.add_case` method on the return value.
 
-* .. method:: IRBuilder.indirectbr(address)
+* .. method:: IRBuilder.branch_indirect(address)
 
      Jump to the basic block with the address *address*, a value
      of type `IntType(8).as_pointer()`.

--- a/docs/source/user-guide/ir/ir-builder.rst
+++ b/docs/source/user-guide/ir/ir-builder.rst
@@ -657,7 +657,7 @@ Inline assembler
 
         fty = FunctionType(IntType(64), [IntType(64),IntType(64)])
         add = builder.asm(fty, "mov $2, $0\nadd $1, $0", "=r,r,r",
-                          (arg_0, arg_1), name="asm_add")
+                          (arg_0, arg_1), True, name="asm_add")
 
 
 * .. method:: IRBuilder.load_reg(reg_type, reg_name, name='')


### PR DESCRIPTION
The method in IRBuilder is called branch_indirect, not indirectbr (https://github.com/numba/llvmlite/blob/master/llvmlite/ir/builder.py#L803)