### PR TITLE
Phi instructions should invalidate their string cache when new incomings are added

### DIFF
--- a/llvmlite/ir/instructions.py
+++ b/llvmlite/ir/instructions.py
@@ -544,6 +544,7 @@ class PhiInstr(Instruction):
     def add_incoming(self, value, block):
         assert isinstance(block, Block)
         self.incomings.append((value, block))
+        self._clear_string_cache()
 
     def replace_usage(self, old, new):
         self.incomings = [((new if val is old else val), blk)


### PR DESCRIPTION
Stringifying a phi (including for debugging purposes) can cause them to freeze themselves in a stale state, and subsequently added incoming instructions will be incorrectly omitted from the instruction.

Any time a phi is mutated by adding an incoming expression, its string cache should be immediately invalidated.