### PR TITLE
Fix meta.yaml

### DIFF
--- a/conda-recipes/llvmlite/meta.yaml
+++ b/conda-recipes/llvmlite/meta.yaml
@@ -1,7 +1,9 @@
+{% set VERSION_SUFFIX = "" %} # debug version suffix, appended to the version
+
 package:
   name: llvmlite
   # GIT_DESCRIBE_TAG may not be set
-  version: {{ "%s%s" % (environ.get('GIT_DESCRIBE_TAG', '').lstrip('v')) }}
+  version: {{ "%s%s" % (environ.get('GIT_DESCRIBE_TAG', '').lstrip('v'), VERSION_SUFFIX) }}
 
 source:
   # Using the local source tree helps test building without pushing changes


### PR DESCRIPTION
Restore `VERSION_SUFFIX` accidentally removed in the llvm9 patch.