### PR TITLE
pin to correct version of llvmdev

### DIFF
--- a/conda-recipes/llvmlite/meta.yaml
+++ b/conda-recipes/llvmlite/meta.yaml
@@ -28,8 +28,10 @@ requirements:
   host:
     - python
     # On channel https://anaconda.org/numba/
-    # LLVM 10.0.0 and 10.0.1 had issues on aarch64
-    - llvmdev 10.0.* # [not aarch64]
+    # Build using LLVM (llvmdev) 10.0.1-1 on most platforms
+    - llvmdev 10.0.1 *1 # [not aarch64 and not win]
+    - llvmdev 10.0.1 1 # [win]
+    # Build using LLVM (llvmdev) 9.0.* on aarch64
     - llvmdev 9.0.* # [aarch64]
     - vs2015_runtime # [win]
     # llvmdev is built with libz compression support


### PR DESCRIPTION
llvmlite will need to be built against the correct version and build
number of llvmdev. This pins that version number as part of the
`conda-recpie`.