### PR TITLE
add GitHub URL for PyPi

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -219,6 +219,9 @@ setup(name='llvmlite',
       ],
       # Include the separately-compiled shared library
       url="http://llvmlite.readthedocs.io",
+      project_urls={
+          "Source": "https://github.com/numba/llvmlite",
+      },
       packages=packages,
       license="BSD",
       cmdclass=cmdclass,


### PR DESCRIPTION
Warehouse now uses the project_urls provided to display links in the sidebar on [this screen](https://pypi.org/project/requests/), as well as including them in API responses to help automation tool find the source code for Requests.