### PR TITLE
Switch encoding to UTF-8 from latin1

### DIFF
--- a/llvmlite/binding/common.py
+++ b/llvmlite/binding/common.py
@@ -2,12 +2,12 @@ import atexit
 
 
 def _encode_string(s):
-    encoded = s.encode('latin1')
+    encoded = s.encode('utf-8')
     return encoded
 
 
 def _decode_string(b):
-    return b.decode('latin1')
+    return b.decode('utf-8')
 
 
 _encode_string.__doc__ = """Encode a string for use by LLVM."""


### PR DESCRIPTION
Opening this PR to see what happens on CI.

This change was originally made in PR #53, but may no longer be required (and may cause issues with comments in IR that use non-latin1 characters).