### PR TITLE
Adds override for LLVM version check, re-formats docs.

### DIFF
--- a/docs/source/admin-guide/install.rst
+++ b/docs/source/admin-guide/install.rst
@@ -7,7 +7,7 @@ libraries that may be present on the system, or in the conda environment.  The
 parts of LLVM required by llvmlite are statically linked at build time.  As a
 result, installing llvmlite from a binary package does not also require the
 end user to install LLVM.  (For more details on the reasoning behind this,
-see: :ref:`why-static`)
+see: :ref:`faq_why_static`).
 
 Pre-built binaries
 ==================
@@ -71,34 +71,46 @@ prebuilt LLVM binary package and skip this step::
 
 The LLVM build process is fully scripted by conda-build_, and the `llvmdev recipe <https://github.com/numba/llvmlite/tree/master/conda-recipes/llvmdev>`_ is the canonical reference for building LLVM for llvmlite.  Please use it if at all possible!
 
-The manual instructions below describe the main steps, but refer to the recipe for details:
+The manual instructions below describe the main steps, but refer to the recipe
+for details:
 
 #. Download the `LLVM 7.0.0 source code <http://releases.llvm.org/7.0.0/llvm-7.0.0.src.tar.xz>`_.
+   or `LLVM 8.0.0 source code <http://releases.llvm.org/8.0.0/llvm-8.0.0.src.tar.xz>`_
 
 #. Download or git checkout the `llvmlite source code <https://github.com/numba/llvmlite>`_.
 
-#. Decompress the LLVM tar file and apply the following patches from the ``llvmlite/conda-recipes/`` directory.  You can apply each patch using the Linux "patch -p1 -i {patch-file}"  command:
+#. Decompress the LLVM tar file and apply the following patches from the
+   ``llvmlite/conda-recipes/`` directory.  You can apply each patch using the
+   Linux ``patch -p1 -i {patch-file}`` command:
 
     #. ``llvm-lto-static.patch``: Fix issue with LTO shared library on Windows
-    #. ``D47188-svml-VF.patch``: Add support for vectorized math functions via Intel SVML
-    #. ``partial-testing.patch``: Enables additional parts of the LLVM test suite
-    #. ``twine_cfg_undefined_behavior.patch``: Fix obscure memory corruption bug in LLVM that hasn't been fixed in master yet
-    #. ``0001-Revert-Limit-size-of-non-GlobalValue-name.patch``: revert the limit put on the length of a non-GlobalValue name
+    #. ``D47188-svml-VF.patch``: Add support for vectorized math functions via
+       Intel SVML (LLVM 8 only)
+    #. ``partial-testing.patch``: Enables additional parts of the LLVM test
+       suite
+    #. ``twine_cfg_undefined_behavior.patch``: Fix obscure memory corruption bug
+       in LLVM that hasn't been fixed in master yet (LLVM 7 only)
+    #. ``0001-Revert-Limit-size-of-non-GlobalValue-name.patch``: revert the
+       limit put on the length of a non-GlobalValue name
 
 #. For Linux/macOS:
-    #. ``export PREFIX=desired_install_location CPU_COUNT=N`` (``N`` is number of parallel compile tasks)
-    #. Run the `build.sh <https://github.com/numba/llvmlite/blob/master/conda-recipes/llvmdev/build.sh>`_ script in the llvmdev conda recipe from the LLVM source directory
+    #. ``export PREFIX=desired_install_location CPU_COUNT=N`` (``N`` is number
+       of parallel compile tasks)
+    #. Run the `build.sh <https://github.com/numba/llvmlite/blob/master/conda-recipes/llvmdev/build.sh>`_
+       script in the llvmdev conda recipe from the LLVM source directory
 
 #. For Windows:
     #. ``set PREFIX=desired_install_location``
-    #. Run the `bld.bat <https://github.com/numba/llvmlite/blob/master/conda-recipes/llvmdev/bld.bat>`_ script in the llvmdev conda recipe from the LLVM source directory.
+    #. Run the `bld.bat <https://github.com/numba/llvmlite/blob/master/conda-recipes/llvmdev/bld.bat>`_
+       script in the llvmdev conda recipe from the LLVM source directory.
 
 
 Compiling llvmlite
 ------------------
 
 #. To build the llvmlite C wrapper, which embeds a statically
-   linked copy of the required subset of LLVM, run the following from the llvmlite source directory::
+   linked copy of the required subset of LLVM, run the following from the
+   llvmlite source directory::
 
      python setup.py build
 
