### PR TITLE
Update Windows and OSX CI images.

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -3,7 +3,7 @@ jobs:
 - template: buildscripts/azure/azure-linux-macos.yml
   parameters:
     name: macOS
-    vmImage: macOS-10.14
+    vmImage: macOS-10.15
     matrix:
       py37:
         PYTHON: '3.7'
@@ -51,4 +51,4 @@ jobs:
 - template: buildscripts/azure/azure-windows.yml
   parameters:
     name: Windows
-    vmImage: vs2017-win2016
+    vmImage: windows-2019


### PR DESCRIPTION
macOS-10.14 and vs2017-win2016 are being deprecated by Azure CI.
This patch updates the images used to the oldest image that is
still supported.