### PR TITLE
Implement reference count pruner LLVM pass

### DIFF
--- a/conda-recipes/llvmlite/meta.yaml
+++ b/conda-recipes/llvmlite/meta.yaml
@@ -1,4 +1,4 @@
-{% set VERSION_SUFFIX = "" %} # debug version suffix, appended to the version
+{% set VERSION_SUFFIX = "_refprune" %} # debug version suffix, appended to the version
 
 package:
   name: llvmlite

--- a/conda-recipes/llvmlite/meta.yaml
+++ b/conda-recipes/llvmlite/meta.yaml
@@ -1,4 +1,4 @@
-{% set VERSION_SUFFIX = "_refprune" %} # debug version suffix, appended to the version
+{% set VERSION_SUFFIX = "" %} # debug version suffix, appended to the version
 
 package:
   name: llvmlite

--- a/ffi/CMakeLists.txt
+++ b/ffi/CMakeLists.txt
@@ -34,7 +34,8 @@ endif()
 # Define our shared library
 add_library(llvmlite SHARED assembly.cpp bitcode.cpp core.cpp initfini.cpp
             module.cpp value.cpp executionengine.cpp transforms.cpp
-            passmanagers.cpp targets.cpp dylib.cpp linker.cpp object_file.cpp)
+            passmanagers.cpp targets.cpp dylib.cpp linker.cpp object_file.cpp
+            custom_passes.cpp)
 
 # Find the libraries that correspond to the LLVM components
 # that we wish to use.

--- a/ffi/Makefile.linux
+++ b/ffi/Makefile.linux
@@ -11,7 +11,7 @@ LIBS = $(LLVM_LIBS)
 INCLUDE = core.h
 SRC = assembly.cpp bitcode.cpp core.cpp initfini.cpp module.cpp value.cpp \
 	  executionengine.cpp transforms.cpp passmanagers.cpp targets.cpp dylib.cpp \
-	  linker.cpp object_file.cpp
+	  linker.cpp object_file.cpp custom_passes.cpp
 OUTPUT = libllvmlite.so
 
 all: $(OUTPUT)

--- a/ffi/Makefile.osx
+++ b/ffi/Makefile.osx
@@ -6,7 +6,7 @@ LIBS = $(LLVM_LIBS)
 INCLUDE = core.h
 SRC = assembly.cpp bitcode.cpp core.cpp initfini.cpp module.cpp value.cpp \
 	  executionengine.cpp transforms.cpp passmanagers.cpp targets.cpp dylib.cpp \
-	  linker.cpp object_file.cpp
+	  linker.cpp object_file.cpp custom_passes.cpp
 OUTPUT = libllvmlite.dylib
 MACOSX_DEPLOYMENT_TARGET ?= 10.9
 

--- a/ffi/custom_passes.cpp
+++ b/ffi/custom_passes.cpp
@@ -1,0 +1,168 @@
+
+#include "core.h"
+
+
+#include "llvm/Pass.h"
+#include "llvm/IR/Function.h"
+#include "llvm/IR/BasicBlock.h"
+#include "llvm/IR/Instructions.h"
+
+#include "llvm/Support/raw_ostream.h"
+#include "llvm/Analysis/Passes.h"
+#include "llvm/Analysis/RegionPass.h"
+#include "llvm/Analysis/RegionInfo.h"
+#include "llvm/Analysis/RegionPrinter.h"
+#include "llvm/Analysis/PostDominators.h"
+#include "llvm/Analysis/DomPrinter.h"
+#include "llvm/Transforms/Utils/UnifyFunctionExitNodes.h"
+
+#include "llvm/Transforms/Scalar.h"
+
+#include "llvm/IR/LegacyPassManager.h"
+#include "llvm/Transforms/IPO/PassManagerBuilder.h"
+
+#include "llvm/InitializePasses.h"
+#include "llvm/LinkAllPasses.h"
+
+#include <vector>
+
+using namespace llvm;
+
+namespace llvm {
+    void initializeRefPrunePassPass(PassRegistry &Registry);
+}
+/*
+struct Hello : public RegionPass {
+  static char ID;
+  Hello() : RegionPass(ID) {
+      initializeHelloPass(*PassRegistry::getPassRegistry());
+  }
+
+  bool runOnRegion(Region *region, RGPassManager &RGM) override {
+    errs() << "Hello: ";
+    errs().write_escaped(region->getNameStr()) << '\n';
+    return false;
+  }
+}; // end of struct Hello
+*/
+
+
+struct RefPrunePass : public FunctionPass {
+  static char ID;
+  RefPrunePass() : FunctionPass(ID) {
+      initializeRefPrunePassPass(*PassRegistry::getPassRegistry());
+  }
+
+  bool runOnFunction(Function &F) override {
+    errs() << "NRT_RefPrunePass\n";
+    errs().write_escaped(F.getName()) << '\n';
+
+    auto &domtree = getAnalysis<DominatorTreeWrapperPass>().getDomTree();
+    auto &postdomtree = getAnalysis<PostDominatorTreeWrapperPass>().getPostDomTree();
+
+    // domtree.viewGraph();   // view domtree
+    // postdomtree.viewGraph();
+
+    bool mutated = false;
+
+    // Find all incref & decref
+    std::vector<CallInst*> incref_list, decref_list;
+    for (BasicBlock &bb : F) {
+        for (Instruction &ii : bb) {
+            if (ii.getOpcode() == Instruction::Call) {
+                CallInst *call_inst = dyn_cast<CallInst>(&ii);
+                // TODO: handle call_inst being NULL
+                Value *callee = call_inst->getCalledOperand();
+                if ( callee->getName() == "NRT_incref" ) {
+                    incref_list.push_back(call_inst);
+                } else if ( callee->getName() == "NRT_decref" ) {
+                    decref_list.push_back(call_inst);
+                }
+            }
+        }
+    }
+
+    errs() << "Counts " << incref_list.size() << " " << decref_list.size() << "\n";
+
+    // Drop refops on NULL pointers
+    for (CallInst*& refop: incref_list) {
+        if (!keepNonNullArg(refop)) {
+            refop->eraseFromParent();
+            mutated |= true;
+            refop = NULL;
+        }
+    }
+    for (CallInst*& refop: decref_list) {
+        if (!keepNonNullArg(refop)) {
+            refop->eraseFromParent();
+            mutated |= true;
+            refop = NULL;
+        }
+    }
+
+    // check pairs that are dominating and postdominating each other
+    for (CallInst* incref: incref_list) {
+        if (incref == NULL) continue;
+
+        for (CallInst*& decref: decref_list) {
+            if (decref == NULL) continue;
+
+            if (incref->getArgOperand(0) != decref->getArgOperand(0) )
+                continue;
+
+            if ( domtree.dominates(incref, decref)
+                    && postdomtree.dominates(decref, incref) ){
+                errs() << "Prune these due to DOM + PDOM\n";
+                incref->dump();
+                decref->dump();
+                errs() << "\n";
+                incref->eraseFromParent();
+                decref->eraseFromParent();
+                decref = NULL;
+                mutated |= true;
+                continue;
+            }
+        }
+    }
+    return mutated;
+  }
+
+   void getAnalysisUsage(AnalysisUsage &Info) const override {
+       Info.addRequired<DominatorTreeWrapperPass>();
+       Info.addRequired<PostDominatorTreeWrapperPass>();
+   }
+
+   bool keepNonNullArg(CallInst *call_inst){
+       auto val = call_inst->getArgOperand(0);
+       auto ptr = dyn_cast<ConstantPointerNull>(val);
+       return ptr == NULL;
+   }
+}; // end of struct RefPrunePass
+
+
+char RefPrunePass::ID = 0;
+
+INITIALIZE_PASS_BEGIN(RefPrunePass, "nrtrefprunepass",
+                      "Prune NRT refops", false, false)
+// INITIALIZE_PASS_DEPENDENCY(RegionInfoPass)
+INITIALIZE_PASS_DEPENDENCY(DominatorTreeWrapperPass)
+INITIALIZE_PASS_DEPENDENCY(PostDominatorTreeWrapperPass)
+
+INITIALIZE_PASS_END(RefPrunePass, "refprunepass",
+                    "Prune NRT refops", false, false)
+
+
+extern "C" {
+
+API_EXPORT(void)
+LLVMPY_AddRefPrunePass(LLVMPassManagerRef PM)
+{
+    // unwrap(PM)->add(createStructurizeCFGPass());
+    // unwrap(PM)->add(createUnifyFunctionExitNodesPass());
+    // unwrap(PM)->add(createPromoteMemoryToRegisterPass());
+    // unwrap(PM)->add(createInstSimplifyLegacyPass());
+    unwrap(PM)->add(new RefPrunePass());
+}
+
+
+} // extern "C"

