### PR TITLE
update install docs

### DIFF
--- a/docs/source/admin-guide/install.rst
+++ b/docs/source/admin-guide/install.rst
@@ -83,8 +83,7 @@ The manual instructions below describe the main steps, but refer to the recipe f
     #. ``D47188-svml-VF.patch``: Add support for vectorized math functions via Intel SVML
     #. ``partial-testing.patch``: Enables additional parts of the LLVM test suite
     #. ``twine_cfg_undefined_behavior.patch``: Fix obscure memory corruption bug in LLVM that hasn't been fixed in master yet
-    #. ``0001-RuntimeDyld-Fix-a-bug-in-RuntimeDyld-loadObjectImpl-.patch``: Fixes a bug relating to common symbol section size computation
-    #. ``0001-RuntimeDyld-Add-test-case-that-was-accidentally-left.patch``: Test for the above patch
+    #. ``0001-Revert-Limit-size-of-non-GlobalValue-name.patch``: revert the limit put on the length of a non-GlobalValue name
 
 #. For Linux/macOS:
     #. ``export PREFIX=desired_install_location CPU_COUNT=N`` (``N`` is number of parallel compile tasks)


### PR DESCRIPTION
# Description

Going through documentation https://llvmlite.readthedocs.io/en/latest/admin-guide/install.html
was trying to do these steps:

```
0001-RuntimeDyld-Fix-a-bug-in-RuntimeDyld-loadObjectImpl-.patch: Fixes a bug relating to common symbol section size computation
0001-RuntimeDyld-Add-test-case-that-was-accidentally-left.patch: Test for the above patch
```
except the patches don't seem to be there:
```
$ find . -name *.patch
./conda-recipes/0001-Revert-Limit-size-of-non-GlobalValue-name.patch
./conda-recipes/D47188-svml-VF.patch
./conda-recipes/twine_cfg_undefined_behavior.patch
./conda-recipes/llvm-lto-static.patch
./conda-recipes/partial-testing.patch
```

Checking through `git log` seems it hasn't been there for a couple of months:
```
$ git log --all --full-history -1 -- "**/0001-RuntimeDyld-Fix-a-bug-in-RuntimeDyld-loadObjectImpl-.patch"
commit 46d9171674938f63c3352e2f4935df4a4003cfba
Merge: 64179e4 bc8fd6a
Author: Siu Kwan Lam <michael.lam.sk@gmail.com>
Date:   Wed Sep 25 19:55:36 2019 -0500
```

PR removes the lines from `install.rst`. It also adds a line for `0001-Revert-Limit-size-of-non-GlobalValue-name.patch` which isn't in the instructions but is in `./conda-recipes/`
