### PR TITLE
Improvements to llvmdev build scripts

### DIFF
--- a/conda-recipes/llvmdev/bld.bat
+++ b/conda-recipes/llvmdev/bld.bat
@@ -16,7 +16,7 @@ if "%ARCH%"=="32" (
 )
 set "CMAKE_GENERATOR[0]=Visual Studio 14 2015%ARCH_POSTFIX%"
 set "CMAKE_GENERATOR[1]=Visual Studio 15 2017%ARCH_POSTFIX%"
-set "CMAKE_GENERATOR[2]=Visual Studio 16 2019%ARCH_POSTFIX%"
+set "CMAKE_GENERATOR[2]=Visual Studio 16 2019"
 set MAX_INDEX_CMAKE_GENERATOR=2
 
 REM the platform toolset host arch is set to x64 so as to use the 64bit linker,

--- a/conda-recipes/llvmdev/bld.bat
+++ b/conda-recipes/llvmdev/bld.bat
@@ -3,49 +3,65 @@ cd build
 
 set BUILD_CONFIG=Release
 
-REM Configure step
-if "%ARCH%"=="32" (
-    set CMAKE_GENERATOR=Visual Studio 14 2015
-) else (
-    set CMAKE_GENERATOR=Visual Studio 14 2015 Win64
-)
-set CMAKE_GENERATOR_TOOLSET=v140_xp
+REM === Configure step ===
 
-REM llvm 8 needs the 64bit linker
+REM allow setting the targets to build as an environment variable
+if "%LLVM_TARGETS_TO_BUILD%"=="" (
+    set "LLVM_TARGETS_TO_BUILD=host;AMDGPU;NVPTX"
+)
+if "%ARCH%"=="32" (
+    set "ARCH_POSTFIX="
+) else (
+    set "ARCH_POSTFIX= Win64"
+)
+set "CMAKE_GENERATOR[0]=Visual Studio 14 2015%ARCH_POSTFIX%"
+set "CMAKE_GENERATOR[1]=Visual Studio 15 2017%ARCH_POSTFIX%"
+set "CMAKE_GENERATOR[2]=Visual Studio 16 2019%ARCH_POSTFIX%"
+set MAX_INDEX_CMAKE_GENERATOR=2
+
+REM the platform toolset host arch is set to x64 so as to use the 64bit linker,
+REM the 32bit linker heap is too small for llvm8 so it tries and falls over to
+REM the 64bit linker anyway
 set PreferredToolArchitecture=x64
 
 REM Reduce build times and package size by removing unused stuff
 REM BENCHMARKS (new for llvm8) don't build under Visual Studio 14 2015
-set CMAKE_CUSTOM=-DLLVM_TARGETS_TO_BUILD="host;AMDGPU;NVPTX" ^
+set CMAKE_CUSTOM=-DLLVM_TARGETS_TO_BUILD="%LLVM_TARGETS_TO_BUILD%" ^
     -DLLVM_INCLUDE_TESTS=OFF -DLLVM_INCLUDE_UTILS=ON -DLLVM_INCLUDE_DOCS=OFF ^
     -DLLVM_INCLUDE_EXAMPLES=OFF -DLLVM_ENABLE_ASSERTIONS=ON ^
     -DLLVM_USE_INTEL_JITEVENTS=ON -DLLVM_TEMPORARILY_ALLOW_OLD_TOOLCHAIN=ON ^
     -DLLVM_INCLUDE_BENCHMARKS=OFF ^
     -DLLVM_EXPERIMENTAL_TARGETS_TO_BUILD=WebAssembly
 