@@ -112,6 +124,13 @@ Compiling llvmlite
    ``llvm-config`` binary located at
    ``/opt/llvm/bin/llvm-config``, set
    ``LLVM_CONFIG=/opt/llvm/bin/llvm-config``.
+
+#. If you wish to build against an unsupported LLVM version, set the environment
+   variable ``LLVMLITE_SKIP_LLVM_VERSION_CHECK`` to non-zero. Note that this is
+   useful for e.g. testing new versions of llvmlite, but support for llvmlite
+   built in this manner is limited/it's entirely possible that llvmlite will not
+   work as expected. See also:
+   :ref:`why llvmlite doesn’t always support the latest release(s) of LLVM<faq_supported_versions>`.
 
 
 Installing
@@ -155,44 +174,6 @@ a custom version of ``llvm`` :
 
 ``LLVM_CONFIG=/path/to/custom/llvm-config CXXFLAGS=-fPIC pip3 install --no-binary :all: llvmlite``
 
-
-.. _why-static:
-
-Why Static Linking to LLVM?
-===========================
-
-The llvmlite package uses LLVM via ctypes calls to a C wrapper that is
-statically linked to LLVM.  Some people are surprised that llvmlite uses
-static linkage to LLVM, but there are several important reasons for this:
-
-#. *The LLVM API has not historically been stable across releases* - Although
-   things have improved since LLVM 4.0, there are still enough changes between
-   LLVM releases to cause compilation issues if the right version is not
-   matched with llvmlite.
-
-#. *The LLVM shipped by most Linux distributions is not the version
-   llvmlite needs* - The release cycles of Linux distributions will never line
-   up with LLVM or llvmlite releases.
-
-#. *We need to patch LLVM* - The binary packages of llvmlite are built
-   against LLVM with a handful of patches to either fix bugs or to add
-   features that have not yet been merged upstream.  In some cases, we've had
-   to carry patches for several releases before they make it into LLVM.
-
-#. *We don't need most of LLVM* - We are sensitive to the install size of
-   llvmlite, and a full build of LLVM is quite large.  We can dramatically
-   reduce the total disk needed by an llvmlite user (who typically doesn't
-   need the rest of LLVM, ignoring the version matching issue) by statically
-   linking to the library and pruning the symbols we do not need.
-
-#. *Numba can use multiple LLVM builds at once* - Some Numba targets (AMD GPU,
-   for example) may require different LLVM versions or non-mainline forks of
-   LLVM to work.  These other LLVMs can be wrapped in a similar fashion as
-   llvmlite, and will stay isolated.
-
-
-Static linkage of LLVM was definitely not our goal early in Numba development,
-but seems to have become the only workable solution given our constraints.
 
 .. _CMake: http://www.cmake.org/
 .. _Numba: http://numba.pydata.org/

--- a/docs/source/faqs.rst
+++ b/docs/source/faqs.rst
@@ -1,0 +1,29 @@
+.. _faqs:
+
+==========================
+Frequently Asked Questions
+==========================
+
+Why doesn't ``llvmlite`` always support the latest release(s) of LLVM?
+======================================================================
+
+There's a few reasons for this:
+
+1. Most importantly, if llvmlite declares it supports a given version of LLVM,
+   it means that the development team has verified that the particular LLVM
+   version will work for llvmlite uses, mainly that it works fine for JIT
+   compiler projects (like Numba). This testing is extensive and it's not
+   uncommon to have to patch LLVM in the process/make decisions about the
+   severity of problems/report problems upstream to LLVM. Ultimately, if the
+   build is not considered stable across all supported architectures/OS
+   combinations then support is not declared.
+
+2. LLVM sometimes updates its API or internal behaviour and it takes time
+   to work out what needs to be done to accommodate this on all of llvmlite's
+   supported architectures/OS combinations.
+
+3. There is a set of patches that ship along with the LLVM builds for llvmlite.
+   These patches are necessary and often need porting to work on new LLVM
+   versions, this takes time and requires testing. It should be noted that LLVM
+   builds that come with e.g. linux distributions may not work well with the
+   llvmlite intended use cases.

--- a/docs/source/faqs.rst
+++ b/docs/source/faqs.rst
@@ -4,6 +4,8 @@
 Frequently Asked Questions
 ==========================
 
+.. _faq_supported_versions:
+
 Why doesn't ``llvmlite`` always support the latest release(s) of LLVM?
 ======================================================================
 
@@ -27,3 +29,42 @@ There's a few reasons for this:
    versions, this takes time and requires testing. It should be noted that LLVM
    builds that come with e.g. linux distributions may not work well with the
    llvmlite intended use cases.
