### PR TITLE
Add RISC-V + all default targets to LLVM build

### DIFF
--- a/conda-recipes/llvmdev/bld.bat
+++ b/conda-recipes/llvmdev/bld.bat
@@ -6,8 +6,9 @@ set BUILD_CONFIG=Release
 REM === Configure step ===
 
 REM allow setting the targets to build as an environment variable
+REM default is LLVM 11 default architectures + RISCV.  Can remove this entire option in LLVM 13
 if "%LLVM_TARGETS_TO_BUILD%"=="" (
-    set "LLVM_TARGETS_TO_BUILD=host;AMDGPU;NVPTX;RISCV"
+    set "LLVM_TARGETS_TO_BUILD=host;AArch64;AMDGPU;ARM;BPF;Hexagon;Mips;MSP430;NVPTX;PowerPC;Sparc;SystemZ;X86;XCore;RISCV"
 )
 if "%ARCH%"=="32" (
     set "ARCH_POSTFIX="

--- a/conda-recipes/llvmdev/bld.bat
+++ b/conda-recipes/llvmdev/bld.bat
@@ -7,7 +7,7 @@ REM === Configure step ===
 
 REM allow setting the targets to build as an environment variable
 if "%LLVM_TARGETS_TO_BUILD%"=="" (
-    set "LLVM_TARGETS_TO_BUILD=host;AMDGPU;NVPTX"
+    set "LLVM_TARGETS_TO_BUILD=host;AMDGPU;NVPTX;RISCV"
 )
 if "%ARCH%"=="32" (
     set "ARCH_POSTFIX="

--- a/conda-recipes/llvmdev/build.sh
+++ b/conda-recipes/llvmdev/build.sh
@@ -88,5 +88,11 @@ make install || exit $?
 if [[ $ARCH == 'x86_64' ]]; then
    bin/opt -S -vector-library=SVML -mcpu=haswell -O3 $RECIPE_DIR/numba-3016.ll | bin/FileCheck $RECIPE_DIR/numba-3016.ll || exit $?
 fi
+
+# run the tests, skip some on linux-32
 cd ../test
-../build/bin/llvm-lit -vv Transforms ExecutionEngine Analysis CodeGen/X86
+if [[ $ARCH == 'i686' ]]; then
+    ../build/bin/llvm-lit -vv Transforms Analysis CodeGen/X86
+else
+    ../build/bin/llvm-lit -vv Transforms ExecutionEngine Analysis CodeGen/X86
+fi

--- a/conda-recipes/llvmdev/build.sh
+++ b/conda-recipes/llvmdev/build.sh
@@ -5,7 +5,8 @@
 set -x
 
 # allow setting the targets to build as an environment variable
-LLVM_TARGETS_TO_BUILD=${LLVM_TARGETS_TO_BUILD:-"host;AMDGPU;NVPTX;RISCV"}
+# default is LLVM 11 default architectures + RISCV.  Can remove this entire option in LLVM 13
+LLVM_TARGETS_TO_BUILD=${LLVM_TARGETS_TO_BUILD:-"host;AArch64;AMDGPU;ARM;BPF;Hexagon;Mips;MSP430;NVPTX;PowerPC;Sparc;SystemZ;X86;XCore;RISCV"}
 
 # This is the clang compiler prefix
 DARWIN_TARGET=x86_64-apple-darwin13.4.0

--- a/conda-recipes/llvmdev/build.sh
+++ b/conda-recipes/llvmdev/build.sh
@@ -5,7 +5,7 @@
 set -x
 
 # allow setting the targets to build as an environment variable
-LLVM_TARGETS_TO_BUILD=${LLVM_TARGETS_TO_BUILD:-"host;AMDGPU;NVPTX"}
+LLVM_TARGETS_TO_BUILD=${LLVM_TARGETS_TO_BUILD:-"host;AMDGPU;NVPTX;RISCV"}
 
 # This is the clang compiler prefix
 DARWIN_TARGET=x86_64-apple-darwin13.4.0

--- a/conda-recipes/llvmdev/meta.yaml
+++ b/conda-recipes/llvmdev/meta.yaml
@@ -2,7 +2,7 @@
 {% set version = "11.1.0" %}
 {% set sha256_llvm = "ce8508e318a01a63d4e8b3090ab2ded3c598a50258cc49e2625b9120d4c03ea5" %}
 {% set sha256_lld = "017a788cbe1ecc4a949abf10755870519086d058a2e99f438829aef24f0c66ce" %}
-{% set build_number = "3" %}
+{% set build_number = "4" %}
 
 package:
   name: llvmdev

--- a/conda-recipes/llvmdev_manylinux2014/build.sh
+++ b/conda-recipes/llvmdev_manylinux2014/build.sh
@@ -28,7 +28,7 @@ _cmake_config+=(-DHAVE_TERMIOS_H=OFF)
 _cmake_config+=(-DCLANG_ENABLE_LIBXML=OFF)
 _cmake_config+=(-DLIBOMP_INSTALL_ALIASES=OFF)
 _cmake_config+=(-DLLVM_ENABLE_RTTI=OFF)
-_cmake_config+=(-DLLVM_TARGETS_TO_BUILD="host;AMDGPU;NVPTX")
+_cmake_config+=(-DLLVM_TARGETS_TO_BUILD="host;AMDGPU;NVPTX;RISCV")
 _cmake_config+=(-DLLVM_EXPERIMENTAL_TARGETS_TO_BUILD=WebAssembly)
 _cmake_config+=(-DLLVM_INCLUDE_UTILS=ON) # for llvm-lit
 # TODO :: It would be nice if we had a cross-ecosystem 'BUILD_TIME_LIMITED' env var we could use to

--- a/conda-recipes/llvmdev_manylinux2014/build.sh
+++ b/conda-recipes/llvmdev_manylinux2014/build.sh
@@ -28,7 +28,8 @@ _cmake_config+=(-DHAVE_TERMIOS_H=OFF)
 _cmake_config+=(-DCLANG_ENABLE_LIBXML=OFF)
 _cmake_config+=(-DLIBOMP_INSTALL_ALIASES=OFF)
 _cmake_config+=(-DLLVM_ENABLE_RTTI=OFF)
-_cmake_config+=(-DLLVM_TARGETS_TO_BUILD="host;AMDGPU;NVPTX;RISCV")
+# default is LLVM 11 default architectures + RISCV.  Can remove this entire option in LLVM 13
+_cmake_config+=(-DLLVM_TARGETS_TO_BUILD="host;AArch64;AMDGPU;ARM;BPF;Hexagon;Mips;MSP430;NVPTX;PowerPC;Sparc;SystemZ;X86;XCore;RISCV")
 _cmake_config+=(-DLLVM_EXPERIMENTAL_TARGETS_TO_BUILD=WebAssembly)
 _cmake_config+=(-DLLVM_INCLUDE_UTILS=ON) # for llvm-lit
 # TODO :: It would be nice if we had a cross-ecosystem 'BUILD_TIME_LIMITED' env var we could use to

--- a/conda-recipes/llvmdev_manylinux2014/meta.yaml
+++ b/conda-recipes/llvmdev_manylinux2014/meta.yaml
@@ -2,7 +2,7 @@
 {% set version = "11.1.0" %}
 {% set sha256_llvm = "ce8508e318a01a63d4e8b3090ab2ded3c598a50258cc49e2625b9120d4c03ea5" %}
 {% set sha256_lld = "017a788cbe1ecc4a949abf10755870519086d058a2e99f438829aef24f0c66ce" %}
-{% set build_number = "2" %}
+{% set build_number = "3" %}
 
 package:
   name: llvmdev


### PR DESCRIPTION
There is growing interest in using llvmlite as a cross-compiler to target RISC-V.  (See #785 and #775)  This adds the RISC-V target as well as all the default targets to both the llvmdev package build and the llvmdev_manylinux2014 package build for all platforms.  The increase in package size with this target should be ~30%.

(Note this is not adding RISC-V as a supported host platform for llvmlite, as that will require greater availability of RISC-V hardware running Linux, as well as a reasonable ecosystem of Python packages on that platform.)

Edit: Originally this PR only added RISC-V (at a size cost of 1.5%) but further discussion in #785 made it clear that we could add all the standard targets too.  Note that starting with LLVM 13, the standard targets include RISC-V and WebAssembly, so the explicit target selection in our config can be dropped whenever we upgrade to LLVM 13.