### PR TITLE
Add issue templates based on those in Numba

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,34 @@
+---
+name: Bug Report
+about: Report a bug. Not for asking general questions - see below.
+
+---
+
+<!--
+
+Thanks for opening an issue! To help the Numba team handle your information
+efficiently, please first ensure that there is no other issue present that
+already describes the issue you have
+(search at https://github.com/numba/llvmlite/issues?&q=is%3Aissue).
+
+-->
+
+## Reporting a bug
+
+<!--
+
+Before submitting a bug report please ensure that you can check off these boxes:
+
+-->
+
+- [ ] I have tried using the latest released version of llvmlite (most recent is
+ visible in the change log (https://github.com/numba/llvmlite/blob/master/CHANGE_LOG).
+- [ ] I have included a self contained code sample to reproduce the problem.
+  i.e. it's possible to run as 'python bug.py'.
+
+<!--
+
+Please include details of the bug here, including, if applicable, what you
+expected to happen!
+
+-->

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,11 @@
+blank_issues_enabled: false
+contact_links:
+  - name: General Question
+    url: https://numba.discourse.group/c/llvmlite
+    about: "If you have a general question (not a bug report or feature request) then please ask in the llvmlite section of Numba's discourse instance."
+  - name: Quick Question/Just want to say Hi!
+    url: https://gitter.im/numba/llvmlite
+    about: "If you have a quick question or want chat to users/developers in real time then please use gitter.im/numba/llvmlite"
+  - name: Discuss an involved feature
+    url: https://numba.discourse.group/c/llvmlite
+    about: "If you would like to suggest a more involved feature like *Can a new pass be added to do X* then please start a discussion in the llvmlite section of Numba's discourse instance."

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -8,9 +8,9 @@ about: Tell us about something you'd like llvmlite to support. Not for asking ge
 
 <!--
 
-Thanks for opening an issue! To help the Numba team handle your information
-efficiently, please first ensure that there is no other issue present that
-already describes the issue you have
+Thanks for opening a feature request! To help the Numba team handle your information
+efficiently, please first ensure that there is no other feature request present that
+already describes the feature you would like to see implemented
 (search at https://github.com/numba/llvmlite/issues?&q=is%3Aissue).
 
 -->

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,25 @@
+---
+name: Feature Request
+about: Tell us about something you'd like llvmlite to support. Not for asking general questions - see below.
+
+---
+
+---
+
+<!--
+
+Thanks for opening an issue! To help the Numba team handle your information
+efficiently, please first ensure that there is no other issue present that
+already describes the issue you have
+(search at https://github.com/numba/llvmlite/issues?&q=is%3Aissue).
+
+-->
+
+## Feature request
+
+<!--
+
+Please include details of the feature you would like to see, why you would
+like to see it/the use case.
+
+-->


### PR DESCRIPTION
These templates are similar to Numba's, but customised for llvmlite. The main aim in adding them is to direct questions and involved feature discussions toward the llvmlite section of the Numba discourse, rather than the creation of new issues.