### PR TITLE
use build 2 on windows

### DIFF
--- a/conda-recipes/llvmlite/meta.yaml
+++ b/conda-recipes/llvmlite/meta.yaml
@@ -30,7 +30,7 @@ requirements:
     # On channel https://anaconda.org/numba/
     # Build using LLVM (llvmdev) 10.0.1-1 on most platforms
     - llvmdev 10.0.1 *1 # [not aarch64 and not win]
-    - llvmdev 10.0.1 1 # [win]
+    - llvmdev 10.0.1 2 # [win]
     # Build using LLVM (llvmdev) 9.0.* on aarch64
     - llvmdev 9.0.* # [aarch64]
     - vs2015_runtime # [win]


### PR DESCRIPTION
Use llvmdev build 2 -- which compared to build 1 is compiled on Visual Studio 16 2019 v141 on Windows, hence the change is for windows only.