### PR TITLE
add missing targets to wheel build

### DIFF
--- a/conda-recipes/llvmdev_manylinux1/build.sh
+++ b/conda-recipes/llvmdev_manylinux1/build.sh
@@ -28,7 +28,8 @@ _cmake_config+=(-DHAVE_TERMIOS_H=OFF)
 _cmake_config+=(-DCLANG_ENABLE_LIBXML=OFF)
 _cmake_config+=(-DLIBOMP_INSTALL_ALIASES=OFF)
 _cmake_config+=(-DLLVM_ENABLE_RTTI=OFF)
-_cmake_config+=(-DLLVM_TARGETS_TO_BUILD=host)
+_cmake_config+=(-DLLVM_TARGETS_TO_BUILD="host;AMDGPU;NVPTX")
+_cmake_config+=(-DLLVM_EXPERIMENTAL_TARGETS_TO_BUILD=WebAssembly)
 _cmake_config+=(-DLLVM_INCLUDE_UTILS=ON) # for llvm-lit
 # TODO :: It would be nice if we had a cross-ecosystem 'BUILD_TIME_LIMITED' env var we could use to
 #         disable these unnecessary but useful things.


### PR DESCRIPTION
Fixes #601: add the missing GPU hosts to the wheel build for llvmdev.