### PR TITLE
Remove unused ninja build requirements on windows

### DIFF
--- a/conda-recipes/llvmdev/meta.yaml
+++ b/conda-recipes/llvmdev/meta.yaml
@@ -65,8 +65,6 @@ requirements:
     - cmake # [not (armv6l or armv7l)]
     # Needed to unpack the source tarball
     - m2w64-xz  # [py27 and win]
-    # ninja not currently used, bld.bat needs an update
-    - ninja  # [win]
     # Needed to build LLVM
     - python >=3
     # need vs2015_runtime to build, do not want it at run time


### PR DESCRIPTION
Ninja is not used. It gets downloaded and installed needlessly.

Also, the ninja cmake generator has issues. It does not play nice with Visual Studio Build tools. Using the Visual Studio generator is more reliable in my experience.