### PR TITLE
Adds _ConstOpMixin.ptrtoint to complement existing bitcast and inttoptr methods.

### DIFF
--- a/llvmlite/ir/values.py
+++ b/llvmlite/ir/values.py
@@ -52,6 +52,24 @@ class _ConstOpMixin(object):
                                                typ)
         return FormattedConstant(typ, op)
 
+    def ptrtoint(self, typ):
+        """
+        Cast this pointer constant to the given integer type.
+        """
+        if not isinstance(typ, types.IntType):
+            raise TypeError(
+                "can only ptrtoint() to integer type, not '%s'"
+                % (typ,))
+        if not isinstance(self.type, types.PointerType):
+            raise TypeError(
+                "can only call inttoptr() on pointer type, not '%s'"
+                % (self.type))
+
+        op = "ptrtoint ({0} {1} to {2})".format(self.type,
+                                                self.get_reference(),
+                                                typ)
+        return FormattedConstant(typ, op)
+
     def inttoptr(self, typ):
         """
         Cast this integer constant to the given pointer type.

--- a/llvmlite/tests/test_ir.py
+++ b/llvmlite/tests/test_ir.py
@@ -2233,14 +2233,14 @@ class TestConstant(TestBase):
 
         self.assertRaisesRegex(
             TypeError,
-            "can only ptrtoint\\(\\) to integer type, not 'i64\\*'",
+            r"can only ptrtoint\(\) to integer type, not 'i64\*'",
             gv.ptrtoint,
             int64.as_pointer())
 
         c2 = ir.Constant(int32, 0)
         self.assertRaisesRegex(
             TypeError,
-            "can only call inttoptr\\(\\) on pointer type, not 'i32'",
+            r"can only call inttoptr\(\) on pointer type, not 'i32'",
             c2.ptrtoint,
             int64)
 

--- a/llvmlite/tests/test_ir.py
+++ b/llvmlite/tests/test_ir.py
@@ -2225,6 +2225,25 @@ class TestConstant(TestBase):
         c = gv.bitcast(int64.as_pointer())
         self.assertEqual(str(c), 'bitcast (i32* @"myconstant" to i64*)')
 
+    def test_ptrtoint(self):
+        m = self.module()
+        gv = ir.GlobalVariable(m, int32, "myconstant")
+        c = gv.ptrtoint(int64)
+        self.assertEqual(str(c), 'ptrtoint (i32* @"myconstant" to i64)')
+
+        self.assertRaisesRegex(
+            TypeError,
+            "can only ptrtoint\\(\\) to integer type, not 'i64\\*'",
+            gv.ptrtoint,
+            int64.as_pointer())
+
+        c2 = ir.Constant(int32, 0)
+        self.assertRaisesRegex(
+            TypeError,
+            "can only call inttoptr\\(\\) on pointer type, not 'i32'",
+            c2.ptrtoint,
+            int64)
+
     def test_inttoptr(self):
         c = ir.Constant(int32, 0).inttoptr(int64.as_pointer())
         self.assertEqual(str(c), 'inttoptr (i32 0 to i64*)')


### PR DESCRIPTION
See details and background in LLVM IR language reference:

https://llvm.org/docs/LangRef.html#ptrtoint-to-instruction