### PR TITLE
fix llvmdev build number

### DIFF
--- a/conda-recipes/llvmdev/meta.yaml
+++ b/conda-recipes/llvmdev/meta.yaml
@@ -13,7 +13,7 @@
 {% set version = "10.0.1" %}
 {% set sha256_llvm = "c5d8e30b57cbded7128d78e5e8dad811bff97a8d471896812f57fa99ee82cdf3" %}
 {% set sha256_lld = "591449e0aa623a6318d5ce2371860401653c48bb540982ccdd933992cb88df7a" %}
-{% set build_number = "0" %}
+{% set build_number = "1" %}
 
 {% endif %}
 

--- a/conda-recipes/llvmdev_manylinux2010/meta.yaml
+++ b/conda-recipes/llvmdev_manylinux2010/meta.yaml
@@ -13,7 +13,7 @@
 {% set version = "10.0.1" %}
 {% set sha256_llvm = "c5d8e30b57cbded7128d78e5e8dad811bff97a8d471896812f57fa99ee82cdf3" %}
 {% set sha256_lld = "591449e0aa623a6318d5ce2371860401653c48bb540982ccdd933992cb88df7a" %}
-{% set build_number = "0" %}
+{% set build_number = "1" %}
 
 {% endif %}
 


### PR DESCRIPTION
The current version of `llvmdev` on `numba/label/main` is 10.0.1-1 -- as
this was build from the PR at:

https://github.com/numba/llvmlite/pull/636

To sync the state of the repository with the state of the build
artifacts, we must increment the llvmdev build number.