### PR TITLE
Continue PR #735 (Add support for more constant expressions)

### DIFF
--- a/docs/source/user-guide/ir/values.rst
+++ b/docs/source/user-guide/ir/values.rst
@@ -23,6 +23,175 @@ A :ref:`module` consists mostly of values.
    The base class for all IR values.
 
 
+.. class:: _ConstOpMixin
+
+   This is the base class for :class:`Constant` and :class:`GlobalValue`; do
+   not instantiate it directly.
+
+   Integer arithmetic operations:
+
+   * .. method:: add(other)
+
+      Integer add `self` and `other`.
+
+   * .. method:: sub(other)
+
+      Integer subtract `other` from `self`.
+
+   * .. method:: mul(other)
+
+      Integer multiply `self` with `other`.
+
+   * .. method:: udiv(other)
+
+      Unsigned integer divide `self` by `other`.
+
+   * .. method:: sdiv(other)a
+
+      Signed integer divide `self` by `other`.
+
+   * .. method:: urem(other)
+
+      Unsigned integer remainder of `self` divided by `other`.
+
+   * .. method:: srem(other)
+
+      Signed integer remainder of `self` divided by `other`.
+
+   * .. method:: neg()
+
+      Negate `self`.
+
+   Integer logical operations:
+
+   * .. method:: shl(other)
+
+      Left-shift `self` by `other` bits.
+
+   * .. method:: ashr(other)
+
+      Arithmetic, signed, right-shift `self` by `other` bits.
+
+   * .. method:: lshr(other)
+
+      Logical right-shift `self` by `other` bits.
+
+   * .. method:: or_(other)
+
+      Bitwise OR `self` with `other`.
+
+   * .. method:: and_(other)
+
+      Bitwise AND `self` with `other`.
+
+   * .. method:: xor(other)
+
+      Bitwise XOR `self` with `other`.
+
+   Floating point arithmetic:
+
+   * .. method:: fadd(other)
+
+      Floating-point add `self` and `other`.
+
+   * .. method:: fsub(other)
+
+      Floating-point subtract `other` from `self`.
+
+   * .. method:: fmul(other)
+
+      Floating-point multiply `self` by `other`.
+
+   * .. method:: fdiv(other)
+
+      Floating-point divide `self` by `other`.
+
+   * .. method:: frem(other)
+
+      Floating-point remainder of `self` divided by `other`.
+
+   Comparisons:
+
+   * .. method:: icmp_signed(cmpop, other)
+
+      Signed integer compare `self` with `other`. The string `cmpop` can be one
+      of ``<``, ``<=``, ``==``, ``!=``, ``>=`` or ``>``.
+
+   * .. method:: icmp_unsigned(cmpop, other)
+
+      Unsigned integer compare `self` with `other`. The string `cmpop` can be
+      one of ``<``, ``<=``, ``==``, ``!=``, ``>=`` or ``>``.
+
+   * .. method:: fcmp_ordered(cmpop, other)
+
+      Floating-point ordered compare `self` with `other`. The string `cmpop`
+      can be one of ``<``, ``<=``, ``==``, ``!=``, ``>=`` or ``>``.
+
+   * .. method:: fcmp_unordered(cmpop, other)
+
+      Floating-point unordered compare `self` with `other`. The string `cmpop`
+      can be one of ``<``, ``<=``, ``==``, ``!=``, ``>=`` or ``>``.
+
+   Integer casts:
+
+   * .. method:: trunc(typ)
+
+      Truncate `self` to integer type `typ`.
+
+   * .. method:: zext(typ)
+
+      Zero-extend `self` to integer type `typ`.
+
+   * .. method:: sext(typ)
+
+       Sign-extend `self` to integer type `typ`.
+
+   * .. method:: bitcast(typ)
+
+      Convert this pointer constant to a constant of the given pointer type
+      `typ`.
+
+   Floating-point casts:
+
+   * .. method:: fptrunc(typ)
+
+      Truncate (approximate ) floating-point value `self` to floating-point
+      type `typ`.
+
+   * .. method:: fpext(typ)
+
+      Extend floating-point value `self` to floating-point type `typ`.
+
+   Integer / floating-point conversion:
+
+   * .. method:: fptoui(typ)
+
+      Convert floating-point value `self` to unsigned integer type `typ`.
+
+   * .. method:: uitofp(typ)
+
+      Convert unsigned integer value `self` to floating-point type `typ`.
+
+   * .. method:: fptosi(typ)
+
+      Convert floating-point value `self` to signed integer type `typ`.
+
+   * .. method:: sitofp(typ)
+
+      Convert signed integer value `self` to floating-point type `typ`.
+
+   Integer / pointer conversions:
+
+   * .. method:: inttoptr(typ)
+
+      Convert this integer constant `self` to a constant of the given pointer
+      type `typ`.
+
+   * .. method:: ptrtoint(typ)
+
+      Convert this pointer constant `self` to a constant of the given integer
+      type `typ`.
+
 .. class:: Constant(typ, constant)
 
    A literal value.
