### PR TITLE
add python_requires to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -191,4 +191,5 @@ setup(name='llvmlite',
       license="BSD",
       cmdclass=cmdclass,
       long_description=long_description,
+      python_requires=">=3.6",
       )


### PR DESCRIPTION
As of version 0.32.0 (?) the lllvmlite package only supports Python 3.6
and beyond. As outlines in
https://packaging.python.org/guides/distributing-packages-using-setuptools/#python-requires
- the appropriate line is added to the `setup.py` file to prevent `pip`
from installing the project on other Python versions.