### PR TITLE
Add pre-commit hooks for clang-format

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,5 @@
+repos:
+- repo: https://github.com/pre-commit/mirrors-clang-format
+  rev: v13.0.1
+  hooks:
+  - id: clang-format

--- a/docs/source/contributing.rst
+++ b/docs/source/contributing.rst
@@ -78,6 +78,19 @@ Coding conventions
   for maximum readability with all existing tools, such as code
   review user interfaces.
 
+Optionally, you may wish to setup `pre-commit hooks <https://pre-commit.com/>`_
+to automatically run ``clang-format`` when you make a git commit. This can be
+done by installing ``pre-commit``::
+
+    pip install pre-commit
+
+and then running::
+
+    pre-commit install
+
+from the root of the Numba repository. Now ``clang-format`` will be run each time
+you commit changes. You can skip this check with ``git commit --no-verify``.
+
 
 Platform support
 ----------------


### PR DESCRIPTION
Include a clang-format pre-commit hook to ensure the code is formatted
automatically.