@@ -53,6 +222,8 @@ A :ref:`module` consists mostly of values.
      instance to initialize the array from a string of bytes.
      This is useful for character constants.
 
+   See also :class:`_ConstOpMixin`.
+
    .. classmethod:: literal_array(elements)
 
       An alternate constructor for constant arrays.
@@ -71,21 +242,11 @@ A :ref:`module` consists mostly of values.
         otherwise. Returns a constant struct containing the
         *elements* in order.
 
-   .. method:: bitcast(typ)
-
-      Convert this pointer constant to a constant of the
-      given pointer type.
-
    .. method:: gep(indices)
 
       Compute the address of the inner element given by the
       sequence of *indices*. The constant must have a pointer
       type.
-
-   .. method:: inttoptr(typ)
-
-      Convert this integer constant to a constant of the
-      given pointer type.
 
    NOTE: You cannot define constant functions. Use a
    :ref:`function declaration` instead.
@@ -212,6 +373,7 @@ Global values are values accessible using a module-wide name.
         * Other possible values include ``dllimport`` and
           ``dllexport``.
 
+   See also :class:`_ConstOpMixin`.
 
 .. class:: GlobalVariable(module, typ, name, addrspace=0)
 

--- a/docs/source/user-guide/ir/values.rst
+++ b/docs/source/user-guide/ir/values.rst
@@ -155,7 +155,7 @@ A :ref:`module` consists mostly of values.
 
    * .. method:: fptrunc(typ)
 
-      Truncate (approximate ) floating-point value `self` to floating-point
+      Truncate (approximate) floating-point value `self` to floating-point
       type `typ`.
 
    * .. method:: fpext(typ)

--- a/llvmlite/ir/values.py
+++ b/llvmlite/ir/values.py
@@ -38,7 +38,7 @@ def _escape_string(text, _map={}):
     return ''.join(buf)
 
 
-def _binop(fn):
+def _binop(opname):
     def wrap(fn):
         @functools.wraps(fn)
         def wrapped(lhs, rhs):
@@ -47,7 +47,7 @@ def _binop(fn):
                                  % (lhs.type, rhs.type))
 
             fmt = "{0} ({1}, {2})"
-            return FormattedConstant(lhs.type, fmt.format(fn.__name__, lhs, rhs))
+            return FormattedConstant(lhs.type, fmt.format(opname, lhs, rhs))
 
         return wrapped
 

--- a/llvmlite/ir/values.py
+++ b/llvmlite/ir/values.py
@@ -266,7 +266,7 @@ class _ConstOpMixin(object):
             self.get_reference(), ', '.join(strindices))
         return FormattedConstant(outtype.as_pointer(self.addrspace), op)
 
-    
+
 class Value(object):
     """
     The base class for all values.

--- a/llvmlite/ir/values.py
+++ b/llvmlite/ir/values.py
@@ -56,9 +56,8 @@ def _binop(opname):
                                  % (lhs.type, rhs.type))
 
             fmt = "{0} ({1} {2}, {3} {4})".format(opname,
-                lhs.type, lhs.get_reference(),
-                rhs.type, rhs.get_reference()
-            )
+                                                  lhs.type, lhs.get_reference(),
+                                                  rhs.type, rhs.get_reference())
             return FormattedConstant(lhs.type, fmt)
 
         return wrapped
@@ -213,15 +212,15 @@ class _ConstOpMixin(object):
 
         if self.type != other.type:
             raise ValueError("Operands must be the same type, got (%s, %s)"
-                                 % (self.type, other.type))
+                             % (self.type, other.type))
 
         fmt = "{0} {1} ({2} {3}, {4} {5})".format(
             ins, op,
             self.type, self.get_reference(),
             other.type, other.get_reference())
-        
+
         return FormattedConstant(types.IntType(1), fmt)
-    
+
     def icmp_signed(self, cmpop, other):
         """
         Signed integer comparison:
