### PR TITLE
Use std::make_unique on LLVM 10

### DIFF
--- a/ffi/linker.cpp
+++ b/ffi/linker.cpp
@@ -42,7 +42,11 @@ LLVMPY_LinkModules(LLVMModuleRef Dest, LLVMModuleRef Src, const char **Err)
     auto OldDiagnosticHandler = Ctx.getDiagnosticHandler();
 
     // set the handler to a new one
+#if LLVM_VERSION_MAJOR >= 10
+    Ctx.setDiagnosticHandler(std::make_unique<ReportNotAbortDiagnosticHandler>(errstream));
+#else
     Ctx.setDiagnosticHandler(llvm::make_unique<ReportNotAbortDiagnosticHandler>(errstream));
+#endif
 
     // link
     bool failed = LLVMLinkModules2(Dest, Src);


### PR DESCRIPTION
LLVM 10 removes llvm::make_unique in favor of std::make_unique.
However, this requires C++14 and is therefore unsuitable for LLVM 9
that forces -std=c++11.  Update the code to use both conditionally.
This fixes all issues with LLVM 10.