--- a/ffi/custom_passes.cpp
+++ b/ffi/custom_passes.cpp
@@ -7,29 +7,19 @@
 #include "llvm/IR/BasicBlock.h"
 #include "llvm/IR/Instructions.h"
 
-#include "llvm/ADT/SmallString.h"
 #include "llvm/ADT/SmallSet.h"
 
 #include "llvm/Support/raw_ostream.h"
 #include "llvm/Analysis/Passes.h"
-#include "llvm/Analysis/RegionPass.h"
-#include "llvm/Analysis/RegionInfo.h"
-#include "llvm/Analysis/RegionPrinter.h"
 #include "llvm/Analysis/PostDominators.h"
-#include "llvm/Analysis/DomPrinter.h"
-#include "llvm/Transforms/Utils/UnifyFunctionExitNodes.h"
-
-#include "llvm/Transforms/Scalar.h"
 
 #include "llvm/IR/LegacyPassManager.h"
-#include "llvm/Transforms/IPO/PassManagerBuilder.h"
 
 #include "llvm/InitializePasses.h"
 #include "llvm/LinkAllPasses.h"
 
 #include <iostream>
 #include <vector>
-#include <map>
 
 // #define DEBUG_PRINT 1
 #define DEBUG_PRINT 0

--- a/ffi/custom_passes.cpp
+++ b/ffi/custom_passes.cpp
@@ -216,7 +216,7 @@ struct RefPrunePass : public FunctionPass {
                 for (size_t i=0; i < decref_list.size(); ++i){
                     CallInst* decref = decref_list[i];
                     // is this instruction a decref thats non-NULL and
-                    // the recref related to the incref?
+                    // the decref related to the incref?
                     if (decref && isRelatedDecref(incref, decref)) {
                         if (DEBUG_PRINT) {
                             errs() << "Prune: matching pair in BB:\n";

--- a/ffi/custom_passes.cpp
+++ b/ffi/custom_passes.cpp
@@ -131,7 +131,7 @@ struct RefPrunePass : public FunctionPass {
             local_mutated |= runFanoutPrune(F, /*prune_raise*/false);
             local_mutated |= runFanoutPrune(F, /*prune_raise*/true);
             mutated |= local_mutated;
-        } while(false && local_mutated);
+        } while(local_mutated);
 
         return mutated;
     }

--- a/ffi/custom_passes.cpp
+++ b/ffi/custom_passes.cpp
@@ -7,6 +7,9 @@
 #include "llvm/IR/BasicBlock.h"
 #include "llvm/IR/Instructions.h"
 
+#include "llvm/ADT/SmallString.h"
+#include "llvm/ADT/SetVector.h"
+
 #include "llvm/Support/raw_ostream.h"
 #include "llvm/Analysis/Passes.h"
 #include "llvm/Analysis/RegionPass.h"
@@ -25,27 +28,13 @@
 #include "llvm/LinkAllPasses.h"
 
 #include <vector>
+#include <map>
 
 using namespace llvm;
 
 namespace llvm {
     void initializeRefPrunePassPass(PassRegistry &Registry);
 }
-/*
-struct Hello : public RegionPass {
-  static char ID;
-  Hello() : RegionPass(ID) {
-      initializeHelloPass(*PassRegistry::getPassRegistry());
-  }
-
-  bool runOnRegion(Region *region, RGPassManager &RGM) override {
-    errs() << "Hello: ";
-    errs().write_escaped(region->getNameStr()) << '\n';
-    return false;
-  }
-}; // end of struct Hello
-*/
-
 
 struct RefPrunePass : public FunctionPass {
   static char ID;
@@ -66,7 +55,7 @@ struct RefPrunePass : public FunctionPass {
     bool mutated = false;
 
     // Find all incref & decref
-    std::vector<CallInst*> incref_list, decref_list;
+    SmallVector<CallInst*, 20> incref_list, decref_list;
     for (BasicBlock &bb : F) {
         for (Instruction &ii : bb) {
             if (ii.getOpcode() == Instruction::Call) {
@@ -85,22 +74,10 @@ struct RefPrunePass : public FunctionPass {
     errs() << "Counts " << incref_list.size() << " " << decref_list.size() << "\n";
 
     // Drop refops on NULL pointers
-    for (CallInst*& refop: incref_list) {
-        if (!keepNonNullArg(refop)) {
-            refop->eraseFromParent();
-            mutated |= true;
-            refop = NULL;
-        }
-    }
-    for (CallInst*& refop: decref_list) {
-        if (!keepNonNullArg(refop)) {
-            refop->eraseFromParent();
-            mutated |= true;
-            refop = NULL;
-        }
-    }
+    mutated |= eraseNullFirstArgFromList(incref_list);
+    mutated |= eraseNullFirstArgFromList(decref_list);
 
-    // check pairs that are dominating and postdominating each other
+    // Check pairs that are dominating and postdominating each other
     for (CallInst* incref: incref_list) {
         if (incref == NULL) continue;
 
@@ -120,11 +97,115 @@ struct RefPrunePass : public FunctionPass {
                 decref->eraseFromParent();
                 decref = NULL;
                 mutated |= true;
-                continue;
             }
         }
     }
+
+    // Deal with fanout
+    // a single incref with multiple decrefs in outgoing edges
+    for (CallInst*& incref : incref_list) {
+        if (incref == NULL) continue;
+
+        SetVector<CallInst*> candidates;
+
+        Instruction* term = incref->getParent()->getTerminator();
+
+        bool balanced = true;
+        errs() << "======= AT\n" ;
+        incref->dump();
+        for (unsigned int i = 0; i < term->getNumSuccessors(); ++i) {
+            DomTreeNode* domchild = domtree.getNode(term->getSuccessor(i));
+
+            errs() << "==== check " << domchild->getBlock()->getName() << "\n";
+            if (!findDecrefDominatedByNode(domtree, postdomtree, domchild, incref,
+                                           candidates)) {
+                balanced = false;
+            }
+        }
+        if (balanced) {
+            errs() << "======balanced" << "\n";
+            for (CallInst* inst : candidates)  {
+                inst->dump();
+            }
+            errs() << "======" << "\n";
+            incref->eraseFromParent();
+            for (CallInst* inst : candidates)  {
+                inst->eraseFromParent();
+            }
+            incref = NULL;
+            mutated |= true;
+        }
+
+    }
     return mutated;
+  }
+
+  template <class T>
+  bool eraseNullFirstArgFromList(T& refops) {
+    bool mutated = false;
+    for (CallInst*& refop: refops) {
+        if (!isNonNullFirstArg(refop)) {
+            refop->eraseFromParent();
+            mutated |= true;
+            refop = NULL;
+        }
+    }
+    return mutated;
+  }
+
+  bool findDecrefDominatedByNode(DominatorTree &domtree,
+                               PostDominatorTree &postdomtree,
+                               DomTreeNode* dom_root,
+                               CallInst* incref,
+                               SetVector<CallInst*> &candidates,
+                               unsigned int depth = 0) {
+
+    bool found = false;
+    BasicBlock* bb_root = dom_root->getBlock();
+
+    errs() << "   -- findDecrefDominatedByNode: " << bb_root->getName() << "\n";
+
+    for (CallInst *decref : findRelatedDecrefs(dom_root->getBlock(), incref) ){
+        if ( domtree.dominates(incref, decref) ){
+            errs() << "   found\n";
+            decref->dump();
+
+            candidates.insert(decref);
+            found = true;
+            // stop on first result
+            break;
+        }
+    }
+
+    if (found) return true;
+
+    for (DomTreeNode* dom_child : dom_root->getChildren()) {
+        if (!findDecrefDominatedByNode(domtree, postdomtree, dom_child, incref, candidates)) {
+            return false;
+        }
+    }
+    return true;
+  }
+
+  /**
+   * Find related decrefs to incref inside a basicblock in order
+   */
+  std::vector<CallInst*> findRelatedDecrefs(BasicBlock* bb, CallInst* incref) {
+      std::vector<CallInst*> res;
+      for (Instruction &ii : *bb) {
+        if (ii.getOpcode() == Instruction::Call) {
+            CallInst *call_inst = dyn_cast<CallInst>(&ii);
+            Value *callee = call_inst->getCalledOperand();
+            if ( callee->getName() != "NRT_decref" ) {
+                continue;
+            }
+            if (incref->getArgOperand(0) != call_inst->getArgOperand(0)) {
+                continue;
+            }
+            res.push_back(call_inst);
+        }
+      }
+      return res;
   }
 
    void getAnalysisUsage(AnalysisUsage &Info) const override {
@@ -132,7 +213,7 @@ struct RefPrunePass : public FunctionPass {
        Info.addRequired<PostDominatorTreeWrapperPass>();
    }
 
-   bool keepNonNullArg(CallInst *call_inst){
+   bool isNonNullFirstArg(CallInst *call_inst){
        auto val = call_inst->getArgOperand(0);
        auto ptr = dyn_cast<ConstantPointerNull>(val);
        return ptr == NULL;

--- a/ffi/custom_passes.cpp
+++ b/ffi/custom_passes.cpp
@@ -445,6 +445,11 @@ struct RefPrunePass : public FunctionPass {
             return true;  // done for this path
         }
 
+        if ( hasAnyDecrefInNode(cur_node) ) {
+            // Because we don't know about aliasing
+            return false;
+        }
+
         // checking for raise blocks
         if (raising_blocks && isRaising(cur_node)) {
             raising_blocks->insert(cur_node);

--- a/ffi/custom_passes.cpp
+++ b/ffi/custom_passes.cpp
@@ -684,8 +684,8 @@ struct RefPrunePass : public FunctionPass {
             found = walkChildForDecref(
                 incref, child, path_stack, decref_blocks, raising_blocks
             );
-            // if not found, return false?! can this just return found?
-            if (!found) return false;
+            // if not found, return false
+            if (!found) return found;  // found must be false
         }
         return found;
     }

--- a/ffi/custom_passes.cpp
+++ b/ffi/custom_passes.cpp
@@ -163,7 +163,7 @@ struct RefPrunePass : public FunctionPass {
             // Remove refops on NULL
             for (CallInst* ci: null_list) {
                 ci->eraseFromParent();
-                mutated |= true;
+                mutated = true;
                 stats_per_bb += 1;
             }
             // Find matching pairs of incref decref
@@ -182,7 +182,7 @@ struct RefPrunePass : public FunctionPass {
                         decref->eraseFromParent();
 
                         decref_list[i] = NULL;
-                        mutated |= true;
+                        mutated = true;
                         stats_per_bb += 2;
                         break;
                     }

--- a/ffi/custom_passes.cpp
+++ b/ffi/custom_passes.cpp
@@ -860,15 +860,37 @@ LLVMPY_AddRefPrunePass(LLVMPassManagerRef PM)
     unwrap(PM)->add(new RefPrunePass());
 }
 
+
+typedef struct PruneStats {
+    size_t basicblock;
+    size_t diamond;
+    size_t fanout;
+    size_t fanout_raise;
+} PRUNESTATS;
+
+
 API_EXPORT(void)
-LLVMPY_DumpRefPruneStats()
+LLVMPY_DumpRefPruneStats(PRUNESTATS *buf, bool do_print)
 {
-    errs() << "refprune stats "
-           << "per-BB " << RefPrunePass::stats_per_bb << " "
-           << "diamond " << RefPrunePass::stats_diamond << " "
-           << "fanout " << RefPrunePass::stats_fanout << " "
-           << "fanout+raise " << RefPrunePass::stats_fanout_raise << " "
-           << "\n";
+    /* PRUNESTATS is updated with the statistics about what has been pruned from
+     * the RefPrunePass static state vars. This isn't threadsafe but neither is
+     * the LLVM pass infrastructure so it's all done under a python thread lock.
+     *
+     * do_print if set will print the stats to stderr.
+     */
+    if (do_print) {
+        errs() << "refprune stats "
+            << "per-BB " << RefPrunePass::stats_per_bb << " "
+            << "diamond " << RefPrunePass::stats_diamond << " "
+            << "fanout " << RefPrunePass::stats_fanout << " "
+            << "fanout+raise " << RefPrunePass::stats_fanout_raise << " "
+            << "\n";
+    };
+
+    buf->basicblock = RefPrunePass::stats_per_bb;
+    buf->diamond = RefPrunePass::stats_diamond;
+    buf->fanout = RefPrunePass::stats_fanout;
+    buf->fanout_raise = RefPrunePass::stats_fanout_raise;
 }
 
 

--- a/llvmlite/binding/passmanagers.py
+++ b/llvmlite/binding/passmanagers.py
@@ -62,12 +62,10 @@ def create_function_pass_manager(module):
 
 
 class RefPruneSubpasses(IntFlag):
-class RefPruneSubpasses(IntFlag):
-    PER_BB       = 0b0001
-    DIAMOND      = 0b0010
-    FANOUT       = 0b0100
+    PER_BB       = 0b0001    # noqa: E221
+    DIAMOND      = 0b0010    # noqa: E221
+    FANOUT       = 0b0100    # noqa: E221
     FANOUT_RAISE = 0b1000
-    ALL = PER_BB | DIAMOND | FANOUT | FANOUT_RAISE
     ALL = PER_BB | DIAMOND | FANOUT | FANOUT_RAISE
 
 

--- a/llvmlite/binding/passmanagers.py
+++ b/llvmlite/binding/passmanagers.py
@@ -6,6 +6,7 @@ from llvmlite.binding import ffi
 _prunestats = namedtuple('PruneStats',
                          ('basicblock diamond fanout fanout_raise'))
 
+
 class PruneStats(_prunestats):
     """ Holds statistics from reference count pruning.
     """
@@ -28,6 +29,7 @@ class PruneStats(_prunestats):
                           self.diamond - other.diamond,
                           self.fanout - other.fanout,
                           self.fanout_raise - other.fanout_raise)
+
 
 class _c_PruneStats(Structure):
     _fields_ = [

--- a/llvmlite/binding/passmanagers.py
+++ b/llvmlite/binding/passmanagers.py
@@ -82,6 +82,11 @@ class PassManager(ffi.ObjectRef):
         """See http://llvm.org/docs/AliasAnalysis.html#the-basicaa-pass."""
         ffi.lib.LLVMPY_AddBasicAliasAnalysisPass(self)
 
+    # Non-standard LLVM passes
+
+    def add_refprune_pass(self):
+        ffi.lib.LLVMPY_AddRefPrunePass(self)
+
 
 class ModulePassManager(PassManager):
 

--- a/llvmlite/binding/passmanagers.py
+++ b/llvmlite/binding/passmanagers.py
@@ -10,6 +10,10 @@ def create_function_pass_manager(module):
     return FunctionPassManager(module)
 
 
+def dump_refprune_stats():
+    ffi.lib.LLVMPY_DumpRefPruneStats()
+
+
 class PassManager(ffi.ObjectRef):
     """PassManager
     """

--- a/llvmlite/binding/passmanagers.py
+++ b/llvmlite/binding/passmanagers.py
@@ -62,10 +62,12 @@ def create_function_pass_manager(module):
 
 
 class RefPruneSubpasses(IntFlag):
-    PER_BB = 1
-    DIAMOND = 1 << 1
-    FANOUT = 1 << 2
-    FANOUT_RAISE = 1 << 3
+class RefPruneSubpasses(IntFlag):
+    PER_BB       = 0b0001
+    DIAMOND      = 0b0010
+    FANOUT       = 0b0100
+    FANOUT_RAISE = 0b1000
+    ALL = PER_BB | DIAMOND | FANOUT | FANOUT_RAISE
     ALL = PER_BB | DIAMOND | FANOUT | FANOUT_RAISE
 
 

--- a/llvmlite/tests/refprune_proto.py
+++ b/llvmlite/tests/refprune_proto.py
@@ -227,6 +227,9 @@ class FanoutAlgorithm:
                 for pred in self.get_predecessors(cur_node):
                     if pred in decref_blocks:
                         # reject because there's a predecessor in decref_blocks
+                        self.print(
+                            "!! reject because predecessor in decref_blocks"
+                        )
                         return False
                     if pred != head_node:
 

--- a/llvmlite/tests/refprune_proto.py
+++ b/llvmlite/tests/refprune_proto.py
@@ -303,7 +303,7 @@ def check_once():
     # Render graph
     G = Digraph()
     for node in edges:
-        G.node(node, shape="rect", label=f"{node}\n" + "\l".join(nodes[node]))
+        G.node(node, shape="rect", label=f"{node}\n" + r"\l".join(nodes[node]))
     for node, children in edges.items():
         for child in children:
             G.edge(node, child)

--- a/llvmlite/tests/refprune_proto.py
+++ b/llvmlite/tests/refprune_proto.py
@@ -1,6 +1,6 @@
 """
-Contains tests and prototype implementation for the fanout algorithm in
-refprune pass.
+Contains tests and a prototype implementation for the fanout algorithm in
+the LLVM refprune pass.
 """
 
 try:
@@ -8,7 +8,6 @@ try:
 except ImportError:
     pass
 from collections import defaultdict
-# from pprint import pprint
 
 # The entry block. It's always the same.
 ENTRY = "A"
@@ -319,7 +318,7 @@ def check_all():
         if k.startswith("case"):
             print(f"{fn}".center(80, "-"))
             nodes, edges, expected = fn()
-            algo = FanoutAlgorithm(nodes, edges, verbose=True)
+            algo = FanoutAlgorithm(nodes, edges)
             got = algo.run()
             assert expected == got
     print("ALL PASSED")

--- a/llvmlite/tests/refprune_proto.py
+++ b/llvmlite/tests/refprune_proto.py
@@ -1,0 +1,328 @@
+"""
+Contains tests and prototype implementation for the fanout algorithm in
+refprune pass.
+"""
+
+try:
+    from graphviz import Digraph
+except ImportError:
+    pass
+from collections import defaultdict
+from copy import deepcopy
+# from pprint import pprint
+
+# The entry block. It's always the same.
+ENTRY = "A"
+
+
+# The following caseNN() functions returns a 3-tuple of
+# (nodes, edges, expected).
+# `nodes` maps BB nodes to incref/decref inside the block.
+# `edges` maps BB nodes to their successor BB.
+# `expected` maps BB-node with incref to a set of BB-nodes with the decrefs, or
+#            the value can be None, indicating invalid prune.
+
+def case1():
+    edges = {
+        "A": ["B"],
+        "B": ["C", "D"],
+        "C": [],
+        "D": ["E", "F"],
+        "E": ["G"],
+        "F": [],
+        "G": ["H", "I"],
+        "I": ["G", "F"],
+        "H": ["J", "K"],
+        "J": ["L", "M"],
+        "K": [],
+        "L": ["Z"],
+        "M": ["Z", "O", "P"],
+        "O": ["Z"],
+        "P": ["Z"],
+        "Z": [],
+    }
+    nodes = defaultdict(list)
+    nodes["D"] = ["incref"]
+    nodes["H"] = ["decref"]
+    nodes["F"] = ["decref", "decref"]
+    expected = {"D": {"H", "F"}}
+    return deepcopy(nodes), deepcopy(edges), deepcopy(expected)
+
+
+def case2():
+    edges = {
+        "A": ["B", "C"],
+        "B": ["C"],
+        "C": [],
+    }
+    nodes = defaultdict(list)
+    nodes["A"] = ["incref"]
+    nodes["B"] = ["decref"]
+    nodes["C"] = ["decref"]
+    expected = {"A": None}
+    return deepcopy(nodes), deepcopy(edges), deepcopy(expected)
+
+
+def case3():
+    nodes, edges, _ = case1()
+    # adds an invalid edge
+    edges["H"].append("F")
+    expected = {"D": None}
+    return deepcopy(nodes), deepcopy(edges), deepcopy(expected)
+
+
+def case4():
+    nodes, edges, _ = case1()
+    # adds an invalid edge
+    edges["H"].append("E")
+    expected = {"D": None}
+    return deepcopy(nodes), deepcopy(edges), deepcopy(expected)
+
+
+def case5():
+    nodes, edges, _ = case1()
+    # adds backedge to go before incref
+    edges["B"].append("I")
+    expected = {"D": None}
+    return deepcopy(nodes), deepcopy(edges), deepcopy(expected)
+
+
+def case6():
+    nodes, edges, _ = case1()
+    # adds backedge to go before incref
+    edges["I"].append("B")
+    expected = {"D": None}
+    return deepcopy(nodes), deepcopy(edges), deepcopy(expected)
+
+
+def case7():
+    nodes, edges, _ = case1()
+    # adds forward jump outside
+    edges["I"].append("M")
+    expected = {"D": None}
+    return deepcopy(nodes), deepcopy(edges), deepcopy(expected)
+
+
+def case8():
+    edges = {
+        "A": ["B", "C"],
+        "B": ["C"],
+        "C": [],
+    }
+    nodes = defaultdict(list)
+    nodes["A"] = ["incref"]
+    nodes["C"] = ["decref"]
+    expected = {"A": {"C"}}
+    return deepcopy(nodes), deepcopy(edges), deepcopy(expected)
+
+
+def case9():
+    nodes, edges, _ = case8()
+    # adds back edge
+    edges["C"].append("B")
+    expected = {"A": None}
+    return deepcopy(nodes), deepcopy(edges), deepcopy(expected)
+
+
+def case10():
+    nodes, edges, _ = case8()
+    # adds back edge to A
+    edges["C"].append("A")
+    expected = {"A": {"C"}}
+    return deepcopy(nodes), deepcopy(edges), deepcopy(expected)
+
+
+def case11():
+    nodes, edges, _ = case8()
+    edges["C"].append("D")
+    edges["D"] = []
+    expected = {"A": {"C"}}
+    return deepcopy(nodes), deepcopy(edges), deepcopy(expected)
+
+
+def case12():
+    nodes, edges, _ = case8()
+    edges["C"].append("D")
+    edges["D"] = ["A"]
+    expected = {"A": {"C"}}
+    return deepcopy(nodes), deepcopy(edges), deepcopy(expected)
+
+
+def case13():
+    nodes, edges, _ = case8()
+    edges["C"].append("D")
+    edges["D"] = ["B"]
+    expected = {"A": None}
+    return deepcopy(nodes), deepcopy(edges), deepcopy(expected)
+
+
+def make_predecessor_map(edges):
+    d = defaultdict(set)
+    for src, outgoings in edges.items():
+        for dst in outgoings:
+            d[dst].add(src)
+    return d
+
+
+class FanoutAlgorithm:
+    def __init__(self, nodes, edges, verbose=False):
+        self.nodes = nodes
+        self.edges = edges
+        self.rev_edges = make_predecessor_map(edges)
+        self.print = print if verbose else self._null_print
+
+    def run(self):
+        return self.find_fanout_in_function()
+
+    def _null_print(self, *args, **kwargs):
+        pass
+
+    def find_fanout_in_function(self):
+        got = {}
+        for cur_node in self.edges:
+            for incref in (x for x in self.nodes[cur_node] if x == "incref"):
+                decref_blocks = self.find_fanout(cur_node)
+                self.print(">>", cur_node, "===", decref_blocks)
+                got[cur_node] = decref_blocks
+        return got
+
+    def find_fanout(self, head_node):
+        decref_blocks = self.find_decref_candidates(head_node)
+        self.print("candidates", decref_blocks)
+        if not decref_blocks:
+            return None
+        if not self.verify_non_overlapping(
+            head_node, decref_blocks, entry=ENTRY
+        ):
+            return None
+        return set(decref_blocks)
+
+    def verify_non_overlapping(self, head_node, decref_blocks, entry):
+        self.print("verify_non_overlapping".center(80, "-"))
+        # reverse walk for each decref_blocks
+        # they should end at head_node
+        todo = list(decref_blocks)
+        while todo:
+            cur_node = todo.pop()
+            visited = set()
+
+            workstack = [cur_node]
+            del cur_node
+            while workstack:
+                cur_node = workstack.pop()
+                self.print("cur_node", cur_node, "|", workstack)
+                if cur_node in visited:
+                    continue  # skip
+                if cur_node == entry:
+                    # Entry node
+                    self.print(
+                        "!! failed because we arrived at entry", cur_node
+                    )
+                    return False
+                visited.add(cur_node)
+                # check all predecessors
+                self.print(
+                    f"   {cur_node} preds {self.get_predecessors(cur_node)}"
+                )
+                for pred in self.get_predecessors(cur_node):
+                    if pred in decref_blocks:
+                        # reject because there's a predecessor in decref_blocks
+                        return False
+                    if pred != head_node:
+
+                        workstack.append(pred)
+
+        return True
+
+    def get_successors(self, node):
+        return tuple(self.edges[node])
+
+    def get_predecessors(self, node):
+        return tuple(self.rev_edges[node])
+
+    def has_decref(self, node):
+        return "decref" in self.nodes[node]
+
+    def walk_child_for_decref(
+        self, cur_node, path_stack, decref_blocks, depth=10
+    ):
+        indent = " " * len(path_stack)
+        self.print(indent, "walk", path_stack, cur_node)
+        if depth <= 0:
+            return False  # missing
+        if cur_node in path_stack:
+            if cur_node == path_stack[0]:
+                return False  # reject interior node backedge
+            return True  # skip
+        if self.has_decref(cur_node):
+            decref_blocks.add(cur_node)
+            self.print(indent, "found decref")
+            return True
+
+        depth -= 1
+        path_stack += (cur_node,)
+        found = False
+        for child in self.get_successors(cur_node):
+            if not self.walk_child_for_decref(
+                child, path_stack, decref_blocks
+            ):
+                found = False
+                break
+            else:
+                found = True
+
+        self.print(indent, f"ret {found}")
+        return found
+
+    def find_decref_candidates(self, cur_node):
+        # Forward pass
+        self.print("find_decref_candidates".center(80, "-"))
+        path_stack = (cur_node,)
+        found = False
+        decref_blocks = set()
+        for child in self.get_successors(cur_node):
+            if not self.walk_child_for_decref(
+                child, path_stack, decref_blocks
+            ):
+                found = False
+                break
+            else:
+                found = True
+        if not found:
+            return set()
+        else:
+            return decref_blocks
+
+
+def check_once():
+    nodes, edges, expected = case13()
+
+    # Render graph
+    G = Digraph()
+    for node in edges:
+        G.node(node, shape="rect", label=f"{node}\n" + "\l".join(nodes[node]))
+    for node, children in edges.items():
+        for child in children:
+            G.edge(node, child)
+
+    G.view()
+
+    algo = FanoutAlgorithm(nodes, edges, verbose=True)
+    got = algo.run()
+    assert expected == got
+
+
+def check_all():
+    for k, fn in list(globals().items()):
+        if k.startswith("case"):
+            print(f"{fn}".center(80, "-"))
+            nodes, edges, expected = fn()
+            algo = FanoutAlgorithm(nodes, edges, verbose=True)
+            got = algo.run()
+            assert expected == got
+    print("ALL PASSED")
+
+
+if __name__ == "__main__":
+    # check_once()
+    check_all()

--- a/llvmlite/tests/refprune_proto.py
+++ b/llvmlite/tests/refprune_proto.py
@@ -8,7 +8,6 @@ try:
 except ImportError:
     pass
 from collections import defaultdict
-from copy import deepcopy
 # from pprint import pprint
 
 # The entry block. It's always the same.
@@ -46,7 +45,7 @@ def case1():
     nodes["H"] = ["decref"]
     nodes["F"] = ["decref", "decref"]
     expected = {"D": {"H", "F"}}
-    return deepcopy(nodes), deepcopy(edges), deepcopy(expected)
+    return nodes, edges, expected
 
 
 def case2():
@@ -60,7 +59,7 @@ def case2():
     nodes["B"] = ["decref"]
     nodes["C"] = ["decref"]
     expected = {"A": None}
-    return deepcopy(nodes), deepcopy(edges), deepcopy(expected)
+    return nodes, edges, expected
 
 
 def case3():
@@ -68,7 +67,7 @@ def case3():
     # adds an invalid edge
     edges["H"].append("F")
     expected = {"D": None}
-    return deepcopy(nodes), deepcopy(edges), deepcopy(expected)
+    return nodes, edges, expected
 
 
 def case4():
@@ -76,7 +75,7 @@ def case4():
     # adds an invalid edge
     edges["H"].append("E")
     expected = {"D": None}
-    return deepcopy(nodes), deepcopy(edges), deepcopy(expected)
+    return nodes, edges, expected
 
 
 def case5():
@@ -84,7 +83,7 @@ def case5():
     # adds backedge to go before incref
     edges["B"].append("I")
     expected = {"D": None}
-    return deepcopy(nodes), deepcopy(edges), deepcopy(expected)
+    return nodes, edges, expected
 
 
 def case6():
@@ -92,7 +91,7 @@ def case6():
     # adds backedge to go before incref
     edges["I"].append("B")
     expected = {"D": None}
-    return deepcopy(nodes), deepcopy(edges), deepcopy(expected)
+    return nodes, edges, expected
 
 
 def case7():
@@ -100,7 +99,7 @@ def case7():
     # adds forward jump outside
     edges["I"].append("M")
     expected = {"D": None}
-    return deepcopy(nodes), deepcopy(edges), deepcopy(expected)
+    return nodes, edges, expected
 
 
 def case8():
@@ -113,7 +112,7 @@ def case8():
     nodes["A"] = ["incref"]
     nodes["C"] = ["decref"]
     expected = {"A": {"C"}}
-    return deepcopy(nodes), deepcopy(edges), deepcopy(expected)
+    return nodes, edges, expected
 
 
 def case9():
@@ -121,7 +120,7 @@ def case9():
     # adds back edge
     edges["C"].append("B")
     expected = {"A": None}
-    return deepcopy(nodes), deepcopy(edges), deepcopy(expected)
+    return nodes, edges, expected
 
 
 def case10():
@@ -129,7 +128,7 @@ def case10():
     # adds back edge to A
     edges["C"].append("A")
     expected = {"A": {"C"}}
-    return deepcopy(nodes), deepcopy(edges), deepcopy(expected)
+    return nodes, edges, expected
 
 
 def case11():
@@ -137,7 +136,7 @@ def case11():
     edges["C"].append("D")
     edges["D"] = []
     expected = {"A": {"C"}}
-    return deepcopy(nodes), deepcopy(edges), deepcopy(expected)
+    return nodes, edges, expected
 
 
 def case12():
@@ -145,7 +144,7 @@ def case12():
     edges["C"].append("D")
     edges["D"] = ["A"]
     expected = {"A": {"C"}}
-    return deepcopy(nodes), deepcopy(edges), deepcopy(expected)
+    return nodes, edges, expected
 
 
 def case13():
@@ -153,7 +152,7 @@ def case13():
     edges["C"].append("D")
     edges["D"] = ["B"]
     expected = {"A": None}
-    return deepcopy(nodes), deepcopy(edges), deepcopy(expected)
+    return nodes, edges, expected
 
 
 def make_predecessor_map(edges):

--- a/llvmlite/tests/test_refprune.py
+++ b/llvmlite/tests/test_refprune.py
@@ -157,4 +157,3 @@ class TestRefPrunePass(TestCase):
 
 if __name__ == '__main__':
     unittest.main()
-

--- a/llvmlite/tests/test_refprune.py
+++ b/llvmlite/tests/test_refprune.py
@@ -77,10 +77,11 @@ class TestRefPrunePass(TestCase):
         bbmap = {}
         for bb in edges:
             bbmap[bb] = fn.append_basic_block(bb)
-        # populate the edges
+        # populate the BB
         builder = ir.IRBuilder()
         for bb, jump_targets in edges.items():
             builder.position_at_end(bbmap[bb])
+            # Insert increfs and decrefs
             for action in nodes[bb]:
                 if action == 'incref':
                     builder.call(incref_fn, [ptr])
@@ -89,6 +90,8 @@ class TestRefPrunePass(TestCase):
                 else:
                     raise AssertionError('unreachable')
 
+            # Insert the terminator.
+            # Switch base on the number of jump targets.
             n_targets = len(jump_targets)
             if n_targets == 0:
                 builder.ret_void()

--- a/llvmlite/tests/test_refprune.py
+++ b/llvmlite/tests/test_refprune.py
@@ -206,6 +206,8 @@ define void @main(i8* %ptr) {
     def test_per_bb_2(self):
         mod, stats = self.check(self.per_bb_ir_2)
         self.assertEqual(stats.basicblock, 4)
+        # not pruned
+        self.assertIn("call void @NRT_incref(i8* %ptr)", str(mod))
 
     per_bb_ir_3 = r"""
 define void @main(i8* %ptr, i8* %other) {

--- a/llvmlite/tests/test_refprune.py
+++ b/llvmlite/tests/test_refprune.py
@@ -1,0 +1,151 @@
+import unittest
+from llvmlite import ir
+from llvmlite import binding as llvm
+from llvmlite.tests import TestCase
+
+from . import refprune_proto as proto
+
+
+def _iterate_cases(generate_test):
+    def wrap(fn):
+        def wrapped(self):
+            return generate_test(self, fn)
+        wrapped.__doc__ = f"generated test for {fn.__module__}.{fn.__name__}"
+        return wrapped
+
+    for k, case_fn in proto.__dict__.items():
+        if k.startswith('case'):
+            yield f'test_{k}', wrap(case_fn)
+
+
+class TestRefPrunePrototype(TestCase):
+    def generate_test(self, case_gen):
+        nodes, edges, expected = case_gen()
+        got = proto.FanoutAlgorithm(nodes, edges).run()
+        self.assertEqual(expected, got)
+
+    # Generate tests
+    for name, case in _iterate_cases(generate_test):
+        locals()[name] = case
+
+
+ptr_ty = ir.IntType(8).as_pointer()
+
+
+class TestRefPrunePass(TestCase):
+
+    def make_incref(self, m):
+        fnty = ir.FunctionType(ir.VoidType(), [ptr_ty])
+        return ir.Function(m, fnty, name='NRT_incref')
+
+    def make_decref(self, m):
+        fnty = ir.FunctionType(ir.VoidType(), [ptr_ty])
+        return ir.Function(m, fnty, name='NRT_decref')
+
+    def make_switcher(self, m):
+        fnty = ir.FunctionType(ir.IntType(32), ())
+        return ir.Function(m, fnty, name='switcher')
+
+    def make_brancher(self, m):
+        fnty = ir.FunctionType(ir.IntType(1), ())
+        return ir.Function(m, fnty, name='brancher')
+
+    def generate_ir(self, nodes, edges):
+        # Build LLVM module for the CFG
+        m = ir.Module()
+
+        incref_fn = self.make_incref(m)
+        decref_fn = self.make_decref(m)
+        switcher_fn = self.make_switcher(m)
+        brancher_fn = self.make_brancher(m)
+
+        fnty = ir.FunctionType(ir.VoidType(), [ptr_ty])
+        fn = ir.Function(m, fnty, name='main')
+        [ptr] = fn.args
+        ptr.name = 'mem'
+        # populate the BB nodes
+        bbmap = {}
+        for bb in edges:
+            bbmap[bb] = fn.append_basic_block(bb)
+        # populate the edges
+        builder = ir.IRBuilder()
+        for bb, jump_targets in edges.items():
+            builder.position_at_end(bbmap[bb])
+            for action in nodes[bb]:
+                if action == 'incref':
+                    builder.call(incref_fn, [ptr])
+                elif action == 'decref':
+                    builder.call(decref_fn, [ptr])
+                else:
+                    raise AssertionError('unreachable')
+
+            n_targets = len(jump_targets)
+            if n_targets == 0:
+                builder.ret_void()
+            elif n_targets == 1:
+                [dst] = jump_targets
+                builder.branch(bbmap[dst])
+            elif n_targets == 2:
+                [left, right] = jump_targets
+                sel = builder.call(brancher_fn, ())
+                builder.cbranch(sel, bbmap[left], bbmap[right])
+            elif n_targets > 2:
+                sel = builder.call(switcher_fn, ())
+                [head, *tail] = jump_targets
+
+                sw = builder.switch(sel, default=bbmap[head])
+                for i, dst in enumerate(tail):
+                    sw.add_case(sel.type(i), bbmap[dst])
+            else:
+                raise AssertionError('unreachable')
+
+        return m
+
+    def apply_refprune(self, irmod):
+        mod = llvm.parse_assembly(str(irmod))
+        pm = llvm.ModulePassManager()
+        pm.add_refprune_pass()
+        pm.run(mod)
+        return mod
+
+    def check(self, mod, expected, nodes):
+        # preprocess incref/decref locations
+        d = {}
+        for k, vs in nodes.items():
+            n_incref = vs.count('incref')
+            n_decref = vs.count('decref')
+            d[k] = {'incref': n_incref, 'decref': n_decref}
+        for k, stats in d.items():
+            if expected.get(k):
+                stats['incref'] -= 1
+                for dec_bb in expected[k]:
+                    d[dec_bb]['decref'] -= 1
+
+        # find the main function
+        for f in mod.functions:
+            if f.name == 'main':
+                break
+        # check each BB
+        for bb in f.blocks:
+            stats = d[bb.name]
+            text = str(bb)
+            n_incref = text.count('NRT_incref')
+            n_decref = text.count('NRT_decref')
+            self.assertEqual(stats['incref'], n_incref, msg=f'BB {bb}')
+            self.assertEqual(stats['decref'], n_decref, msg=f'BB {bb}')
+
+    def generate_test(self, case_gen):
+        nodes, edges, expected = case_gen()
+        irmod = self.generate_ir(nodes, edges)
+        print(irmod)
+        outmod = self.apply_refprune(irmod)
+        self.check(outmod, expected, nodes)
+
+    # Generate tests
+    for name, case in _iterate_cases(generate_test):
+        locals()[name] = case
+
+
+if __name__ == '__main__':
+    unittest.main()
+

--- a/llvmlite/tests/test_refprune.py
+++ b/llvmlite/tests/test_refprune.py
@@ -40,7 +40,7 @@ class TestRefPrunePass(TestCase):
     Test that the C++ implementation matches the expected behavior as for
     the prototype.
 
-    This generates a LLVM module for each test case, runs the pruner and check
+    This generates a LLVM module for each test case, runs the pruner and checks
     that the expected results are achieved.
     """
 

--- a/llvmlite/tests/test_refprune.py
+++ b/llvmlite/tests/test_refprune.py
@@ -19,6 +19,9 @@ def _iterate_cases(generate_test):
 
 
 class TestRefPrunePrototype(TestCase):
+    """
+    Test that the prototype is working.
+    """
     def generate_test(self, case_gen):
         nodes, edges, expected = case_gen()
         got = proto.FanoutAlgorithm(nodes, edges).run()
@@ -33,6 +36,13 @@ ptr_ty = ir.IntType(8).as_pointer()
 
 
 class TestRefPrunePass(TestCase):
+    """
+    Test that the C++ implementation matches the expected behavior as for
+    the prototype.
+
+    This generates a LLVM module for each test case, runs the pruner and check
+    that the expected results are achieved.
+    """
 
     def make_incref(self, m):
         fnty = ir.FunctionType(ir.VoidType(), [ptr_ty])
@@ -137,7 +147,6 @@ class TestRefPrunePass(TestCase):
     def generate_test(self, case_gen):
         nodes, edges, expected = case_gen()
         irmod = self.generate_ir(nodes, edges)
-        print(irmod)
         outmod = self.apply_refprune(irmod)
         self.check(outmod, expected, nodes)
 


### PR DESCRIPTION
This adds a custom pass mainly for `numba` to prune redundant reference count.

Before merge, do these:

- [x] undo version postfix https://github.com/numba/llvmlite/pull/634/files/dfcb6bb9f225eb9b12b4da751f058f1b08d42506#r500189193