### PR TITLE
Add FFI to test whether a type is an LLVM "single value"

### DIFF
--- a/ffi/value.cpp
+++ b/ffi/value.cpp
@@ -425,6 +425,12 @@ LLVMPY_GetElementType(LLVMTypeRef type)
     return nullptr;
 }
 
+API_EXPORT(bool)
+LLVMPY_IsSingleValueType(LLVMTypeRef type)
+{
+    return llvm::unwrap(type)->isSingleValueType();
+}
+
 API_EXPORT(void)
 LLVMPY_SetLinkage(LLVMValueRef Val, int Linkage)
 {

--- a/llvmlite/binding/value.py
+++ b/llvmlite/binding/value.py
@@ -61,6 +61,13 @@ class TypeRef(ffi.ObjectRef):
         return ffi.lib.LLVMPY_TypeIsPointer(self)
 
     @property
+    def is_single_value_type(self):
+        """
+        Returns whether the type is a valid type for a register in codegen.
+        """
+        return ffi.lib.LLVMPY_TypeIsSingleValueType(self)
+
+    @property
     def element_type(self):
         """
         Returns the pointed-to type. When the type is not a pointer,
@@ -431,6 +438,8 @@ ffi.lib.LLVMPY_TypeIsPointer.restype = c_bool
 ffi.lib.LLVMPY_GetElementType.argtypes = [ffi.LLVMTypeRef]
 ffi.lib.LLVMPY_GetElementType.restype = ffi.LLVMTypeRef
 
+ffi.lib.LLVMPY_TypeIsSingleValueType.argtypes = [ffi.LLVMTypeRef]
+ffi.lib.LLVMPY_TypeIsSingleValueType.restype = c_bool
 
 ffi.lib.LLVMPY_GetTypeName.argtypes = [ffi.LLVMTypeRef]
 ffi.lib.LLVMPY_GetTypeName.restype = c_void_p

--- a/llvmlite/tests/test_binding.py
+++ b/llvmlite/tests/test_binding.py
@@ -904,6 +904,13 @@ class TestValueRef(BaseTest):
         tp = glob.type
         self.assertIsInstance(tp, llvm.TypeRef)
 
+    def test_single_value(self):
+        mod = self.module()
+        small_glob = mod.get_global_variable("glob")
+        large_glob = mod.get_global_variable("glob_struct")
+        self.assertTrue(small_glob.type.is_single_value_type)
+        self.assertFalse(large_glob.type.is_single_value_type)
+
     def test_type_name(self):
         mod = self.module()
         glob = mod.get_global_variable("glob")


### PR DESCRIPTION
Exposes [llvm::Type::isSingleValue()](https://llvm.org/doxygen/classllvm_1_1Type.html#a5f6edc5246188225b3f49bd5c974c759) via FFI.

This may be useful for determining the calling convention of C functions which return structs by value.