### PR TITLE
Deprecated `llvmlite.llvmpy`

### DIFF
--- a/docs/source/user-guide/deprecation.rst
+++ b/docs/source/user-guide/deprecation.rst
@@ -9,6 +9,57 @@ APIs that have become undesirable/obsolete. Any information about the schedule
 for their deprecation and reasoning behind the changes, along with examples, is
 provided.
 
+Deprecation of `llvmlite.llvmpy` module
+=======================================
+The `llvmlite.llvmpy` module was originally created for compatibility with
+`llvmpy`. As time has passed, that functionality was redesigned and put in
+`llvmlite.ir` with `llvmlite.llvmpy` remaining as a compatibility layer. No
+continued maintenance has ensured that it provides a matching API to `llvmpy`
+and it provides no advantage over the `llvmlite.ir` module.
+
+Reason for deprecation
+----------------------
+The functionality provided by `llvmlite.llvmpy` and its child modules is now
+present in `llvmlite.ir`, so this module will be dropped.
+
+Example(s) of the impact
+------------------------
+Code that imports `llvmlite.llvmpy`, `llvmlite.llvmpy.core` or
+`llvmlite.llvmpy.passes` will break.
+
+Schedule
+--------
+The feature change was implemented as follows:
+
+* v0.39 module is deprecated
+* v0.41 module is removed
+
+Recommendations
+---------------
+Since similar functionality already exists in `llvmlite.ir`, the transition
+path is relatively short:
+
+- replace `llvmlite.llvmpy.core.Builder` with `llvmlite.ir.IRBuilder`
+- replace `llvmlite.llvmpy.core.Builder.icmp` with
+  `llvmlite.ir.IRBuilder.icmp_signed` and `icmp_unsigned`, as appropriate
+- replace `llvmlite.llvmpy.core.Builder.fcmp` with
+  `llvmlite.ir.IRBuilder.fcmp_ordered` and `fcmp_unordered`, as appropriate
+- replace calls to the static methods of `llvmlite.llvmpy.core.Type` with the
+  constructors provided in `llvmlite.ir` (_e.g._, `Type.int(8)` with
+  `IntType(8)`)
+- Replace calls to the static methods of `llvmlite.llvmpy.core.Constant` with
+  calls to the constructor of `llvmlite.ir.Constant` or
+  `llvmlite.ir.Constanti.literal_struct`, as appropriate. Note that `stringz`
+  and `array` have no direct equivalents.
+- replace `llvmlite.llvmpy.core.Module`, `Function`, `MetaDataString`,
+  `InlineAsm` with the classes of the same name in `llvmlite.ir.`
+- replace `llvmlite.llvmpy.core.MetaData.get` with
+  `llvmlite.ir.Module.add_metadata`
+- replace `llvmlite.llvmpy.core.Function.intrinsic` with
+  `llvmlite.ir.Module.declare_intrinsic`
+- for `llvmlite.llvmpy.passes`, create the pass manager directly using
+  `llvmlite.binding`
+
 Deprecation of use of memset/memcpy llvm intrinsic with specified alignment
 ===========================================================================
 From LLVM 7 onward the `memset <https://releases.llvm.org/7.0.0/docs/LangRef.html#llvm-memset-intrinsics>`_

--- a/docs/source/user-guide/deprecation.rst
+++ b/docs/source/user-guide/deprecation.rst
@@ -49,7 +49,7 @@ path is relatively short:
   `IntType(8)`)
 - Replace calls to the static methods of `llvmlite.llvmpy.core.Constant` with
   calls to the constructor of `llvmlite.ir.Constant` or
-  `llvmlite.ir.Constanti.literal_struct`, as appropriate. Note that `stringz`
+  `llvmlite.ir.Constant.literal_struct`, as appropriate. Note that `stringz`
   and `array` have no direct equivalents.
 - replace `llvmlite.llvmpy.core.Module`, `Function`, `MetaDataString`,
   `InlineAsm` with the classes of the same name in `llvmlite.ir.`

--- a/docs/source/user-guide/deprecation.rst
+++ b/docs/source/user-guide/deprecation.rst
@@ -32,7 +32,7 @@ Schedule
 The feature change was implemented as follows:
 
 * v0.39 module is deprecated
-* v0.41 module is removed
+* v0.40 module is removed
 
 Recommendations
 ---------------

--- a/llvmlite/llvmpy/__init__.py
+++ b/llvmlite/llvmpy/__init__.py
@@ -1,0 +1,5 @@
+import warnings
+
+warnings.warn(
+    "The module `llvmlite.llvmpy` is deprecated and will be removed in the "
+    "future.")

--- a/llvmlite/llvmpy/core.py
+++ b/llvmlite/llvmpy/core.py
@@ -3,6 +3,12 @@ import itertools
 from llvmlite import ir
 from llvmlite import binding as llvm
 
+import warnings
+
+warnings.warn(
+    "The module `llvmlite.llvmpy.passes` is deprecated and will be removed in "
+    "the future. Equivalent functionality is provided by `llvmlite.ir`.")
+
 CallOrInvokeInstruction = ir.CallInstr
 
 

--- a/llvmlite/llvmpy/core.py
+++ b/llvmlite/llvmpy/core.py
@@ -6,7 +6,7 @@ from llvmlite import binding as llvm
 import warnings
 
 warnings.warn(
-    "The module `llvmlite.llvmpy.passes` is deprecated and will be removed in "
+    "The module `llvmlite.llvmpy.core` is deprecated and will be removed in "
     "the future. Equivalent functionality is provided by `llvmlite.ir`.")
 
 CallOrInvokeInstruction = ir.CallInstr

--- a/llvmlite/llvmpy/passes.py
+++ b/llvmlite/llvmpy/passes.py
@@ -12,6 +12,12 @@ llvm.set_option("test", "-help-hidden")
 
 from llvmlite import binding as llvm
 from collections import namedtuple
+import warnings
+
+warnings.warn(
+    "The module `llvmlite.llvmpy.passes` is deprecated and will be removed in "
+    "the future. If you are using this code, it should be inlined into your "
+    "own project.")
 
 
 def _inlining_threshold(optlevel, sizelevel=0):


### PR DESCRIPTION
Add deprecation warnings to `llvmlite.llvmpy` and all of its submodules.