### PR TITLE
Fix refprune fanout_raise case getting stuck on large graphs

### DIFF
--- a/ffi/custom_passes.cpp
+++ b/ffi/custom_passes.cpp
@@ -174,7 +174,7 @@ struct RefPrunePass : public FunctionPass {
     static const size_t FANOUT_RECURSE_DEPTH= 15;
     typedef SmallSet<BasicBlock*, FANOUT_RECURSE_DEPTH> SmallBBSet;
 
-    // Limit the number of nodes that the fanout pruners will look at.
+    // The maximum number of nodes that the fanout pruners will look at.
     size_t subgraph_limit;
 
     /**

--- a/llvmlite/binding/passmanagers.py
+++ b/llvmlite/binding/passmanagers.py
@@ -143,16 +143,21 @@ class PassManager(ffi.ObjectRef):
 
     # Non-standard LLVM passes
 
-    def add_refprune_pass(self, subpasses_flags=RefPruneSubpasses.ALL):
+    def add_refprune_pass(self, subpasses_flags=RefPruneSubpasses.ALL,
+                          subgraph_limit=1000):
         """Add Numba specific Reference count pruning pass.
 
         Parameters
         ----------
         subpasses_flags : RefPruneSubpasses
             A bitmask to control the subpasses to be enabled.
+        subgraph_limit : int
+            Limit the fanout pruners to subgraph of no bigger than this number
+            of basic-blocks to avoid spending too much time in very large
+            graph. Default to 1000. Subject to change in future versions.
         """
         iflags = RefPruneSubpasses(subpasses_flags)
-        ffi.lib.LLVMPY_AddRefPrunePass(self, iflags)
+        ffi.lib.LLVMPY_AddRefPrunePass(self, iflags, subgraph_limit)
 
 
 class ModulePassManager(PassManager):
@@ -241,4 +246,5 @@ ffi.lib.LLVMPY_AddSROAPass.argtypes = [ffi.LLVMPassManagerRef]
 ffi.lib.LLVMPY_AddTypeBasedAliasAnalysisPass.argtypes = [ffi.LLVMPassManagerRef]
 ffi.lib.LLVMPY_AddBasicAliasAnalysisPass.argtypes = [ffi.LLVMPassManagerRef]
 
-ffi.lib.LLVMPY_AddRefPrunePass.argtypes = [ffi.LLVMPassManagerRef, c_int]
+ffi.lib.LLVMPY_AddRefPrunePass.argtypes = [ffi.LLVMPassManagerRef, c_int,
+                                           c_size_t]

--- a/llvmlite/binding/passmanagers.py
+++ b/llvmlite/binding/passmanagers.py
@@ -152,9 +152,10 @@ class PassManager(ffi.ObjectRef):
         subpasses_flags : RefPruneSubpasses
             A bitmask to control the subpasses to be enabled.
         subgraph_limit : int
-            Limit the fanout pruners to working on a subgraph no bigger than this number
-            of basic-blocks to avoid spending too much time in very large
-            graphs. Default is 1000. Subject to change in future versions.
+            Limit the fanout pruners to working on a subgraph no bigger than
+            this number of basic-blocks to avoid spending too much time in very
+            large graphs. Default is 1000. Subject to change in future
+            versions.
         """
         iflags = RefPruneSubpasses(subpasses_flags)
         ffi.lib.LLVMPY_AddRefPrunePass(self, iflags, subgraph_limit)

--- a/llvmlite/binding/passmanagers.py
+++ b/llvmlite/binding/passmanagers.py
@@ -152,9 +152,9 @@ class PassManager(ffi.ObjectRef):
         subpasses_flags : RefPruneSubpasses
             A bitmask to control the subpasses to be enabled.
         subgraph_limit : int
-            Limit the fanout pruners to subgraph of no bigger than this number
+            Limit the fanout pruners to working on a subgraph no bigger than this number
             of basic-blocks to avoid spending too much time in very large
-            graph. Default to 1000. Subject to change in future versions.
+            graphs. Default is 1000. Subject to change in future versions.
         """
         iflags = RefPruneSubpasses(subpasses_flags)
         ffi.lib.LLVMPY_AddRefPrunePass(self, iflags, subgraph_limit)


### PR DESCRIPTION
~~by rejecting visited nodes in fanout forward pass.~~

by limiting maximum visit count in fanout subgraph and avoiding revisiting into nodes that are known to always fail because of the CFG.