### PR TITLE
MNT: allow llvm 9.0.1 to be used

### DIFF
--- a/ffi/build.py
+++ b/ffi/build.py
@@ -111,7 +111,7 @@ def main_posix(kind, library_ext):
     out = out.decode('latin1')
     print(out)
     if not (out.startswith('8.0.') or out.startswith('7.0.')
-            or out.startswith('7.1.')):
+            or out.startswith('7.1.') or out.startswith('9.0.')):
         msg = (
             "Building llvmlite requires LLVM 7.0.x, 7.1.x or 8.0.x, got {!r}. "
             "Be sure to set LLVM_CONFIG to the right executable path.\n"

--- a/llvmlite/tests/test_binding.py
+++ b/llvmlite/tests/test_binding.py
@@ -356,7 +356,7 @@ class TestMisc(BaseTest):
     def test_version(self):
         major, minor, patch = llvm.llvm_version_info
         # one of these can be valid
-        valid = [(8, 0), (7, 0), (7, 1)]
+        valid = [(8, 0), (7, 0), (7, 1), (9, 0)]
         self.assertIn((major, minor), valid)
         self.assertIn(patch, range(10))
 


### PR DESCRIPTION
This only removes the version checks.