### PR TITLE
Cherry-picks for 0.37.0

### DIFF
--- a/conda-recipes/llvmdev/conda_build_config.yaml
+++ b/conda-recipes/llvmdev/conda_build_config.yaml
@@ -1,0 +1,12 @@
+# Numba/llvmlite stack needs an older compiler for backwards compatability.
+c_compiler_version:         # [linux]
+  - 7                       # [linux and (x86_64 or ppc64le)]
+  - 9                       # [linux and aarch64]
+
+cxx_compiler_version:       # [linux]
+  - 7                       # [linux and (x86_64 or ppc64le)]
+  - 9                       # [linux and aarch64]
+
+fortran_compiler_version:   # [linux]
+  - 7                       # [linux and (x86_64 or ppc64le)]
+  - 9                       # [linux and aarch64]

--- a/conda-recipes/llvmdev/meta.yaml
+++ b/conda-recipes/llvmdev/meta.yaml
@@ -2,7 +2,7 @@
 {% set version = "11.1.0" %}
 {% set sha256_llvm = "ce8508e318a01a63d4e8b3090ab2ded3c598a50258cc49e2625b9120d4c03ea5" %}
 {% set sha256_lld = "017a788cbe1ecc4a949abf10755870519086d058a2e99f438829aef24f0c66ce" %}
-{% set build_number = "2" %}
+{% set build_number = "3" %}
 
 package:
   name: llvmdev

--- a/conda-recipes/llvmlite/conda_build_config.yaml
+++ b/conda-recipes/llvmlite/conda_build_config.yaml
@@ -1,0 +1,12 @@
+# Numba/llvmlite stack needs an older compiler for backwards compatability.
+c_compiler_version:         # [linux]
+  - 7                       # [linux and (x86_64 or ppc64le)]
+  - 9                       # [linux and aarch64]
+
+cxx_compiler_version:       # [linux]
+  - 7                       # [linux and (x86_64 or ppc64le)]
+  - 9                       # [linux and aarch64]
+
+fortran_compiler_version:   # [linux]
+  - 7                       # [linux and (x86_64 or ppc64le)]
+  - 9                       # [linux and aarch64]

--- a/conda-recipes/llvmlite/meta.yaml
+++ b/conda-recipes/llvmlite/meta.yaml
@@ -30,8 +30,8 @@ requirements:
   host:
     - python
     # On channel https://anaconda.org/numba/
-    - llvmdev 11.1.0 *2 # [not win]
-    - llvmdev 11.1.0 2 # [win]
+    - llvmdev 11.1.0 *3 # [not win]
+    - llvmdev 11.1.0 3 # [win]
     - vs2015_runtime # [win]
     # llvmdev is built with libz compression support
     - zlib           # [unix and not (armv6l or armv7l or aarch64)]


### PR DESCRIPTION
* PR #758 continued. Ensure GCC7 is used on non-ARM platforms.