### PR TITLE
don't build docs on every platform, only once

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -48,6 +48,11 @@ jobs:
         CONDA_ENV: cienv
         WHEEL: 'yes'
 
+      py39_docs:
+        PYTHON: '3.9'
+        CONDA_ENV: cienv
+        BUILD_DOCS: 'yes'
+
 - template: buildscripts/azure/azure-windows.yml
   parameters:
     name: Windows

--- a/buildscripts/azure/azure-linux-macos.yml
+++ b/buildscripts/azure/azure-linux-macos.yml
@@ -15,6 +15,7 @@ jobs:
 
   steps:
     - script: |
+        set -e
         if [ "$(uname)" == "Linux" ] && [[ "$CONDA_SUBDIR" == "linux-32" || "$BITS32" == "yes" ]]; then sudo apt-get install -y libc6-dev-i386; fi
         echo "Installing Miniconda"
         buildscripts/incremental/install_miniconda.sh
@@ -24,11 +25,13 @@ jobs:
       displayName: 'Before Install'
 
     - script: |
+        set -e
         export PATH=$HOME/miniconda3/bin:$PATH
         buildscripts/incremental/build.sh
       displayName: 'Build'
 
     - script: |
+        set -e
         export PATH=$HOME/miniconda3/bin:$PATH
         conda install -y flake8
         echo "Running flake8 check"
@@ -37,6 +40,7 @@ jobs:
       condition: eq(variables['RUN_FLAKE8'], 'yes')
 
     - script: |
+        set -e
         export PATH=$HOME/miniconda3/bin:$PATH
         conda install -y sphinx sphinx_rtd_theme pygments
         echo "Building docs"
@@ -47,6 +51,7 @@ jobs:
       condition: eq(variables['BUILD_DOCS'], 'yes')
 
     - script: |
+        set -e
         export PATH=$HOME/miniconda3/bin:$PATH
         buildscripts/incremental/test.sh
       displayName: 'Test'

--- a/buildscripts/azure/azure-linux-macos.yml
+++ b/buildscripts/azure/azure-linux-macos.yml
@@ -38,5 +38,15 @@ jobs:
 
     - script: |
         export PATH=$HOME/miniconda3/bin:$PATH
+        conda install -y sphinx sphinx_rtd_theme pygments
+        echo "Building docs"
+        cd docs
+        SPHINXOPTS=-Wn clean html
+        cd ..
+      displayName: 'Build Docs'
+      condition: eq(variables['BUILD_DOCS'], 'yes')
+
+    - script: |
+        export PATH=$HOME/miniconda3/bin:$PATH
         buildscripts/incremental/test.sh
       displayName: 'Test'

--- a/buildscripts/azure/azure-linux-macos.yml
+++ b/buildscripts/azure/azure-linux-macos.yml
@@ -41,7 +41,7 @@ jobs:
         conda install -y sphinx sphinx_rtd_theme pygments
         echo "Building docs"
         cd docs
-        SPHINXOPTS=-Wn clean html
+        make SPHINXOPTS=-Wn clean html
         cd ..
       displayName: 'Build Docs'
       condition: eq(variables['BUILD_DOCS'], 'yes')

--- a/buildscripts/incremental/setup_conda_environment.sh
+++ b/buildscripts/incremental/setup_conda_environment.sh
@@ -35,17 +35,5 @@ if [[ $(uname) == Linux ]]; then
 $CONDA_INSTALL gcc_linux-64 gxx_linux-64
 fi
 
-# Install enum34 for Python < 3.4 and PyPy, and install dependencies for
-# building the docs.
-if [ "$PYTHON" == "pypy" ]; then
-  $CONDA_INSTALL zlib # pypy has no conda-level zlib linkage
-  python -m ensurepip
-  $PIP_INSTALL enum34
-  # Sphinx 1.5.4 has a bug.
-  $PIP_INSTALL sphinx==1.5.1 sphinx_rtd_theme pygments
-else
-  $CONDA_INSTALL sphinx sphinx_rtd_theme pygments
-fi
-
 # Install dependencies for code coverage (codecov.io)
 if [ "$RUN_COVERAGE" == "yes" ]; then $PIP_INSTALL codecov coveralls; fi

--- a/buildscripts/incremental/test.sh
+++ b/buildscripts/incremental/test.sh
@@ -5,12 +5,8 @@ source activate $CONDA_ENV
 # Make sure any error below is reported as such
 set -v -e
 
-# Ensure that the documentation builds without warnings nor missing references
-cd docs
-make SPHINXOPTS=-Wn clean html
-
 # Run test suite
-cd ..
+
 python --version
 
 if [ "$WHEEL" == "yes" ]; then


### PR DESCRIPTION
This will ease the load on the testing runs. Also, it means, we can release for new versions of Python without having to wait for the availability of the doc packages.

cc: #769 