### PR TITLE
add support for more constant expressions

### DIFF
--- a/llvmlite/ir/values.py
+++ b/llvmlite/ir/values.py
@@ -38,7 +38,7 @@ def _escape_string(text, _map={}):
     return ''.join(buf)
 
 
-def _binop(fn):
+def _binop(opname):
     def wrap(fn):
         @functools.wraps(fn)
         def wrapped(lhs, rhs):
@@ -47,7 +47,7 @@ def _binop(fn):
                                  % (lhs.type, rhs.type))
 
             fmt = "{0} ({1}, {2})"
-            return FormattedConstant(lhs.type, fmt.format(fn.__name__, lhs, rhs))
+            return FormattedConstant(lhs.type, fmt.format(opname, lhs, rhs))
 
         return wrapped
 

--- a/llvmlite/ir/values.py
+++ b/llvmlite/ir/values.py
@@ -266,7 +266,7 @@ class _ConstOpMixin(object):
             self.get_reference(), ', '.join(strindices))
         return FormattedConstant(outtype.as_pointer(self.addrspace), op)
 
-    
+
 class Value(object):
     """
     The base class for all values.

--- a/llvmlite/ir/values.py
+++ b/llvmlite/ir/values.py
@@ -56,9 +56,8 @@ def _binop(opname):
                                  % (lhs.type, rhs.type))
 
             fmt = "{0} ({1} {2}, {3} {4})".format(opname,
-                lhs.type, lhs.get_reference(),
-                rhs.type, rhs.get_reference()
-            )
+                                                  lhs.type, lhs.get_reference(),
+                                                  rhs.type, rhs.get_reference())
             return FormattedConstant(lhs.type, fmt)
 
         return wrapped
@@ -213,15 +212,15 @@ class _ConstOpMixin(object):
 
         if self.type != other.type:
             raise ValueError("Operands must be the same type, got (%s, %s)"
-                                 % (self.type, other.type))
+                             % (self.type, other.type))
 
         fmt = "{0} {1} ({2} {3}, {4} {5})".format(
             ins, op,
             self.type, self.get_reference(),
             other.type, other.get_reference())
-        
+
         return FormattedConstant(types.IntType(1), fmt)
-    
+
     def icmp_signed(self, cmpop, other):
         """
         Signed integer comparison:
@@ -248,7 +247,7 @@ class _ConstOpMixin(object):
         where cmpop can be '==', '!=', '<', '<=', '>', '>=', 'ord', 'uno'
         """
         return self._cmp('f', 'o', cmpop, other)
-    
+
     def fcmp_unordered(self, cmpop, other):
         """
         Floating-point unordered comparison:
@@ -257,7 +256,7 @@ class _ConstOpMixin(object):
         where cmpop can be '==', '!=', '<', '<=', '>', '>=', 'ord', 'uno'
         """
         return self._cmp('f', 'u', cmpop, other)
-    
+
     #
     # Unary APIs
     #
@@ -271,9 +270,9 @@ class _ConstOpMixin(object):
             rhs = values.Constant(self.type, (-1,) * self.type.count)
         else:
             rhs = values.Constant(self.type, -1)
-        
+
         return self.xor(rhs)
-    
+
     def neg(self):
         """
         Integer negative:
@@ -281,7 +280,7 @@ class _ConstOpMixin(object):
         """
         zero = values.Constant(self.type, 0)
         return zero.sub(self)
-    
+
     def fneg(self):
         """
         Floating-point negative:

--- a/llvmlite/ir/values.py
+++ b/llvmlite/ir/values.py
@@ -287,7 +287,8 @@ class _ConstOpMixin(object):
         Floating-point negative:
             -value
         """
-        return self.neg()
+        fmt = "fneg ({0} {1})".format(self.type, self.get_reference())
+        return FormattedConstant(self.type, fmt)
 
     def bitcast(self, typ):
         """

