### PR TITLE
Implement minimal support for call-site argument attributes

### DIFF
--- a/docs/source/user-guide/ir/ir-builder.rst
+++ b/docs/source/user-guide/ir/ir-builder.rst
@@ -576,13 +576,11 @@ The following methods are all :ref:`terminators <terminator>`:
 Exception handling
 ------------------
 
-* .. method:: IRBuilder.invoke(self, fn, args, normal_to, unwind_to, name='', cconv=None, tail=False)
+* .. method:: IRBuilder.invoke(self, fn, args, normal_to, unwind_to, name='', cconv=None)
 
      Call function *fn* with arguments *args*, a sequence of values.
 
-     * *cconv* is the optional calling convention.
-     * *tail*, if ``True``, is a hint for the optimizer to perform
-       tail-call optimization.
+     *cconv* is the optional calling convention.
 
      If the function *fn* returns normally, control is transferred
      to *normal_to*. Otherwise, it is transferred to *unwind_to*,

--- a/docs/source/user-guide/ir/ir-builder.rst
+++ b/docs/source/user-guide/ir/ir-builder.rst
@@ -516,7 +516,8 @@ Memory
 Function call
 ---------------
 
-.. method:: IRBuilder.call(fn, args, name='', cconv=None, tail=False, fastmath=())
+.. method:: IRBuilder.call(fn, args, name='', cconv=None, tail=False, \
+   fastmath=(), attrs=(), arg_attrs=None)
 
    Call function *fn* with arguments *args*, a sequence of values.
 
@@ -526,6 +527,18 @@ Function call
    * *fastmath* is a string or a sequence of strings of names for
      `fast-math flags
      <http://llvm.org/docs/LangRef.html#fast-math-flags>`_.
+   * *attrs* is a string or sequence of strings of function attributes to
+     attach to the call site.
+   * *arg_attrs* is a dictionary matching argument indices (as regular
+     integers, starting at zero) to strings or sequences of strings giving
+     the attributes to attach to the respective argument at this call site.
+     If an index is not present in the dictionary, or *arg_attrs* is missing
+     entirely, no attributes are emitted for the given argument.
+
+     If some attributes, such as ``sret``, are specified at the function
+     declaration, they must also be specified at each call site for
+     correctness. (As of LLVM 11, this does not seem to be explicitly
+     specified in the LLVM language reference.)
 
 
 Branches
@@ -576,15 +589,17 @@ The following methods are all :ref:`terminators <terminator>`:
 Exception handling
 ------------------
 
-* .. method:: IRBuilder.invoke(self, fn, args, normal_to, unwind_to, name='', cconv=None)
+* .. method:: IRBuilder.invoke(fn, args, normal_to, unwind_to, name='', \
+     cconv=None, fastmath=(), attrs=(), arg_attrs=None)
 
      Call function *fn* with arguments *args*, a sequence of values.
-
-     *cconv* is the optional calling convention.
 
      If the function *fn* returns normally, control is transferred
      to *normal_to*. Otherwise, it is transferred to *unwind_to*,
      whose first non-phi instruction must be :class:`LandingPad`.
+
+     The remaining arguments give additional attributes to specify
+     at the call site; see :meth:`call` for a description.
 
 * .. method:: IRBuilder.landingpad(typ, personality, name='', cleanup=False)
 

--- a/llvmlite/ir/builder.py
+++ b/llvmlite/ir/builder.py
@@ -908,9 +908,11 @@ class IRBuilder(object):
         return self.asm(ftype, "", "{%s}" % reg_name, [value], True, name)
 
     def invoke(self, fn, args, normal_to, unwind_to,
-               name='', cconv=None):
+               name='', cconv=None, fastmath=(), attrs=(), arg_attrs=None):
         inst = instructions.InvokeInstr(self.block, fn, args, normal_to,
-                                        unwind_to, name=name, cconv=cconv)
+                                        unwind_to, name=name, cconv=cconv,
+                                        fastmath=fastmath, attrs=attrs,
+                                        arg_attrs=arg_attrs)
         self._set_terminator(inst)
         return inst
 

--- a/llvmlite/ir/builder.py
+++ b/llvmlite/ir/builder.py
@@ -908,7 +908,7 @@ class IRBuilder(object):
         return self.asm(ftype, "", "{%s}" % reg_name, [value], True, name)
 
     def invoke(self, fn, args, normal_to, unwind_to,
-               name='', cconv=None, tail=False):
+               name='', cconv=None):
         inst = instructions.InvokeInstr(self.block, fn, args, normal_to,
                                         unwind_to, name=name, cconv=cconv)
         self._set_terminator(inst)

