### PR TITLE
Allow `gep` instructions to accept bare Python integers as indices.

### DIFF
--- a/llvmlite/ir/_utils.py
+++ b/llvmlite/ir/_utils.py
@@ -78,3 +78,17 @@ class _HasMetadata(object):
             return ', '.join(buf)
         else:
             return ''
+
+
+def bytes_to_represent(i):
+    """Take a Python integer `i` and return the power-of-two number
+    of bytes required to represent the integer."""
+    N_BITS_IN_BYTE = 8
+    def ceil_div(a, b):
+        return  (a + b - 1) // b
+    nbits  = i.bit_length()
+    nbytes = ceil_div(nbits, N_BITS_IN_BYTE)
+     # make the number of bytes a power of 2
+    return 2 ** max(nbytes - 1, 0).bit_length()
+
+

--- a/llvmlite/tests/test_ir.py
+++ b/llvmlite/tests/test_ir.py
@@ -839,14 +839,15 @@ my_block:
     def test_gep(self):
         block = self.block(name='my_block')
         builder = ir.IRBuilder(block)
+        elem_type = ir.LiteralStructType([int32, int32])
         a, b = builder.function.args[:2]
-        c = builder.alloca(ir.PointerType(int32), name='c')
-        d = builder.gep(c, [ir.Constant(int32, 5), a], name='d')
+        c = builder.alloca(ir.PointerType(elem_type), name='c')
+        d = builder.gep(c, [ir.Constant(int32, 5), a, 1], name='d')
         self.assertEqual(d.type, ir.PointerType(int32))
         self.check_block(block, """\
             my_block:
-                %"c" = alloca i32*
-                %"d" = getelementptr i32*, i32** %"c", i32 5, i32 %".1"
+                %"c" = alloca {i32, i32}*
+                %"d" = getelementptr {i32, i32}*, {i32, i32}** %"c", i32 5, i32 %".1", i8 1
             """)
         # XXX test with more complex types
 


### PR DESCRIPTION
New feature: `gep` instructions can accept Python integers as indices, instead of requiring the client code to tediously construct ir.Constants around each index.

For example:

```
int32 = ir.IntType(32)
builder.gep(my_object, [int32(5), int32(0), int32(3)])
```

becomes

```
builder.gep(my_object, [5, 0, 3])
```

The width of each converted integer will be chosen to be the smallest number of 8-bit bytes that is a power of two and can represent the value.

It is permissible to intermix Python integers with IR instructions in the index list.