+
+
+.. _faq_why_static:
+
+Why Static Linking to LLVM?
+===========================
+
+The llvmlite package uses LLVM via ctypes calls to a C wrapper that is
+statically linked to LLVM.  Some people are surprised that llvmlite uses
+static linkage to LLVM, but there are several important reasons for this:
+
+#. *The LLVM API has not historically been stable across releases* - Although
+   things have improved since LLVM 4.0, there are still enough changes between
+   LLVM releases to cause compilation issues if the right version is not
+   matched with llvmlite.
+
+#. *The LLVM shipped by most Linux distributions is not the version
+   llvmlite needs* - The release cycles of Linux distributions will never line
+   up with LLVM or llvmlite releases.
+
+#. *We need to patch LLVM* - The binary packages of llvmlite are built
+   against LLVM with a handful of patches to either fix bugs or to add
+   features that have not yet been merged upstream.  In some cases, we've had
+   to carry patches for several releases before they make it into LLVM.
+
+#. *We don't need most of LLVM* - We are sensitive to the install size of
+   llvmlite, and a full build of LLVM is quite large.  We can dramatically
+   reduce the total disk needed by an llvmlite user (who typically doesn't
+   need the rest of LLVM, ignoring the version matching issue) by statically
+   linking to the library and pruning the symbols we do not need.
+
+#. *Numba can use multiple LLVM builds at once* - Some Numba targets (AMD GPU,
+   for example) may require different LLVM versions or non-mainline forks of
+   LLVM to work.  These other LLVMs can be wrapped in a similar fashion as
+   llvmlite, and will stay isolated.
+
+
+Static linkage of LLVM was definitely not our goal early in Numba development,
+but seems to have become the only workable solution given our constraints.

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -88,6 +88,7 @@ the llvmlite API at each release, for the following reasons:
 
    admin-guide/install
    user-guide/index
+   faqs
    contributing
    release-notes
    glossary

--- a/ffi/build.py
+++ b/ffi/build.py
@@ -110,14 +110,38 @@ def main_posix(kind, library_ext):
 
     out = out.decode('latin1')
     print(out)
-    if not (out.startswith('8.0.') or out.startswith('7.0.')
-            or out.startswith('7.1.')):
-        msg = (
-            "Building llvmlite requires LLVM 7.0.x, 7.1.x or 8.0.x, got {!r}. "
-            "Be sure to set LLVM_CONFIG to the right executable path.\n"
-            "Read the documentation at http://llvmlite.pydata.org/ for more "
-            "information about building llvmlite.\n".format(out.strip()))
-        raise RuntimeError(msg)
+
+    # See if the user is overriding the version check, this is unsupported
+    try:
+        _ver_check_skip = os.environ.get("LLVMLITE_SKIP_LLVM_VERSION_CHECK", 0)
+        skipcheck = int(_ver_check_skip)
+    except ValueError as e:
+        msg = ('If set, the environment variable '
+               'LLVMLITE_SKIP_LLVM_VERSION_CHECK should be an integer, got '
+               '"{}".')
+        raise ValueError(msg.format(_ver_check_skip)) from e
+
+    if skipcheck:
+        # user wants to use an unsupported version, warn about doing this...
+        msg = ("The LLVM version check for supported versions has been "
+               "overridden.\nThis is unsupported behaviour, llvmlite may not "
+               "work as intended.\nRequested LLVM version: {}".format(
+                   out.strip()))
+        warn = ' * '.join(("WARNING",) * 8)
+        blk = '=' * 80
+        warning = '{}\n{}\n{}'.format(blk, warn, blk)
+        print(warning)
+        print(msg)
+        print(warning + '\n')
+    else:
+        if not (out.startswith('8.0.') or out.startswith('7.0.')
+                or out.startswith('7.1.')):
+            msg = ("Building llvmlite requires LLVM 7.0.x, 7.1.x or 8.0.x, got "
+                   "{!r}. Be sure to set LLVM_CONFIG to the right executable "
+                   "path.\nRead the documentation at "
+                   "http://llvmlite.pydata.org/ for more information about "
+                   "building llvmlite.\n".format(out.strip()))
+            raise RuntimeError(msg)
 
     # Get LLVM information for building
     libs = run_llvm_config(llvm_config, "--system-libs --libs all".split())


### PR DESCRIPTION
Builds on: https://github.com/numba/llvmlite/pull/581


Adds override for LLVM version check, re-formats docs.

* Adds environment variable to remove LLVM version check.
* Reformats install guide doc:
  * 80 char limit
  * Move static linking prose to FAQ
  * Add section on using unsupported LLVMs

