### PR TITLE
Disallow alwaysinline and noinline on functions

### DIFF
--- a/docs/source/glossary.rst
+++ b/docs/source/glossary.rst
@@ -44,8 +44,9 @@ getelementptr
 An LLVM :ref:`instruction` that lets you get the address of a
 subelement of an aggregate data structure.
 
-See :llvm:ref:`i_getelementptr` in the official LLVM
-documentation.
+See `the getelementptr instruction
+<https://releases.llvm.org/10.0.0/docs/LangRef.html#i-getelementptr>`_ in the
+official LLVM documentation.
 
 
 .. _global value:

--- a/llvmlite/ir/values.py
+++ b/llvmlite/ir/values.py
@@ -556,6 +556,13 @@ class FunctionAttributes(AttributeSet):
         self._personality = None
         super(FunctionAttributes, self).__init__(args)
 
+    def add(self, name):
+        if ((name == 'alwaysinline' and 'noinline' in self) or
+                (name == 'noinline' and 'alwaysinline' in self)):
+            raise ValueError("Can't have alwaysinline and noinline")
+
+        super().add(name)
+
     @property
     def alignstack(self):
         return self._alignstack

--- a/llvmlite/tests/test_ir.py
+++ b/llvmlite/tests/test_ir.py
@@ -209,6 +209,24 @@ class TestFunction(TestBase):
         fn = self.function()
         self.assert_pickle_correctly(fn)
 
+    def test_alwaysinline_noinline_disallowed(self):
+        module = self.module()
+        func = self.function(module)
+        func.attributes.add('alwaysinline')
+
+        msg = "Can't have alwaysinline and noinline"
+        with self.assertRaisesRegex(ValueError, msg):
+            func.attributes.add('noinline')
+
+    def test_noinline_alwaysinline_disallowed(self):
+        module = self.module()
+        func = self.function(module)
+        func.attributes.add('noinline')
+
+        msg = "Can't have alwaysinline and noinline"
+        with self.assertRaisesRegex(ValueError, msg):
+            func.attributes.add('alwaysinline')
+
 
 class TestIR(TestBase):
 


### PR DESCRIPTION
Adding "alwaysinline" and "noinline" attributes to a function results in an error similar to the following when compiling with LLVM:

```
Attributes 'noinline and alwaysinline' are incompatible!
LLVM ERROR: Broken module found, compilation aborted!
```

and then the interpreter is killed. This PR prevents both attributes being added at the Python level, to prevent the above error message and termination.