### PR TITLE
Fix encoding of unicode string in metadata.

### DIFF
--- a/llvmlite/ir/values.py
+++ b/llvmlite/ir/values.py
@@ -21,9 +21,10 @@ _SIMPLE_IDENTIFIER_RE = re.compile(r"[-a-zA-Z$._][-a-zA-Z$._0-9]*$")
 def _escape_string(text, _map={}):
     """
     Escape the given bytestring for safe use as a LLVM array constant.
+    Any unicode string input is first encoded with utf8 into bytes.
     """
     if isinstance(text, str):
-        text = text.encode('ascii')
+        text = text.encode()
     assert isinstance(text, (bytes, bytearray))
 
     if not _map:

--- a/llvmlite/tests/test_ir.py
+++ b/llvmlite/tests/test_ir.py
@@ -389,7 +389,7 @@ class TestIR(TestBase):
 
     def test_debug_info_unicode_string(self):
         mod = self.module()
-        di = mod.add_debug_info("DILocalVariable", {"name": "a∆"})
+        mod.add_debug_info("DILocalVariable", {"name": "a∆"})
         # Check output
         strmod = str(mod)
         # The unicode character is utf8 encoded with \XX format, where XX is hex

--- a/llvmlite/tests/test_ir.py
+++ b/llvmlite/tests/test_ir.py
@@ -387,6 +387,15 @@ class TestIR(TestBase):
                             '"foo")', strmod)
         self.assert_valid_ir(mod)
 
+    def test_debug_info_unicode_string(self):
+        mod = self.module()
+        di = mod.add_debug_info("DILocalVariable", {"name": "a∆"})
+        # Check output
+        strmod = str(mod)
+        # The unicode character is utf8 encoded with \XX format, where XX is hex
+        name = ''.join(map(lambda x: f"\\{x:02x}", "∆".encode()))
+        self.assert_ir_line(f'!0 = !DILocalVariable(name: "a{name}")', strmod)
+
     def test_inline_assembly(self):
         mod = self.module()
         foo = ir.Function(mod, ir.FunctionType(ir.VoidType(), []), 'foo')


### PR DESCRIPTION
Supersede to https://github.com/numba/numba/pull/7208

Fixes unicode encoding for LLVM debug metadata string.