### PR TITLE
Support loading llvmlite from the main executable.

### DIFF
--- a/llvmlite/binding/__init__.py
+++ b/llvmlite/binding/__init__.py
@@ -14,3 +14,9 @@ from .value import *
 from .analysis import *
 from .object_file import *
 from .context import *
+
+
+def __getattr__(name):
+    if name == 'llvm_version_info':
+        return initfini._version_info()
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/llvmlite/binding/ffi.py
+++ b/llvmlite/binding/ffi.py
@@ -159,7 +159,7 @@ for lib_context in (
         contextlib.nullcontext(None)):
     try:
         with lib_context as lib_path:
-            lib = ctypes.CDLL(lib_path)
+            lib = ctypes.CDLL(lib_path and str(lib_path))
             # Check that we can look up expected symbols.
             version_info = lib.LLVMPY_GetVersionInfo()
             break

--- a/llvmlite/binding/ffi.py
+++ b/llvmlite/binding/ffi.py
@@ -166,7 +166,8 @@ for lib_context in (
     except (OSError, AttributeError) as e:
         _lib_load_errors.append(e)
 else:
-    raise OSError("Could not find/load shared object file") from _lib_load_errors[0]
+    raise OSError(
+        "Could not find/load shared object file") from _lib_load_errors[0]
 
 
 lib = _lib_wrapper(lib)

--- a/llvmlite/binding/ffi.py
+++ b/llvmlite/binding/ffi.py
@@ -92,6 +92,7 @@ class _suppress_cleanup_errors:
         except PermissionError:
             pass  # Resource dylibs can't be deleted on Windows.
 
+
 class _lib_wrapper(object):
     """Wrap libllvmlite with a lock such that only one thread may access it at
     a time.

--- a/llvmlite/binding/ffi.py
+++ b/llvmlite/binding/ffi.py
@@ -105,6 +105,10 @@ class _lib_wrapper(object):
                 contextlib.nullcontext(None)):
             try:
                 with lib_context as lib_path:
+                    if os.name() == 'nt' and not lib_path:
+                        # The Windows implementation of ctypes.CDLL does not
+                        # support None as an argument.
+                        continue
                     self._lib_handle = ctypes.CDLL(lib_path and str(lib_path))
                     # Check that we can look up expected symbols.
                     _ = self._lib_handle.LLVMPY_GetVersionInfo()

--- a/llvmlite/binding/ffi.py
+++ b/llvmlite/binding/ffi.py
@@ -91,12 +91,14 @@ class _lib_wrapper(object):
 
     def _load_lib(self):
         _lib_load_errors = []
-        # llvmlite native code may exist in one of two places, with the first taking
-        # priority:
-        # 1) In a shared library available as a resource of the llvmlite package.
-        #    This may involve unpacking the shared library from an archive.
-        # 2) Linked directly into the main binary. Symbols may be resolved from the
-        #    main binary by passing None as the argument to ctypes.CDLL.
+        # llvmlite native code may exist in one of two places, with the first
+        # taking priority:
+        # 1) In a shared library available as a resource of the llvmlite
+        #    package. This may involve unpacking the shared library from an
+        #    archive.
+        # 2) Linked directly into the main binary. Symbols may be resolved
+        #    from the main binary by passing None as the argument to
+        #    ctypes.CDLL.
         for lib_context in (
                 importlib.resources.path(
                     __name__.rpartition(".")[0], get_library_name()),
@@ -105,19 +107,20 @@ class _lib_wrapper(object):
                 with lib_context as lib_path:
                     self._lib_handle = ctypes.CDLL(lib_path and str(lib_path))
                     # Check that we can look up expected symbols.
-                    version_info = self._lib_handle.LLVMPY_GetVersionInfo()
+                    _ = self._lib_handle.LLVMPY_GetVersionInfo()
                     break
             except (OSError, AttributeError) as e:
                 # OSError may be raised if the file cannot be opened, or is not
                 # a shared library.
-                # AttributeError is raised if LLVMPY_GetVersionInfo does not exist.
+                # AttributeError is raised if LLVMPY_GetVersionInfo does not
+                # exist.
                 _lib_load_errors.append(e)
         else:
-            # None of the expected locations contains a loadable version of llvmlite.
-            # raise OSError with the first error seen during the load event as the
-            # cause of this exception.
-            raise OSError(
-                "Could not find/load shared object file") from _lib_load_errors[0]
+            # None of the expected locations contains a loadable version of
+            # llvmlite. Raise OSError with the first error seen during the load
+            # event as the cause of this exception.
+            raise OSError("Could not find/load shared object file") \
+                from _lib_load_errors[0]
 
     @property
     def _lib(self):

--- a/llvmlite/binding/ffi.py
+++ b/llvmlite/binding/ffi.py
@@ -1,7 +1,8 @@
 import contextlib
 import ctypes
-import threading
 import importlib.resources
+import os
+import threading
 
 from llvmlite.binding.common import _decode_string, _is_shutting_down
 from llvmlite.utils import get_library_name

--- a/llvmlite/binding/ffi.py
+++ b/llvmlite/binding/ffi.py
@@ -106,7 +106,7 @@ class _lib_wrapper(object):
                 contextlib.nullcontext(None)):
             try:
                 with lib_context as lib_path:
-                    if os.name() == 'nt' and not lib_path:
+                    if os.name == 'nt' and not lib_path:
                         # The Windows implementation of ctypes.CDLL does not
                         # support None as an argument.
                         continue

--- a/llvmlite/binding/initfini.py
+++ b/llvmlite/binding/initfini.py
@@ -68,6 +68,3 @@ def _version_info():
         v.append(x & 0xff)
         x >>= 8
     return tuple(reversed(v))
-
-
-llvm_version_info = _version_info()

--- a/llvmlite/tests/__init__.py
+++ b/llvmlite/tests/__init__.py
@@ -1,5 +1,6 @@
 import sys
 
+import multiprocessing
 import unittest
 from unittest import TestCase
 
@@ -53,5 +54,6 @@ def run_tests(suite=None, xmloutput=None, verbosity=1):
 
 
 def main():
+    multiprocessing.set_start_method('spawn')
     res = run_tests()
     sys.exit(0 if res.wasSuccessful() else 1)

--- a/llvmlite/tests/test_loading.py
+++ b/llvmlite/tests/test_loading.py
@@ -1,29 +1,31 @@
-import ctypes
-import functools
 import importlib
 import multiprocessing
 import unittest
 import unittest.mock
-import pickle
 
 from llvmlite import binding as llvm
 
 
 def _test_dylib_resource_loading(result):
     try:
-        assert llvm.ffi.lib._lib_handle is None  # We must not have loaded the llvmlite dylib yet.
+        # We must not have loaded the llvmlite dylib yet.
+        assert llvm.ffi.lib._lib_handle is None
         spec = importlib.util.find_spec(llvm.ffi.__name__.rpartition(".")[0])
 
-        true_dylib = spec.loader.get_resource_reader().open_resource(llvm.ffi.get_library_name())
+        true_dylib = spec.loader.get_resource_reader() \
+            .open_resource(llvm.ffi.get_library_name())
 
         # A mock resource loader that does not support resource paths
         class MockResourceReader(importlib.abc.ResourceReader):
             def is_resource(self, name):
                 return True
+
             def resource_path(self, name):
                 raise FileNotFoundError
+
             def open_resource(self, name):
                 return true_dylib
+
             def contents(self):
                 return []
 
@@ -31,10 +33,10 @@ def _test_dylib_resource_loading(result):
         # temporary file.
         with unittest.mock.patch.object(
                 spec.loader, 'get_resource_reader',
-                return_value = MockResourceReader()), \
+                return_value=MockResourceReader()), \
              unittest.mock.patch(
                  'llvmlite.binding.ffi.get_library_name',
-                 return_value = 'notllvmlite.so'):
+                 return_value='notllvmlite.so'):
             llvm.llvm_version_info  # force library loading to occur.
     except Exception as e:
         result.put(e)
@@ -46,8 +48,8 @@ class TestModuleLoading(unittest.TestCase):
     def test_dylib_resource_loading(self):
         subproc_result = multiprocessing.Queue()
         subproc = multiprocessing.Process(
-                target=_test_dylib_resource_loading,
-                args=(subproc_result,))
+            target=_test_dylib_resource_loading,
+            args=(subproc_result,))
         subproc.start()
         result = subproc_result.get()
         subproc.join()

--- a/llvmlite/tests/test_loading.py
+++ b/llvmlite/tests/test_loading.py
@@ -1,0 +1,59 @@
+import ctypes
+import functools
+import importlib
+import multiprocessing
+import unittest
+import unittest.mock
+import pickle
+
+from llvmlite import binding as llvm
+
+
+def _test_dylib_resource_loading(result):
+    try:
+        assert llvm.ffi.lib._lib_handle is None  # We must not have loaded the llvmlite dylib yet.
+        spec = importlib.util.find_spec(llvm.ffi.__name__.rpartition(".")[0])
+
+        true_dylib = spec.loader.get_resource_reader().open_resource(llvm.ffi.get_library_name())
+
+        # A mock resource loader that does not support resource paths
+        class MockResourceReader(importlib.abc.ResourceReader):
+            def is_resource(self, name):
+                return True
+            def resource_path(self, name):
+                raise FileNotFoundError
+            def open_resource(self, name):
+                return true_dylib
+            def contents(self):
+                return []
+
+        # Mock resource loader to force the dylib to be extracted into a
+        # temporary file.
+        with unittest.mock.patch.object(
+                spec.loader, 'get_resource_reader',
+                return_value = MockResourceReader()), \
+             unittest.mock.patch(
+                 'llvmlite.binding.ffi.get_library_name',
+                 return_value = 'notllvmlite.so'):
+            llvm.llvm_version_info  # force library loading to occur.
+    except Exception as e:
+        result.put(e)
+        raise
+    result.put(None)
+
+
+class TestModuleLoading(unittest.TestCase):
+    def test_dylib_resource_loading(self):
+        subproc_result = multiprocessing.Queue()
+        subproc = multiprocessing.Process(
+                target=_test_dylib_resource_loading,
+                args=(subproc_result,))
+        subproc.start()
+        result = subproc_result.get()
+        subproc.join()
+        if subproc.exitcode:
+            raise result
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Change library loading code to also check for the presence of llvmlite
statically linked into the main executable if the dynamic library fails
to load. This allows llvmlite to be used in hermetic and embedded
build cases.

Check that the version function can be dynamically resolved before
declaring success.

Exit the resource context manager correctly so that any extracted
files are unlinked correctly.

On failure, raise OSError with the first error chained.