### PR TITLE
Docs/remove travis

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -7,16 +7,16 @@ jobs:
     matrix:
       py36:
         PYTHON: '3.6'
-        CONDA_ENV: travisci
+        CONDA_ENV: cienv
       py37:
         PYTHON: '3.7'
-        CONDA_ENV: travisci
+        CONDA_ENV: cienv
       py38:
         PYTHON: '3.8'
-        CONDA_ENV: travisci
+        CONDA_ENV: cienv
       py39:
         PYTHON: '3.9'
-        CONDA_ENV: travisci
+        CONDA_ENV: cienv
 
 - template: buildscripts/azure/azure-linux-macos.yml
   parameters:
@@ -25,37 +25,37 @@ jobs:
     matrix:
       py36:
         PYTHON: '3.6'
-        CONDA_ENV: travisci
+        CONDA_ENV: cienv
       py37:
         PYTHON: '3.7'
-        CONDA_ENV: travisci
+        CONDA_ENV: cienv
       py38:
         PYTHON: '3.8'
-        CONDA_ENV: travisci
+        CONDA_ENV: cienv
         RUN_FLAKE8: yes
       py39:
         PYTHON: '3.9'
-        CONDA_ENV: travisci
+        CONDA_ENV: cienv
         RUN_FLAKE8: yes
 # temporarily disabled
 #       pypy:
 #         PYTHON: pypy
-#         CONDA_ENV: travisci
+#         CONDA_ENV: cienv
       py36_wheel:
         PYTHON: '3.6'
-        CONDA_ENV: travisci
+        CONDA_ENV: cienv
         WHEEL: 'yes'
       py37_wheel:
         PYTHON: '3.7'
-        CONDA_ENV: travisci
+        CONDA_ENV: cienv
         WHEEL: 'yes'
       py38_wheel:
         PYTHON: '3.8'
-        CONDA_ENV: travisci
+        CONDA_ENV: cienv
         WHEEL: 'yes'
       py39_wheel:
         PYTHON: '3.9'
-        CONDA_ENV: travisci
+        CONDA_ENV: cienv
         WHEEL: 'yes'
 
 - template: buildscripts/azure/azure-windows.yml

--- a/buildscripts/azure/azure-windows.yml
+++ b/buildscripts/azure/azure-windows.yml
@@ -11,7 +11,7 @@ jobs:
     matrix:
       py39:
         PYTHON: '3.9'
-        CONDA_ENV: travisci
+        CONDA_ENV: cienv
 
 
   steps:

--- a/docs/source/contributing.rst
+++ b/docs/source/contributing.rst
@@ -87,13 +87,10 @@ Platform support
 Llvmlite will be kept compatible with Python 3.6 and later
 under at least Windows, macOS and Linux.
 
-We do not expect contributors to test their code on all platforms.
-Pull requests are automatically built and tested using
-`Travis-CI <https://travis-ci.org/numba/llvmlite>`_, which
-addresses Linux compatibility. Other operating systems are tested
-on an internal continuous integration platform at
-Anaconda\ |reg|.
-
+We do not expect contributors to test their code on all platforms.  Pull
+requests are automatically built and tested using `Azure Pipelines
+<https://dev.azure.com/numba/numba/_build?definitionId=2>`_ for Winows, OSX and
+Linux.
 
 Documentation
 =============


### PR DESCRIPTION
as part of the final removal of Travis-CI integration, remove the link from the docs and rename the environment used for testing.