### PR TITLE
llvm::Module::GetSourceFileName

### DIFF
--- a/docs/source/user-guide/binding/modules.rst
+++ b/docs/source/user-guide/binding/modules.rst
@@ -126,6 +126,11 @@ The ModuleRef class
         The module's identifier, as a string. This attribute can
         be set.
 
+   * .. attribute:: source_file
+
+        The module's reported source file, as a string. This
+        attribute can not be set.
+	
    * .. attribute:: triple
 
         The platform "triple" string for this module. This

--- a/ffi/module.cpp
+++ b/ffi/module.cpp
@@ -124,6 +124,12 @@ LLVMPY_PrintModuleToString(LLVMModuleRef M,
 }
 
 API_EXPORT(const char *)
+LLVMPY_GetModuleSourceFileName(LLVMModuleRef M)
+{
+    return llvm::unwrap(M)->getSourceFileName().c_str();
+}
+
+API_EXPORT(const char *)
 LLVMPY_GetModuleName(LLVMModuleRef M)
 {
     return llvm::unwrap(M)->getModuleIdentifier().c_str();

--- a/llvmlite/binding/module.py
+++ b/llvmlite/binding/module.py
@@ -130,7 +130,7 @@ class ModuleRef(ffi.ObjectRef):
         """
         The module's original source file name
         """
-        return ffi.lib.LLVMPY_GetModuleSourceFileName(self)
+        return _decode_string(ffi.lib.LLVMPY_GetModuleSourceFileName(self))
 
     @property
     def data_layout(self):

--- a/llvmlite/binding/module.py
+++ b/llvmlite/binding/module.py
@@ -126,6 +126,13 @@ class ModuleRef(ffi.ObjectRef):
         ffi.lib.LLVMPY_SetModuleName(self, _encode_string(value))
 
     @property
+    def source_file(self):
+        """
+        The module's original source file name
+        """
+        return ffi.lib.LLVMPY_GetModuleSourceFileName(self)
+
+    @property
     def data_layout(self):
         """
         This module's data layout specification, as a string.
@@ -337,3 +344,6 @@ ffi.lib.LLVMPY_GetModuleName.argtypes = [ffi.LLVMModuleRef]
 ffi.lib.LLVMPY_GetModuleName.restype = c_char_p
 
 ffi.lib.LLVMPY_SetModuleName.argtypes = [ffi.LLVMModuleRef, c_char_p]
+
+ffi.lib.LLVMPY_GetModuleSourceFileName.argtypes = [ffi.LLVMModuleRef]
+ffi.lib.LLVMPY_GetModuleSourceFileName.restype = c_char_p

--- a/llvmlite/tests/test_binding.py
+++ b/llvmlite/tests/test_binding.py
@@ -565,7 +565,7 @@ class TestModuleRef(BaseTest):
 
     def test_source_file(self):
         mod = self.module()
-        self.assertEqual(mod.source_file, b"asm_sum.c")
+        self.assertEqual(mod.source_file, "asm_sum.c")
         
     def test_data_layout(self):
         mod = self.module()

--- a/llvmlite/tests/test_binding.py
+++ b/llvmlite/tests/test_binding.py
@@ -37,6 +37,7 @@ def no_de_locale():
 
 asm_sum = r"""
     ; ModuleID = '<string>'
+    source_filename = "asm_sum.c"
     target triple = "{triple}"
     %struct.glob_type = type {{ i64, [2 x i64]}}
 
@@ -562,6 +563,10 @@ class TestModuleRef(BaseTest):
         mod.name = "bar"
         self.assertEqual(mod.name, "bar")
 
+    def test_source_file(self):
+        mod = self.module()
+        self.assertEqual(mod.source_file, b"asm_sum.c")
+        
     def test_data_layout(self):
         mod = self.module()
         s = mod.data_layout

--- a/llvmlite/tests/test_binding.py
+++ b/llvmlite/tests/test_binding.py
@@ -566,7 +566,7 @@ class TestModuleRef(BaseTest):
     def test_source_file(self):
         mod = self.module()
         self.assertEqual(mod.source_file, "asm_sum.c")
-        
+
     def test_data_layout(self):
         mod = self.module()
         s = mod.data_layout


### PR DESCRIPTION
This PR just adds a binding in `binding.ModuleRef` for llvm::Module::getSourceFileName