### PR TITLE
Fixes #522, closes #542

### DIFF
--- a/ffi/Makefile.freebsd
+++ b/ffi/Makefile.freebsd
@@ -1,6 +1,6 @@
 
 CXX = clang++ -std=c++11 -stdlib=libc++
-CXXFLAGS = $(LLVM_CXXFLAGS)
+CXXFLAGS = $(LLVM_CXXFLAGS) -fPIC
 LDFLAGS = $(LLVM_LDFLAGS)
 LIBS = $(LLVM_LIBS)
 INCLUDE = core.h

--- a/ffi/build.py
+++ b/ffi/build.py
@@ -152,6 +152,11 @@ def main_posix(kind, library_ext):
     cxxflags = cxxflags.replace('\0', '')
     cxxflags = cxxflags.split() + ['-fno-rtti', '-g']
 
+    # Add environment CXXFLAGS
+    env_cxxflags = os.environ.get('CXXFLAGS')
+    if env_cxxflags:
+        cxxflags += env_cxxflags.split()
+
     # look for SVML
     include_dir = run_llvm_config(llvm_config, ['--includedir']).strip()
     svml_indicator = os.path.join(include_dir, 'llvm', 'IR', 'SVML.inc')


### PR DESCRIPTION
Take the environmnent passed CXXFLAGS into account, add -fPIC to Makefile.freebsd so it won't have to be specified at each build. For the freebsd package llvm-90, -fPIC is necessary for the successful build.