### PR TITLE
Set AppVeyor to python 3.6

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,7 +8,7 @@ environment:
 
   matrix:
     # Since appveyor is quite slow, we only use a single configuration
-    - PYTHON: "3.8"
+    - PYTHON: "3.6"
       ARCH: "64"
       CONDA_ENV: testenv
 


### PR DESCRIPTION
AppVeyor does not currently support python 3.8. This sets it to the minimum requirement of python 3.6.