### PR TITLE
Update the Azure default linux image to Ubuntu 18.04

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -18,7 +18,7 @@ jobs:
 - template: buildscripts/azure/azure-linux-macos.yml
   parameters:
     name: Linux
-    vmImage: ubuntu-16.04
+    vmImage: ubuntu-18.04
     matrix:
       py37:
         PYTHON: '3.7'


### PR DESCRIPTION
As title. 16.04 is EOL since April 2021. See details here:
https://github.com/actions/virtual-environments/issues/3287