### PR TITLE
Add m1 support to conda build scripts

### DIFF
--- a/conda-recipes/llvmdev/build.sh
+++ b/conda-recipes/llvmdev/build.sh
@@ -9,7 +9,11 @@ set -x
 LLVM_TARGETS_TO_BUILD=${LLVM_TARGETS_TO_BUILD:-"host;AArch64;AMDGPU;ARM;BPF;Hexagon;Mips;MSP430;NVPTX;PowerPC;Sparc;SystemZ;X86;XCore;RISCV"}
 
 # This is the clang compiler prefix
-DARWIN_TARGET=x86_64-apple-darwin13.4.0
+if [[ $build_platform == osx-arm64 ]]; then
+    DARWIN_TARGET=arm64-apple-darwin20.0.0
+else
+    DARWIN_TARGET=x86_64-apple-darwin13.4.0
+fi
 
 
 declare -a _cmake_config

--- a/conda-recipes/llvmdev/meta.yaml
+++ b/conda-recipes/llvmdev/meta.yaml
@@ -2,7 +2,7 @@
 {% set version = "11.1.0" %}
 {% set sha256_llvm = "ce8508e318a01a63d4e8b3090ab2ded3c598a50258cc49e2625b9120d4c03ea5" %}
 {% set sha256_lld = "017a788cbe1ecc4a949abf10755870519086d058a2e99f438829aef24f0c66ce" %}
-{% set build_number = "4" %}
+{% set build_number = "5" %}
 
 package:
   name: llvmdev
@@ -54,7 +54,7 @@ requirements:
   host:
     # needed for llc at runtime
     - zlib # [not win]
-    - xar # [osx]
+    - xar # [osx and x86_64]
     # llvm-lit testing needs *a* python
     - python # [not (armv6l or armv7l or aarch64 or win)]
 

--- a/conda-recipes/llvmlite/build.sh
+++ b/conda-recipes/llvmlite/build.sh
@@ -3,7 +3,12 @@
 set -x
 
 if [[ $(uname) == Darwin ]]; then
-  ${SYS_PREFIX}/bin/conda create -y -p ${SRC_DIR}/bootstrap clangxx_osx-64=10
+  if [[ $build_platform == osx-arm64 ]]; then
+      CLANG_PKG_SELECTOR=clangxx_osx-arm64=12
+  else
+      CLANG_PKG_SELECTOR=clangxx_osx-64=10
+  fi
+  ${SYS_PREFIX}/bin/conda create -y -p ${SRC_DIR}/bootstrap ${CLANG_PKG_SELECTOR}
   export PATH=${SRC_DIR}/bootstrap/bin:${PATH}
   CONDA_PREFIX=${SRC_DIR}/bootstrap \
     . ${SRC_DIR}/bootstrap/etc/conda/activate.d/*
@@ -19,11 +24,21 @@ if [[ $(uname) == Darwin ]]; then
 fi
 
 if [ -n "$MACOSX_DEPLOYMENT_TARGET" ]; then
-    # OSX needs 10.7 or above with libc++ enabled
-    export MACOSX_DEPLOYMENT_TARGET=10.10
+    if [[ $build_platform == osx-arm64 ]]; then
+	export MACOSX_DEPLOYMENT_TARGET=11.0
+    else
+	# OSX needs 10.7 or above with libc++ enabled
+	export MACOSX_DEPLOYMENT_TARGET=10.10
+    fi
 fi
 
-DARWIN_TARGET=x86_64-apple-darwin13.4.0
+
+# This is the clang compiler prefix
+if [[ $build_platform == osx-arm64 ]]; then
+    DARWIN_TARGET=arm64-apple-darwin20.0.0
+else
+    DARWIN_TARGET=x86_64-apple-darwin13.4.0
+fi
 
 
 export PYTHONNOUSERSITE=1


### PR DESCRIPTION
Minor adjustments needed to address differences in clang version and SDK version for osx-aarch64.