@@ -248,7 +247,7 @@ class _ConstOpMixin(object):
         where cmpop can be '==', '!=', '<', '<=', '>', '>=', 'ord', 'uno'
         """
         return self._cmp('f', 'o', cmpop, other)
-    
+
     def fcmp_unordered(self, cmpop, other):
         """
         Floating-point unordered comparison:
@@ -257,7 +256,7 @@ class _ConstOpMixin(object):
         where cmpop can be '==', '!=', '<', '<=', '>', '>=', 'ord', 'uno'
         """
         return self._cmp('f', 'u', cmpop, other)
-    
+
     #
     # Unary APIs
     #
@@ -271,9 +270,9 @@ class _ConstOpMixin(object):
             rhs = values.Constant(self.type, (-1,) * self.type.count)
         else:
             rhs = values.Constant(self.type, -1)
-        
+
         return self.xor(rhs)
-    
+
     def neg(self):
         """
         Integer negative:
@@ -281,7 +280,7 @@ class _ConstOpMixin(object):
         """
         zero = values.Constant(self.type, 0)
         return zero.sub(self)
-    
+
     def fneg(self):
         """
         Floating-point negative:

--- a/llvmlite/ir/values.py
+++ b/llvmlite/ir/values.py
@@ -287,7 +287,8 @@ class _ConstOpMixin(object):
         Floating-point negative:
             -value
         """
-        return self.neg()
+        fmt = "fneg ({0} {1})".format(self.type, self.get_reference())
+        return FormattedConstant(self.type, fmt)
 
     def bitcast(self, typ):
         """

--- a/llvmlite/ir/values.py
+++ b/llvmlite/ir/values.py
@@ -55,8 +55,11 @@ def _binop(opname):
                 raise ValueError("Operands must be the same type, got (%s, %s)"
                                  % (lhs.type, rhs.type))
 
-            fmt = "{0} ({1}, {2})"
-            return FormattedConstant(lhs.type, fmt.format(opname, lhs, rhs))
+            fmt = "{0} ({1} {2}, {3} {4})".format(opname,
+                lhs.type, lhs.get_reference(),
+                rhs.type, rhs.get_reference()
+            )
+            return FormattedConstant(lhs.type, fmt)
 
         return wrapped
 
@@ -204,17 +207,20 @@ class _ConstOpMixin(object):
             op = _CMP_MAP[cmpop]
         except KeyError:
             raise ValueError("invalid comparison %r for %s" % (cmpop, ins))
-        if cmpop not in ('==', '!='):
+
+        if not (prefix == 'i' and cmpop in ('==', '!=')):
             op = sign + op
 
         if self.type != other.type:
             raise ValueError("Operands must be the same type, got (%s, %s)"
                                  % (self.type, other.type))
 