--- a/llvmlite/ir/builder.py
+++ b/llvmlite/ir/builder.py
@@ -872,14 +872,14 @@ class IRBuilder(object):
     # Call APIs
 
     def call(self, fn, args, name='', cconv=None, tail=False, fastmath=(),
-             attrs=()):
+             attrs=(), arg_attrs=None):
         """
         Call function *fn* with *args*:
             name = fn(args...)
         """
         inst = instructions.CallInstr(self.block, fn, args, name=name,
                                       cconv=cconv, tail=tail, fastmath=fastmath,
-                                      attrs=attrs)
+                                      attrs=attrs, arg_attrs=arg_attrs)
         self._insert(inst)
         return inst
 

--- a/llvmlite/ir/instructions.py
+++ b/llvmlite/ir/instructions.py
@@ -154,10 +154,12 @@ class CallInstr(Instruction):
 
 class InvokeInstr(CallInstr):
     def __init__(self, parent, func, args, normal_to, unwind_to, name='',
-                 cconv=None):
+                 cconv=None, fastmath=(), attrs=(), arg_attrs=None):
         assert isinstance(normal_to, Block)
         assert isinstance(unwind_to, Block)
-        super(InvokeInstr, self).__init__(parent, func, args, name, cconv)
+        super(InvokeInstr, self).__init__(parent, func, args, name, cconv,
+                                          tail=False, fastmath=fastmath,
+                                          attrs=attrs, arg_attrs=arg_attrs)
         self.opname = "invoke"
         self.normal_to = normal_to
         self.unwind_to = unwind_to

--- a/llvmlite/ir/instructions.py
+++ b/llvmlite/ir/instructions.py
@@ -5,7 +5,7 @@ Implementation of LLVM IR instructions.
 from llvmlite.ir import types
 from llvmlite.ir.values import (Block, Function, Value, NamedValue, Constant,
                                 MetaDataArgument, MetaDataString, AttributeSet,
-                                Undefined)
+                                Undefined, ArgumentAttributes)
 from llvmlite.ir._utils import _HasMetadata
 
 
@@ -63,13 +63,20 @@ class FastMathFlags(AttributeSet):
 
 class CallInstr(Instruction):
     def __init__(self, parent, func, args, name='', cconv=None, tail=False,
-                 fastmath=(), attrs=()):
+                 fastmath=(), attrs=(), arg_attrs=None):
         self.cconv = (func.calling_convention
                       if cconv is None and isinstance(func, Function)
                       else cconv)
         self.tail = tail
         self.fastmath = FastMathFlags(fastmath)
         self.attributes = CallInstrAttributes(attrs)
+        self.arg_attributes = {}
+        if arg_attrs:
+            for idx, attrs in arg_attrs.items():
+                if not (0 <= idx < len(args)):
+                    raise ValueError("Invalid argument index {}"
+                                     .format(idx))
+                self.arg_attributes[idx] = ArgumentAttributes(attrs)
 
         # Fix and validate arguments
         args = list(args)
@@ -111,8 +118,13 @@ class CallInstr(Instruction):
         return self.callee
 
     def _descr(self, buf, add_metadata):
-        args = ', '.join(['{0} {1}'.format(a.type, a.get_reference())
-                          for a in self.args])
+        def descr_arg(i, a):
+            if i in self.arg_attributes:
+                attrs = ' '.join(self.arg_attributes[i]._to_list()) + ' '
+            else:
+                attrs = ''
+            return '{0} {1}{2}'.format(a.type, attrs, a.get_reference())
+        args = ', '.join([descr_arg(i, a) for i, a in enumerate(self.args)])
 
         fnty = self.callee.function_type
         # Only print function type if variable-argument

--- a/llvmlite/tests/test_ir.py
+++ b/llvmlite/tests/test_ir.py
@@ -1205,6 +1205,15 @@ my_block:
             call void @"fun"(i32* noalias sret %"retval", i32 42, i32* noalias %"other")
         """)  # noqa E501
 
+    def test_invalid_call_attributes(self):
+        block = self.block()
+        builder = ir.IRBuilder(block)
+        fun_ty = ir.FunctionType(ir.VoidType(), ())
+        fun = ir.Function(builder.function.module, fun_ty, 'fun')
+        with self.assertRaises(ValueError):
+            # The function has no arguments, so this should fail.
+            builder.call(fun, (), arg_attrs={0: 'sret'})
+
     def test_invoke(self):
         block = self.block(name='my_block')
         builder = ir.IRBuilder(block)


### PR DESCRIPTION
This implements support for adding argument attributes at call
sites (`call`, `invoke`), which is necessary to actually emit
functions with attributes such as `sret` (for which leaving off
the attribute at the call site, i.e. specifying it only in the
function declaration, leads to miscompilations).

I opted for a fairly minimal implementation, just optionally
taking a dictionary of `AttributeSet`s in the constructur, as
the vast majority of call sites will not need to specify extra
attributes. Not sure whether a dictionary indexed by positional
indices is the most idiomatic solution…

I also added a commit removing the `tail` parameter from the
InvokeInstr constructor, as the tail call kind attributes aren't
actually supported on `invoke` by LLVM. Previously, that
parameter was just silently ignored, which doesn't seem
desirable.