--- a/llvmlite/ir/values.py
+++ b/llvmlite/ir/values.py
@@ -55,8 +55,11 @@ def _binop(opname):
                 raise ValueError("Operands must be the same type, got (%s, %s)"
                                  % (lhs.type, rhs.type))
 
-            fmt = "{0} ({1}, {2})"
-            return FormattedConstant(lhs.type, fmt.format(opname, lhs, rhs))
+            fmt = "{0} ({1} {2}, {3} {4})".format(opname,
+                lhs.type, lhs.get_reference(),
+                rhs.type, rhs.get_reference()
+            )
+            return FormattedConstant(lhs.type, fmt)
 
         return wrapped
 
@@ -204,17 +207,20 @@ class _ConstOpMixin(object):
             op = _CMP_MAP[cmpop]
         except KeyError:
             raise ValueError("invalid comparison %r for %s" % (cmpop, ins))
-        if cmpop not in ('==', '!='):
+
+        if not (prefix == 'i' and cmpop in ('==', '!=')):
             op = sign + op
 
         if self.type != other.type:
             raise ValueError("Operands must be the same type, got (%s, %s)"
                                  % (self.type, other.type))
 
-
-        int1 = types.IntType(1)
-        fmt = "{0} {1} ({2}, {3})"
-        return FormattedConstant(int1, fmt.format(ins, op, self, other))
+        fmt = "{0} {1} ({2} {3}, {4} {5})".format(
+            ins, op,
+            self.type, self.get_reference(),
+            other.type, other.get_reference())
+        
+        return FormattedConstant(types.IntType(1), fmt)
     
     def icmp_signed(self, cmpop, other):
         """

--- a/llvmlite/tests/test_ir.py
+++ b/llvmlite/tests/test_ir.py
@@ -2232,8 +2232,8 @@ class TestConstant(TestBase):
     def test_add(self):
         one = ir.Constant(int32, 1)
         two = ir.Constant(int32, 2)
-        two = one.add(two)
-        self.assertEqual(str(two), 'add (i32 1, i32 2)')
+        three = one.add(two)
+        self.assertEqual(str(three), 'add (i32 1, i32 2)')
 
 
 class TestTransforms(TestBase):

--- a/llvmlite/tests/test_ir.py
+++ b/llvmlite/tests/test_ir.py
@@ -2241,7 +2241,7 @@ class TestConstant(TestBase):
         three = one.or_(two)
         self.assertEqual(str(three), 'or (i32 1, i32 2)')
 
-        
+
 class TestTransforms(TestBase):
     def test_call_transform(self):
         mod = ir.Module()

--- a/llvmlite/tests/test_ir.py
+++ b/llvmlite/tests/test_ir.py
@@ -2229,6 +2229,12 @@ class TestConstant(TestBase):
         c = ir.Constant(int32, 0).inttoptr(int64.as_pointer())
         self.assertEqual(str(c), 'inttoptr (i32 0 to i64*)')
 
+    def test_add(self):
+        one = ir.Constant(int32, 1)
+        two = ir.Constant(int32, 2)
+        two = one.add(two)
+        self.assertEqual(str(two), 'add (i32 1, i32 2)')
+
 
 class TestTransforms(TestBase):
     def test_call_transform(self):

--- a/llvmlite/tests/test_ir.py
+++ b/llvmlite/tests/test_ir.py
@@ -2235,7 +2235,13 @@ class TestConstant(TestBase):
         three = one.add(two)
         self.assertEqual(str(three), 'add (i32 1, i32 2)')
 
+    def test_or(self):
+        one = ir.Constant(int32, 1)
+        two = ir.Constant(int32, 2)
+        three = one.or_(two)
+        self.assertEqual(str(three), 'or (i32 1, i32 2)')
 
+        
 class TestTransforms(TestBase):
     def test_call_transform(self):
         mod = ir.Module()

--- a/llvmlite/tests/test_ir.py
+++ b/llvmlite/tests/test_ir.py
@@ -2244,7 +2244,7 @@ class TestConstant(TestBase):
     def test_int_binops(self):
         one = ir.Constant(int32, 1)
         two = ir.Constant(int32, 2)
-        
+
         oracle = {one.shl:  'shl',  one.lshr: 'lshr', one.ashr: 'ashr',
                   one.add:  'add',  one.sub:  'sub',  one.mul:  'mul',
                   one.udiv: 'udiv', one.sdiv: 'sdiv', one.urem: 'urem',
@@ -2254,17 +2254,17 @@ class TestConstant(TestBase):
             self.assertEqual(str(fn(two)), irop + ' (i32 1, i32 2)')
 
         # unsigned integer compare
-        oracle = {'==': 'eq', '!=': 'ne', '>' : 'ugt', '>=' : 'uge',
-                  '<' : 'ult', '<=' : 'ule'}
-        for cop, cond  in oracle.items():
+        oracle = {'==': 'eq', '!=': 'ne', '>':
+                  'ugt', '>=': 'uge', '<': 'ult', '<=': 'ule'}
+        for cop, cond in oracle.items():
             actual = str(one.icmp_unsigned(cop, two))
             expected = 'icmp ' + cond + ' (i32 1, i32 2)'
             self.assertEqual(actual, expected)
 
         # signed integer compare
-        oracle = {'==': 'eq', '!=': 'ne', '>' : 'sgt', '>=' : 'sge',
-                  '<' : 'slt', '<=' : 'sle'}
-        for cop, cond  in oracle.items():
+        oracle = {'==': 'eq', '!=': 'ne',
+                  '>': 'sgt', '>=': 'sge', '<': 'slt', '<=': 'sle'}
+        for cop, cond in oracle.items():
             actual = str(one.icmp_signed(cop, two))
             expected = 'icmp ' + cond + ' (i32 1, i32 2)'
             self.assertEqual(actual, expected)
@@ -2277,23 +2277,26 @@ class TestConstant(TestBase):
                   one.fdiv: 'fdiv', one.frem: 'frem'}
         for fn, irop in oracle.items():
             actual = str(fn(two))
-            expected = irop + ' (float 0x3ff0000000000000, float 0x4000000000000000)'
+            expected = irop + (' (float 0x3ff0000000000000,'
+                               ' float 0x4000000000000000)')
             self.assertEqual(actual, expected)
 
         # ordered float compare
-        oracle = {'==': 'oeq', '!=': 'one', '>' : 'ogt', '>=' : 'oge',
-                  '<' : 'olt', '<=' : 'ole'}
-        for cop, cond  in oracle.items():
+        oracle = {'==': 'oeq', '!=': 'one', '>': 'ogt', '>=': 'oge',
+                  '<': 'olt', '<=': 'ole'}
+        for cop, cond in oracle.items():
             actual = str(one.fcmp_ordered(cop, two))
-            expected = 'fcmp ' + cond + ' (float 0x3ff0000000000000, float 0x4000000000000000)'
+            expected = 'fcmp ' + cond + (' (float 0x3ff0000000000000,'
+                                         ' float 0x4000000000000000)')
             self.assertEqual(actual, expected)
 
         # unordered float compare
-        oracle = {'==': 'ueq', '!=': 'une', '>' : 'ugt', '>=' : 'uge',
-                  '<' : 'ult', '<=' : 'ule'}
-        for cop, cond  in oracle.items():
+        oracle = {'==': 'ueq', '!=': 'une', '>': 'ugt', '>=': 'uge',
+                  '<': 'ult', '<=': 'ule'}
+        for cop, cond in oracle.items():
             actual = str(one.fcmp_unordered(cop, two))
-            expected = 'fcmp ' + cond + ' (float 0x3ff0000000000000, float 0x4000000000000000)'
+            expected = 'fcmp ' + cond + (' (float 0x3ff0000000000000,'
+                                         ' float 0x4000000000000000)')
             self.assertEqual(actual, expected)
 
 

--- a/llvmlite/tests/test_ir.py
+++ b/llvmlite/tests/test_ir.py
@@ -2219,15 +2219,65 @@ class TestConstant(TestBase):
                           'addrspace(4)* @"myconstant", i32 0, i32 1)'))
         self.assertEqual(c.type, ir.PointerType(int1, addrspace=addrspace))
 
+    def test_trunc(self):
+        c = ir.Constant(int64, 1).trunc(int32)
+        self.assertEqual(str(c), 'trunc (i64 1 to i32)')
+
+    def test_zext(self):
+        c = ir.Constant(int32, 1).zext(int64)
+        self.assertEqual(str(c), 'zext (i32 1 to i64)')
+
+    def test_sext(self):
+        c = ir.Constant(int32, -1).sext(int64)
+        self.assertEqual(str(c), 'sext (i32 -1 to i64)')
+
+    def test_fptrunc(self):
+        c = ir.Constant(flt, 1).fptrunc(hlf)
+        self.assertEqual(str(c), 'fptrunc (float 0x3ff0000000000000 to half)')
+
+    def test_fpext(self):
+        c = ir.Constant(flt, 1).fpext(dbl)
+        self.assertEqual(str(c), 'fpext (float 0x3ff0000000000000 to double)')
+
     def test_bitcast(self):
         m = self.module()
         gv = ir.GlobalVariable(m, int32, "myconstant")
         c = gv.bitcast(int64.as_pointer())
         self.assertEqual(str(c), 'bitcast (i32* @"myconstant" to i64*)')
 
+    def test_fptoui(self):
+        c = ir.Constant(flt, 1).fptoui(int32)
+        self.assertEqual(str(c), 'fptoui (float 0x3ff0000000000000 to i32)')
+
+    def test_uitofp(self):
+        c = ir.Constant(int32, 1).uitofp(flt)
+        self.assertEqual(str(c), 'uitofp (i32 1 to float)')
+
+    def test_fptosi(self):
+        c = ir.Constant(flt, 1).fptosi(int32)
+        self.assertEqual(str(c), 'fptosi (float 0x3ff0000000000000 to i32)')
+
+    def test_sitofp(self):
+        c = ir.Constant(int32, 1).sitofp(flt)
+        self.assertEqual(str(c), 'sitofp (i32 1 to float)')
+
+    def test_ptrtoint(self):
+        ptr = ir.Constant(int64.as_pointer(), None)
+        one = ir.Constant(int32, 1)
+        c = ptr.ptrtoint(int32)
+
+        self.assertRaises(TypeError, one.ptrtoint, int64)
+        self.assertRaises(TypeError, ptr.ptrtoint, flt)
+        self.assertEqual(str(c), 'ptrtoint (i64* null to i32)')
+
     def test_inttoptr(self):
-        c = ir.Constant(int32, 0).inttoptr(int64.as_pointer())
-        self.assertEqual(str(c), 'inttoptr (i32 0 to i64*)')
+        one = ir.Constant(int32, 1)
+        pi = ir.Constant(flt, 3.14)
+        c = one.inttoptr(int64.as_pointer())
+
+        self.assertRaises(TypeError, one.inttoptr, int64)
+        self.assertRaises(TypeError, pi.inttoptr, int64.as_pointer())
+        self.assertEqual(str(c), 'inttoptr (i32 1 to i64*)')
 
     def test_neg(self):
         one = ir.Constant(int32, 1)


### PR DESCRIPTION
This is an initial PR to clarify preferred design decisions before I commit more time and effort, expect more commits based on feedback before a potential merge.

1. Is the use of a decorator called _binop appropriate? It is somewhat copy&paste from builder.py
2. Is the naming scheme "lhs" and "rhs" in docstrings OK, even though they do not match argument list?
3. is the testing approach appropriate, i.e., string compare of emitted llvm-ir?

