### PR TITLE
binding: Allow empty features list

### DIFF
--- a/llvmlite/binding/targets.py
+++ b/llvmlite/binding/targets.py
@@ -59,7 +59,7 @@ def get_host_cpu_features():
     with ffi.OutputString() as out:
         outdict = FeatureMap()
         if not ffi.lib.LLVMPY_GetHostCPUFeatures(out):
-            raise RuntimeError("failed to get host cpu features.")
+            return outdict
         flag_map = {'+': True, '-': False}
         content = str(out)
         if content:  # protect against empty string

--- a/llvmlite/tests/test_binding.py
+++ b/llvmlite/tests/test_binding.py
@@ -303,23 +303,13 @@ class TestMisc(BaseTest):
         self.assertEqual(default_parts[0], triple_parts[0])
 
     def test_get_host_cpu_features(self):
-        try:
-            features = llvm.get_host_cpu_features()
-        except RuntimeError:
-            # Allow non-x86 arch to pass even if an RuntimeError is raised
-            triple = llvm.get_process_triple()
-            # For now, we know for sure that x86 is supported.
-            # We can restrict the test if we know this works on other arch.
-            is_x86 = triple.startswith('x86')
-            self.assertFalse(is_x86,
-                             msg="get_host_cpu_features() should not raise")
-            return
+        features = llvm.get_host_cpu_features()
         # Check the content of `features`
         self.assertIsInstance(features, dict)
         self.assertIsInstance(features, llvm.FeatureMap)
         for k, v in features.items():
             self.assertIsInstance(k, str)
-            self.assertTrue(k)  # feature string cannot be empty
+            self.assertTrue(k)  # single feature string cannot be empty
             self.assertIsInstance(v, bool)
         self.assertIsInstance(features.flatten(), str)
 
@@ -330,7 +320,10 @@ class TestMisc(BaseTest):
         self.assertIsNotNone(re.match(regex, "+aa"))
         self.assertIsNotNone(re.match(regex, "+a,-bb"))
         # check CpuFeature.flatten()
-        self.assertIsNotNone(re.match(regex, features.flatten()))
+        if len(features) == 0:
+            self.assertEqual(features.flatten(), "")
+        else:
+            self.assertIsNotNone(re.match(regex, features.flatten()))
 
     def test_get_host_cpu_name(self):
         cpu = llvm.get_host_cpu_name()


### PR DESCRIPTION
Return value of 0 indicates empty string/feature map:
https://github.com/llvm/llvm-project/blob/master/llvm/lib/Support/Host.cpp
Fixes: https://github.com/numba/llvmlite/issues/550

Signed-off-by: Jan Vesely <jano.vesely@gmail.com>