### PR TITLE
Delete `requirements.txt`

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,0 @@
-enum34; python_version < '3.4'


### PR DESCRIPTION
As this just lists a requirement for dropped Python versions, go ahead and remove this file.