-REM the platform toolset host arch is set to x64 so as to use the 64bit linker,
-REM the 32bit linker heap is too small for llvm8 so it tries and falls over to
-REM the 64bit linker anyway
-cmake -G "%CMAKE_GENERATOR%" -T "%CMAKE_GENERATOR_TOOLSET%" ^
-    -DCMAKE_BUILD_TYPE="%BUILD_CONFIG%" -DCMAKE_PREFIX_PATH=%LIBRARY_PREFIX% ^
-    -DCMAKE_INSTALL_PREFIX:PATH=%LIBRARY_PREFIX% %CMAKE_CUSTOM% %SRC_DIR% ^
-    -DCMAKE_VS_PLATFORM_TOOLSET_HOST_ARCHITECTURE=x64
-if errorlevel 1 exit 1
+REM try all compatible visual studio toolsets to find one that is installed
+setlocal enabledelayedexpansion
+for /l %%n in (0,1,%MAX_INDEX_CMAKE_GENERATOR%) do (
+    cmake -G "!CMAKE_GENERATOR[%%n]!" -Thost=%PreferredToolArchitecture%^
+        -DCMAKE_BUILD_TYPE="%BUILD_CONFIG%" -DCMAKE_PREFIX_PATH="%LIBRARY_PREFIX%" ^
+        -DCMAKE_INSTALL_PREFIX:PATH="%LIBRARY_PREFIX%" %CMAKE_CUSTOM% "%SRC_DIR%"
+    if not errorlevel 1 goto configuration_successful
+    del CMakeCache.txt
+)
 
-REM Build step
+REM no compatible visual studio toolset was found
+exit 1
+
+:configuration_successful
+endlocal
+REM === Build step ===
 cmake --build . --config "%BUILD_CONFIG%"
 if errorlevel 1 exit 1
 
-REM Install step
+REM === Install step ===
 cmake --build . --config "%BUILD_CONFIG%" --target install
 if errorlevel 1 exit 1
 
 REM From: https://github.com/conda-forge/llvmdev-feedstock/pull/53
-%BUILD_CONFIG%\bin\opt -S -vector-library=SVML -mcpu=haswell -O3 %RECIPE_DIR%\numba-3016.ll | %BUILD_CONFIG%\bin\FileCheck %RECIPE_DIR%\numba-3016.ll
+"%BUILD_CONFIG%\bin\opt" -S -vector-library=SVML -mcpu=haswell -O3 "%RECIPE_DIR%\numba-3016.ll" | "%BUILD_CONFIG%\bin\FileCheck" "%RECIPE_DIR%\numba-3016.ll"
 if errorlevel 1 exit 1
 
 REM This is technically how to run the suite, but it will only run in an
 REM enhanced unix-like shell which has functions like `grep` available.
 REM cd ..\test
-REM %PYTHON% ..\build\%BUILD_CONFIG%\bin\llvm-lit.py -vv Transforms ExecutionEngine Analysis CodeGen/X86
+REM "%PYTHON%" "..\build\%BUILD_CONFIG%\bin\llvm-lit.py" -vv Transforms ExecutionEngine Analysis CodeGen/X86
 REM if errorlevel 1 exit 1

--- a/conda-recipes/llvmdev/build.sh
+++ b/conda-recipes/llvmdev/build.sh
@@ -4,6 +4,9 @@
 
 set -x
 
+# allow setting the targets to build as an environment variable
+LLVM_TARGETS_TO_BUILD=${LLVM_TARGETS_TO_BUILD:-"host;AMDGPU;NVPTX"}
+
 # This is the clang compiler prefix
 DARWIN_TARGET=x86_64-apple-darwin13.4.0
 
@@ -28,7 +31,7 @@ _cmake_config+=(-DHAVE_TERMIOS_H=OFF)
 _cmake_config+=(-DCLANG_ENABLE_LIBXML=OFF)
 _cmake_config+=(-DLIBOMP_INSTALL_ALIASES=OFF)
 _cmake_config+=(-DLLVM_ENABLE_RTTI=OFF)
-_cmake_config+=(-DLLVM_TARGETS_TO_BUILD="host;AMDGPU;NVPTX")
+_cmake_config+=(-DLLVM_TARGETS_TO_BUILD=${LLVM_TARGETS_TO_BUILD})
 _cmake_config+=(-DLLVM_EXPERIMENTAL_TARGETS_TO_BUILD=WebAssembly)
 _cmake_config+=(-DLLVM_INCLUDE_UTILS=ON) # for llvm-lit
 # TODO :: It would be nice if we had a cross-ecosystem 'BUILD_TIME_LIMITED' env var we could use to


### PR DESCRIPTION
Improvements:
- allow setting the targets to be built with the environment variable `LLVM_TARGETS_TO_BUILD`
- allow building on all compatible Visual Studio versions
- quote path strings to fix issues with paths with spaces