### PR TITLE
azure-pipelines: Bump VM images.

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -3,7 +3,7 @@ jobs:
 - template: buildscripts/azure/azure-linux-macos.yml
   parameters:
     name: macOS
-    vmImage: xcode9-macos10.13
+    vmImage: macOS-10.14
     matrix:
       py27:
         PYTHON: '2.7'
@@ -48,4 +48,4 @@ jobs:
 - template: buildscripts/azure/azure-windows.yml
   parameters:
     name: Windows
-    vmImage: vs2015-win2012r2
+    vmImage: vs2017-win2016

--- a/ffi/build.py
+++ b/ffi/build.py
@@ -69,6 +69,7 @@ def find_win32_generator():
     generators = list(filter(drop_old_vs, generators))
 
     generators.append('Visual Studio 14 2015' + (' Win64' if is_64bit else ''))
+    generators.append('Visual Studio 15 2017' + (' Win64' if is_64bit else ''))
     for generator in generators:
         build_dir = tempfile.mkdtemp()
         print("Trying generator %r" % (generator,))


### PR DESCRIPTION
The old ones will be removed 03/23/2020.
Allow Visual Studio 15 2017 as cmake generator.

Signed-off-by: Jan Vesely <jano.vesely@gmail.com>