### PR TITLE
Added fneg instruction

### DIFF
--- a/docs/source/user-guide/ir/ir-builder.rst
+++ b/docs/source/user-guide/ir/ir-builder.rst
@@ -301,6 +301,10 @@ Floating-point
 
      Floating-point remainder of *lhs* divided by *rhs*.
 
+* .. method:: IRBuilder.fneg(arg, name='', flags=())
+
+     Floating-point negation of *arg*.
+
 
 Conversions
 -----------

--- a/llvmlite/ir/builder.py
+++ b/llvmlite/ir/builder.py
@@ -13,6 +13,19 @@ _CMP_MAP = {
 }
 
 
+def _unop(opname, cls=instructions.Instruction):
+    def wrap(fn):
+        @functools.wraps(fn)
+        def wrapped(self, arg, name='', flags=()):
+            instr = cls(self.block, arg.type, opname, [arg], name, flags)
+            self._insert(instr)
+            return instr
+
+        return wrapped
+
+    return wrap
+
+
 def _binop(opname, cls=instructions.Instruction):
     def wrap(fn):
         @functools.wraps(fn)
@@ -540,6 +553,13 @@ class IRBuilder(object):
             name = -value
         """
         return self.sub(values.Constant(value.type, 0), value, name=name)
+
+    @_unop('fneg')
+    def fneg(self, arg, name=''):
+        """
+        Floating-point negative:
+            name = -arg
+        """
 
     #
     # Comparison APIs

--- a/llvmlite/tests/test_ir.py
+++ b/llvmlite/tests/test_ir.py
@@ -645,14 +645,16 @@ my_block:
     def test_unary_ops(self):
         block = self.block(name='my_block')
         builder = ir.IRBuilder(block)
-        a, b = builder.function.args[:2]
-        builder.neg(a, 'c')
-        builder.not_(b, 'd')
+        a, b, c = builder.function.args[:3]
+        builder.neg(a, 'd')
+        builder.not_(b, 'e')
+        builder.fneg(c, 'f')
         self.assertFalse(block.is_terminated)
         self.check_block(block, """\
             my_block:
-                %"c" = sub i32 0, %".1"
-                %"d" = xor i32 %".2", -1
+                %"d" = sub i32 0, %".1"
+                %"e" = xor i32 %".2", -1
+                %"f" = fneg double %".3"
             """)
 
     def test_replace_operand(self):


### PR DESCRIPTION
Whilst following our Compiler Construction course at VU University Amsterdam, we noticed the presence of the [`fneg` instruction in LLVM](https://llvm.org/docs/LangRef.html#fneg-instruction), which was absent in LLVMlite. 
Hence, we decided to make an attempt at adding this instruction.

We created a new decorator `_unop` for unary instructions and used that on `fneg`.