### PR TITLE
Move Azure to use macos-11.

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -3,7 +3,7 @@ jobs:
 - template: buildscripts/azure/azure-linux-macos.yml
   parameters:
     name: macOS
-    vmImage: macOS-10.15
+    vmImage: macos-11
     matrix:
       py37:
         PYTHON: '3.7'


### PR DESCRIPTION
As title. vmImage macOS-10.15 is deprecated.