### PR TITLE
Adding zlib as dependency for aarch64

### DIFF
--- a/conda-recipes/llvmlite/meta.yaml
+++ b/conda-recipes/llvmlite/meta.yaml
@@ -35,7 +35,7 @@ requirements:
     - llvmdev 11.1.0 4 # [win]
     - vs2015_runtime # [win]
     # llvmdev is built with libz compression support
-    - zlib           # [unix and not (armv6l or armv7l or aarch64)]
+    - zlib           # [unix and not (armv6l or armv7l)]
   run:
     - python >=3.7,<3.10
     - vs2015_runtime # [win]


### PR DESCRIPTION
As part of the Anaconda build farm we also build and test llvmlite on
aarch64 using miniforge and conda-forge packages. The build has been
fine, until today, where we started seeing the following error messages:

```
/opt/conda/conda-bld/llvmlite_1661342292898/_build_env/bin/../lib/gcc/aarch64-conda-linux-gnu/9.5.0/../../../../aarch64-conda-linux-gnu/bin/ld: cannot find -lz
```

Upon inspection, it turns out that the zlib package had been excluded on
aarch64. The assumption is, that the package was installed as a
transient dependency and that this is no longer the case.

The resolution is to require it explicity during build.