-
-        int1 = types.IntType(1)
-        fmt = "{0} {1} ({2}, {3})"
-        return FormattedConstant(int1, fmt.format(ins, op, self, other))
+        fmt = "{0} {1} ({2} {3}, {4} {5})".format(
+            ins, op,
+            self.type, self.get_reference(),
+            other.type, other.get_reference())
+        
+        return FormattedConstant(types.IntType(1), fmt)
     
     def icmp_signed(self, cmpop, other):
         """

--- a/llvmlite/tests/test_ir.py
+++ b/llvmlite/tests/test_ir.py
@@ -2232,8 +2232,8 @@ class TestConstant(TestBase):
     def test_add(self):
         one = ir.Constant(int32, 1)
         two = ir.Constant(int32, 2)
-        two = one.add(two)
-        self.assertEqual(str(two), 'add (i32 1, i32 2)')
+        three = one.add(two)
+        self.assertEqual(str(three), 'add (i32 1, i32 2)')
 
 
 class TestTransforms(TestBase):

--- a/llvmlite/tests/test_ir.py
+++ b/llvmlite/tests/test_ir.py
@@ -2241,7 +2241,7 @@ class TestConstant(TestBase):
         three = one.or_(two)
         self.assertEqual(str(three), 'or (i32 1, i32 2)')
 
-        
+
 class TestTransforms(TestBase):
     def test_call_transform(self):
         mod = ir.Module()

--- a/llvmlite/tests/test_ir.py
+++ b/llvmlite/tests/test_ir.py
@@ -2229,6 +2229,12 @@ class TestConstant(TestBase):
         c = ir.Constant(int32, 0).inttoptr(int64.as_pointer())
         self.assertEqual(str(c), 'inttoptr (i32 0 to i64*)')
 
+    def test_add(self):
+        one = ir.Constant(int32, 1)
+        two = ir.Constant(int32, 2)
+        two = one.add(two)
+        self.assertEqual(str(two), 'add (i32 1, i32 2)')
+
 
 class TestTransforms(TestBase):
     def test_call_transform(self):

--- a/llvmlite/tests/test_ir.py
+++ b/llvmlite/tests/test_ir.py
@@ -2235,7 +2235,13 @@ class TestConstant(TestBase):
         three = one.add(two)
         self.assertEqual(str(three), 'add (i32 1, i32 2)')
 
+    def test_or(self):
+        one = ir.Constant(int32, 1)
+        two = ir.Constant(int32, 2)
+        three = one.or_(two)
+        self.assertEqual(str(three), 'or (i32 1, i32 2)')
 
+        
 class TestTransforms(TestBase):
     def test_call_transform(self):
         mod = ir.Module()

--- a/llvmlite/tests/test_ir.py
+++ b/llvmlite/tests/test_ir.py
@@ -2244,7 +2244,7 @@ class TestConstant(TestBase):
     def test_int_binops(self):
         one = ir.Constant(int32, 1)
         two = ir.Constant(int32, 2)
-        
+
         oracle = {one.shl:  'shl',  one.lshr: 'lshr', one.ashr: 'ashr',
                   one.add:  'add',  one.sub:  'sub',  one.mul:  'mul',
                   one.udiv: 'udiv', one.sdiv: 'sdiv', one.urem: 'urem',
@@ -2254,17 +2254,17 @@ class TestConstant(TestBase):
             self.assertEqual(str(fn(two)), irop + ' (i32 1, i32 2)')
 
         # unsigned integer compare
-        oracle = {'==': 'eq', '!=': 'ne', '>' : 'ugt', '>=' : 'uge',
-                  '<' : 'ult', '<=' : 'ule'}
-        for cop, cond  in oracle.items():
+        oracle = {'==': 'eq', '!=': 'ne', '>':
+                  'ugt', '>=': 'uge', '<': 'ult', '<=': 'ule'}
+        for cop, cond in oracle.items():
             actual = str(one.icmp_unsigned(cop, two))
             expected = 'icmp ' + cond + ' (i32 1, i32 2)'
             self.assertEqual(actual, expected)
 
         # signed integer compare
-        oracle = {'==': 'eq', '!=': 'ne', '>' : 'sgt', '>=' : 'sge',
-                  '<' : 'slt', '<=' : 'sle'}
-        for cop, cond  in oracle.items():
+        oracle = {'==': 'eq', '!=': 'ne',
+                  '>': 'sgt', '>=': 'sge', '<': 'slt', '<=': 'sle'}
+        for cop, cond in oracle.items():
             actual = str(one.icmp_signed(cop, two))
             expected = 'icmp ' + cond + ' (i32 1, i32 2)'
             self.assertEqual(actual, expected)
@@ -2277,23 +2277,26 @@ class TestConstant(TestBase):
                   one.fdiv: 'fdiv', one.frem: 'frem'}
         for fn, irop in oracle.items():
             actual = str(fn(two))
-            expected = irop + ' (float 0x3ff0000000000000, float 0x4000000000000000)'
+            expected = irop + (' (float 0x3ff0000000000000,'
+                               ' float 0x4000000000000000)')
             self.assertEqual(actual, expected)
 
         # ordered float compare
-        oracle = {'==': 'oeq', '!=': 'one', '>' : 'ogt', '>=' : 'oge',
-                  '<' : 'olt', '<=' : 'ole'}
-        for cop, cond  in oracle.items():
+        oracle = {'==': 'oeq', '!=': 'one', '>': 'ogt', '>=': 'oge',
+                  '<': 'olt', '<=': 'ole'}
+        for cop, cond in oracle.items():
             actual = str(one.fcmp_ordered(cop, two))
-            expected = 'fcmp ' + cond + ' (float 0x3ff0000000000000, float 0x4000000000000000)'
+            expected = 'fcmp ' + cond + (' (float 0x3ff0000000000000,'
+                                         ' float 0x4000000000000000)')
             self.assertEqual(actual, expected)
 
         # unordered float compare
-        oracle = {'==': 'ueq', '!=': 'une', '>' : 'ugt', '>=' : 'uge',
-                  '<' : 'ult', '<=' : 'ule'}
-        for cop, cond  in oracle.items():
+        oracle = {'==': 'ueq', '!=': 'une', '>': 'ugt', '>=': 'uge',
+                  '<': 'ult', '<=': 'ule'}
+        for cop, cond in oracle.items():
             actual = str(one.fcmp_unordered(cop, two))
-            expected = 'fcmp ' + cond + ' (float 0x3ff0000000000000, float 0x4000000000000000)'
+            expected = 'fcmp ' + cond + (' (float 0x3ff0000000000000,'
+                                         ' float 0x4000000000000000)')
             self.assertEqual(actual, expected)
 
 

--- a/llvmlite/tests/test_ir.py
+++ b/llvmlite/tests/test_ir.py
@@ -2219,15 +2219,65 @@ class TestConstant(TestBase):
                           'addrspace(4)* @"myconstant", i32 0, i32 1)'))
         self.assertEqual(c.type, ir.PointerType(int1, addrspace=addrspace))
 
+    def test_trunc(self):
+        c = ir.Constant(int64, 1).trunc(int32)
+        self.assertEqual(str(c), 'trunc (i64 1 to i32)')
+
+    def test_zext(self):
+        c = ir.Constant(int32, 1).zext(int64)
+        self.assertEqual(str(c), 'zext (i32 1 to i64)')
+
+    def test_sext(self):
+        c = ir.Constant(int32, -1).sext(int64)
+        self.assertEqual(str(c), 'sext (i32 -1 to i64)')
+
+    def test_fptrunc(self):
+        c = ir.Constant(flt, 1).fptrunc(hlf)
+        self.assertEqual(str(c), 'fptrunc (float 0x3ff0000000000000 to half)')
+
+    def test_fpext(self):
+        c = ir.Constant(flt, 1).fpext(dbl)
+        self.assertEqual(str(c), 'fpext (float 0x3ff0000000000000 to double)')
+
     def test_bitcast(self):
         m = self.module()
         gv = ir.GlobalVariable(m, int32, "myconstant")
         c = gv.bitcast(int64.as_pointer())
         self.assertEqual(str(c), 'bitcast (i32* @"myconstant" to i64*)')
 
+    def test_fptoui(self):
+        c = ir.Constant(flt, 1).fptoui(int32)
+        self.assertEqual(str(c), 'fptoui (float 0x3ff0000000000000 to i32)')
+
+    def test_uitofp(self):
+        c = ir.Constant(int32, 1).uitofp(flt)
+        self.assertEqual(str(c), 'uitofp (i32 1 to float)')
+
+    def test_fptosi(self):
+        c = ir.Constant(flt, 1).fptosi(int32)
+        self.assertEqual(str(c), 'fptosi (float 0x3ff0000000000000 to i32)')
+
+    def test_sitofp(self):
+        c = ir.Constant(int32, 1).sitofp(flt)
+        self.assertEqual(str(c), 'sitofp (i32 1 to float)')
+
+    def test_ptrtoint(self):
+        ptr = ir.Constant(int64.as_pointer(), None)
+        one = ir.Constant(int32, 1)
+        c = ptr.ptrtoint(int32)
+
+        self.assertRaises(TypeError, one.ptrtoint, int64)
+        self.assertRaises(TypeError, ptr.ptrtoint, flt)
+        self.assertEqual(str(c), 'ptrtoint (i64* null to i32)')
+
     def test_inttoptr(self):
-        c = ir.Constant(int32, 0).inttoptr(int64.as_pointer())
-        self.assertEqual(str(c), 'inttoptr (i32 0 to i64*)')
+        one = ir.Constant(int32, 1)
+        pi = ir.Constant(flt, 3.14)
+        c = one.inttoptr(int64.as_pointer())
+
+        self.assertRaises(TypeError, one.inttoptr, int64)
+        self.assertRaises(TypeError, pi.inttoptr, int64.as_pointer())
+        self.assertEqual(str(c), 'inttoptr (i32 1 to i64*)')
 
     def test_neg(self):
         one = ir.Constant(int32, 1)


### PR DESCRIPTION
This continues PR #735, which I think was good to merge, save for the following required additions included in this PR:

- Merge master
- Resolve conflicts
- Document the new methods.

Documentation for the new methods follows the documentation of similar methods in the IR builder documentation (i.e. https://llvmlite.readthedocs.io/en/latest/user-guide/ir/ir-builder.html) - it is not new as such, but instead the wording was re-used for consistency.