### PR TITLE
Make symbol resolution lazy

### DIFF
--- a/llvmlite/binding/__init__.py
+++ b/llvmlite/binding/__init__.py
@@ -14,3 +14,9 @@ from .value import *
 from .analysis import *
 from .object_file import *
 from .context import *
+
+
+def __getattr__(name):
+    if name == 'llvm_version_info':
+        return initfini._version_info()
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/llvmlite/binding/ffi.py
+++ b/llvmlite/binding/ffi.py
@@ -77,19 +77,53 @@ class _LLVMLock:
         self._lock.release()
 
 
+class _suppress_cleanup_errors:
+    def __init__(self, context):
+        self._context = context
+
+    def __enter__(self):
+        return self._context.__enter__()
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        try:
+            return self._context.__exit__(exc_type, exc_value, traceback)
+        except PermissionError:
+            pass  # Resource dylibs can't be deleted on Windows.
+
+
 class _lib_wrapper(object):
     """Wrap libllvmlite with a lock such that only one thread may access it at
     a time.
 
     This class duck-types a CDLL.
     """
-    __slots__ = ['_lib', '_fntab', '_lock']
+    __slots__ = ['_lib_handle', '_fntab', '_lock']
 
-    def __init__(self, lib):
-        self._lib = lib
+    def __init__(self):
+        self._lib_handle = None
         self._fntab = {}
         self._lock = _LLVMLock()
 
+    def _load_lib(self):
+        try:
+            with _suppress_cleanup_errors(importlib.resources.path(
+                __name__.rpartition(".")[0], get_library_name())) as lib_path:
+                self._lib_handle = ctypes.CDLL(str(lib_path))
+                # Check that we can look up expected symbols.
+                _ = self._lib_handle.LLVMPY_GetVersionInfo()
+        except (OSError, AttributeError) as e:
+            # OSError may be raised if the file cannot be opened, or is not
+            # a shared library.
+            # AttributeError is raised if LLVMPY_GetVersionInfo does not
+            # exist.
+            raise OSError("Could not find/load shared object file") from e
+
+    @property
+    def _lib(self):
+        # Not threadsafe.
+        if not self._lib_handle:
+            self._load_lib()
+        return self._lib_handle
     def __getattr__(self, name):
         try:
             return self._fntab[name]
@@ -151,23 +185,7 @@ class _lib_fn_wrapper(object):
             return self._cfn(*args, **kwargs)
 
 
-_lib_name = get_library_name()
-
-
-pkgname = ".".join(__name__.split(".")[0:-1])
-try:
-    _lib_handle = importlib.resources.path(pkgname, _lib_name)
-    lib = ctypes.CDLL(str(_lib_handle.__enter__()))
-    # on windows file handles to the dll file remain open after
-    # loading, therefore we can not exit the context manager
-    # which might delete the file
-except OSError as e:
-    msg = f"""Could not find/load shared object file: {_lib_name}
- Error was: {e}"""
-    raise OSError(msg)
-
-
-lib = _lib_wrapper(lib)
+lib = _lib_wrapper()
 
 
 def register_lock_callback(acq_fn, rel_fn):

--- a/llvmlite/binding/initfini.py
+++ b/llvmlite/binding/initfini.py
@@ -68,6 +68,3 @@ def _version_info():
         v.append(x & 0xff)
         x >>= 8
     return tuple(reversed(v))
-
-
-llvm_version_info = _version_info()

--- a/llvmlite/tests/__init__.py
+++ b/llvmlite/tests/__init__.py
@@ -1,5 +1,6 @@
 import sys
 
+import multiprocessing
 import unittest
 from unittest import TestCase
 
@@ -53,5 +54,6 @@ def run_tests(suite=None, xmloutput=None, verbosity=1):
 
 
 def main():
+    multiprocessing.set_start_method('spawn')
     res = run_tests()
     sys.exit(0 if res.wasSuccessful() else 1)

--- a/llvmlite/tests/test_loading.py
+++ b/llvmlite/tests/test_loading.py
@@ -1,0 +1,65 @@
+import importlib
+import multiprocessing
+import unittest
+import unittest.mock
+
+from llvmlite import binding as llvm
+
+
+def _test_dylib_resource_loading(result):
+    try:
+        # We must not have loaded the llvmlite dylib yet.
+        assert llvm.ffi.lib._lib_handle is None
+        spec = importlib.util.find_spec(llvm.ffi.__name__.rpartition(".")[0])
+
+        true_dylib = spec.loader.get_resource_reader() \
+            .open_resource(llvm.ffi.get_library_name())
+
+        # A mock resource reader that does not support resource paths
+        class MockResourceReader(importlib.abc.ResourceReader):
+            def is_resource(self, name):
+                return True
+
+            def resource_path(self, name):
+                # Resource does not have a path, so it must be extracted to the
+                # filesystem.
+                raise FileNotFoundError
+
+            def open_resource(self, name):
+                # File-like object, from which the content of the resource
+                # is extracted.
+                return true_dylib
+
+            def contents(self):
+                return []
+
+        # Mock resource loader to force the dylib to be extracted into a
+        # temporary file.
+        with unittest.mock.patch.object(
+                spec.loader, 'get_resource_reader',
+                return_value=MockResourceReader()), \
+             unittest.mock.patch(
+                 'llvmlite.binding.ffi.get_library_name',
+                 return_value='notllvmlite.so'):
+            llvm.llvm_version_info  # force library loading to occur.
+    except Exception as e:
+        result.put(e)
+        raise
+    result.put(None)
+
+
+class TestModuleLoading(unittest.TestCase):
+    def test_dylib_resource_loading(self):
+        subproc_result = multiprocessing.Queue()
+        subproc = multiprocessing.Process(
+            target=_test_dylib_resource_loading,
+            args=(subproc_result,))
+        subproc.start()
+        result = subproc_result.get()
+        subproc.join()
+        if subproc.exitcode:
+            raise result
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This delays the lookup of a symbol until it is first called, which
in turn allows us to write a test for extraction of native code from
a package.