### PR TITLE
Remove 3.6 support

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -64,7 +64,7 @@ layer.
 Compatibility
 =============
 
-llvmlite works with Python 3.6 and greater.
+llvmlite works with Python 3.7 and greater.
 
 As of version 0.34.0, llvmlite requires LLVM 10.0.x. on all architectures
 except ``aarch64`` which requires LLVM 9.0.x due to:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -5,9 +5,6 @@ jobs:
     name: macOS
     vmImage: macOS-10.14
     matrix:
-      py36:
-        PYTHON: '3.6'
-        CONDA_ENV: cienv
       py37:
         PYTHON: '3.7'
         CONDA_ENV: cienv
@@ -23,9 +20,6 @@ jobs:
     name: Linux
     vmImage: ubuntu-16.04
     matrix:
-      py36:
-        PYTHON: '3.6'
-        CONDA_ENV: cienv
       py37:
         PYTHON: '3.7'
         CONDA_ENV: cienv
@@ -41,10 +35,6 @@ jobs:
 #       pypy:
 #         PYTHON: pypy
 #         CONDA_ENV: cienv
-      py36_wheel:
-        PYTHON: '3.6'
-        CONDA_ENV: cienv
-        WHEEL: 'yes'
       py37_wheel:
         PYTHON: '3.7'
         CONDA_ENV: cienv

--- a/conda-recipes/llvmlite/meta.yaml
+++ b/conda-recipes/llvmlite/meta.yaml
@@ -36,7 +36,7 @@ requirements:
     # llvmdev is built with libz compression support
     - zlib           # [unix and not (armv6l or armv7l or aarch64)]
   run:
-    - python >=3.6
+    - python >=3.7
     - vs2015_runtime # [win]
     # osx has dynamically linked libstdc++
     - libcxx >=4.0.1 # [osx]

--- a/conda-recipes/llvmlite/meta.yaml
+++ b/conda-recipes/llvmlite/meta.yaml
@@ -36,7 +36,7 @@ requirements:
     # llvmdev is built with libz compression support
     - zlib           # [unix and not (armv6l or armv7l or aarch64)]
   run:
-    - python >=3.7
+    - python >=3.7,<3.10
     - vs2015_runtime # [win]
     # osx has dynamically linked libstdc++
     - libcxx >=4.0.1 # [osx]

--- a/docs/source/contributing.rst
+++ b/docs/source/contributing.rst
@@ -84,7 +84,7 @@ Coding conventions
 Platform support
 ----------------
 
-Llvmlite will be kept compatible with Python 3.6 and later
+Llvmlite will be kept compatible with Python 3.7 and later
 under at least Windows, macOS and Linux.
 
 We do not expect contributors to test their code on all platforms.  Pull

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ except ImportError:
         pass
 
 
-min_python_version = "3.6"
+min_python_version = "3.7"
 max_python_version = "3.10"  # exclusive
 
 
@@ -209,7 +209,6 @@ setup(name='llvmlite',
           "Operating System :: OS Independent",
           "Programming Language :: Python",
           "Programming Language :: Python :: 3",
-          "Programming Language :: Python :: 3.6",
           "Programming Language :: Python :: 3.7",
           "Programming Language :: Python :: 3.8",
           "Programming Language :: Python :: 3.9",


### PR DESCRIPTION
Remove 3.6 support and include clamping the maximum Python version in the conda recipe as this had been omitted. 