### PR TITLE
travis: Cleanup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,11 +4,13 @@
 # Reference:
 # - https://github.com/pypa/python-manylinux-demo
 
-sudo: required
+language: shell
+os: linux
+dist: xenial
 services:
   - docker
 
-matrix:
+jobs:
   include:
     - env: PYVER=cp27-cp27mu ARCH=x64
     - env: PYVER=cp35-cp35m  ARCH=x64


### PR DESCRIPTION
Use language:shell to avoid the overhead of setting up ruby.
Use new syntax keys.
Drop sudo: required.