### PR TITLE
fix rst syntax in install docs

### DIFF
--- a/docs/source/admin-guide/install.rst
+++ b/docs/source/admin-guide/install.rst
@@ -88,17 +88,19 @@ for details:
     #. ``intel-D47188-svml-VF.patch``: Add support for vectorized math
        functions via Intel SVML.
     #. ``expect-fastmath-entrypoints-in-add-TLI-mappings.ll.patch``: Fix for a
-        test failure caused by the previous patch.
+       test failure caused by the previous patch.
     #. ``0001-Revert-Limit-size-of-non-GlobalValue-name.patch``: revert the
        limit put on the length of a non-GlobalValue name
 
 #. For Linux/macOS:
-    #. ``export PREFIX=desired_install_location CPU_COUNT=N`` (``N`` is number
-       of parallel compile tasks)
+
+    #. ``export PREFIX=desired_install_location CPU_COUNT=N``
+       ( ``N`` is number of parallel compile tasks)
     #. Run the `build.sh <https://github.com/numba/llvmlite/blob/master/conda-recipes/llvmdev/build.sh>`_
        script in the llvmdev conda recipe from the LLVM source directory
 
 #. For Windows:
+
     #. ``set PREFIX=desired_install_location``
     #. Run the `bld.bat <https://github.com/numba/llvmlite/blob/master/conda-recipes/llvmdev/bld.bat>`_
        script in the llvmdev conda recipe from the LLVM source directory.

--- a/docs/source/admin-guide/install.rst
+++ b/docs/source/admin-guide/install.rst
@@ -82,22 +82,22 @@ for details:
    ``llvmlite/conda-recipes/`` directory.  You can apply each patch using the
    Linux ``patch -p1 -i {patch-file}`` command:
 
-    #. ``llvm-lto-static.patch``: Fix issue with LTO shared library on Windows
+    #. ``llvm-lto-static.patch``: Fix issue with LTO shared library on Windows.
     #. ``partial-testing.patch``: Enables additional parts of the LLVM test
-       suite
+       suite.
     #. ``intel-D47188-svml-VF.patch``: Add support for vectorized math
        functions via Intel SVML.
     #. ``expect-fastmath-entrypoints-in-add-TLI-mappings.ll.patch``: Fix for a
        test failure caused by the previous patch.
-    #. ``0001-Revert-Limit-size-of-non-GlobalValue-name.patch``: revert the
-       limit put on the length of a non-GlobalValue name
+    #. ``0001-Revert-Limit-size-of-non-GlobalValue-name.patch``: Revert the
+       limit put on the length of a non-GlobalValue name.
 
 #. For Linux/macOS:
 
     #. ``export PREFIX=desired_install_location CPU_COUNT=N``
        ( ``N`` is number of parallel compile tasks)
     #. Run the `build.sh <https://github.com/numba/llvmlite/blob/master/conda-recipes/llvmdev/build.sh>`_
-       script in the llvmdev conda recipe from the LLVM source directory
+       script in the llvmdev conda recipe from the LLVM source directory.
 
 #. For Windows:
 


### PR DESCRIPTION


Some missing whitespace and incorrect indentation caused the
installation instructuions to be malformed.

Before:

<img width="707" alt="Screen Shot 2020-12-10 at 14 28 38" src="https://user-images.githubusercontent.com/41563/101778843-b6e7ae00-3af4-11eb-88aa-1e6f776b2404.png">


After:

<img width="707" alt="Screen Shot 2020-12-10 at 14 29 39" src="https://user-images.githubusercontent.com/41563/101778818-acc5af80-3af4-11eb-897f-f1c8a3738919.png">
