### PR TITLE
Align linker flags between CMake and non-CMake builds

### DIFF
--- a/ffi/CMakeLists.txt
+++ b/ffi/CMakeLists.txt
@@ -61,3 +61,7 @@ list(REMOVE_ITEM llvm_libs "OptRemarks")
 
 # Link against LLVM libraries
 target_link_libraries(llvmlite ${llvm_libs})
+# -flto and --exclude-libs allow us to remove those parts of LLVM we don't use
+if(${CMAKE_SYSTEM_NAME} MATCHES "Linux" OR ${CMAKE_SYSTEM_NAME} MATCHES "FreeBSD")
+    set_property(TARGET llvmlite APPEND_STRING PROPERTY LINK_FLAGS "-flto -Wl,--exclude-libs,ALL")
+endif()


### PR DESCRIPTION
While debugging https://github.com/conda-forge/llvmlite-feedstock/issues/54 I discovered `-flto -Wl,--exclude-libs,ALL` isn't used when `$LLVMLITE_USE_CMAKE` is set.