### PR TITLE
Adds support for calling functions with 'tail', 'notail', or 'musttail' markers.

### DIFF
--- a/docs/source/user-guide/ir/ir-builder.rst
+++ b/docs/source/user-guide/ir/ir-builder.rst
@@ -516,7 +516,7 @@ Memory
 Function call
 ---------------
 
-.. method:: IRBuilder.call(fn, args, name='', cconv=None, tail=False, \
+.. method:: IRBuilder.call(fn, args, name='', cconv=None, tail=None, \
    fastmath=(), attrs=(), arg_attrs=None)
 
    Call function *fn* with arguments *args*, a sequence of values.

--- a/docs/source/user-guide/ir/ir-builder.rst
+++ b/docs/source/user-guide/ir/ir-builder.rst
@@ -522,8 +522,8 @@ Function call
    Call function *fn* with arguments *args*, a sequence of values.
 
    * *cconv* is the optional calling convention.
-   * *tail*, if ``"tail"``, is a hint for the optimizer to perform
-     tail-call optimization. Use ``"musttail"`` to indicate the specified the call must be tail call optimized in order for the program to be correct. Use ``"notail"`` to indicate that the call should never be tail call optimized. Alternatively, may provide ``False`` to indicate no specific tail call optimization behavior, or ``True`` to request `"tail"`` hint behavior (this is backwards compatible with the previous API).
+   * *tail*, if ``"tail"`` it's a hint for the optimizer to perform
+     tail-call optimization. Use ``"musttail"`` to indicate the specified call must be tail-call optimized in order for the program to be correct. Use ``"notail"`` to indicate that the call should never be tail-call optimized. Alternatively, may provide ``False`` to indicate no specific tail-call optimization behavior, or ``True`` to request `"tail"`` hint behavior (use of a boolean is for backwards compatibility with the previous API).
    * *fastmath* is a string or a sequence of strings of names for
      `fast-math flags
      <http://llvm.org/docs/LangRef.html#fast-math-flags>`_.

--- a/docs/source/user-guide/ir/ir-builder.rst
+++ b/docs/source/user-guide/ir/ir-builder.rst
@@ -522,8 +522,8 @@ Function call
    Call function *fn* with arguments *args*, a sequence of values.
 
    * *cconv* is the optional calling convention.
-   * *tail*, if ``True``, is a hint for the optimizer to perform
-     tail-call optimization.
+   * *tail*, if ``"tail"``, is a hint for the optimizer to perform
+     tail-call optimization. Use ``"musttail"`` to indicate the specified the call must be tail call optimized in order for the program to be correct. Use ``"notail"`` to indicate that the call should never be tail call optimized. Alternatively, may provide ``False`` to indicate no specific tail call optimization behavior, or ``True`` to request `"tail"`` hint behavior (this is backwards compatible with the previous API).
    * *fastmath* is a string or a sequence of strings of names for
      `fast-math flags
      <http://llvm.org/docs/LangRef.html#fast-math-flags>`_.

--- a/docs/source/user-guide/ir/ir-builder.rst
+++ b/docs/source/user-guide/ir/ir-builder.rst
@@ -522,8 +522,22 @@ Function call
    Call function *fn* with arguments *args*, a sequence of values.
 
    * *cconv* is the optional calling convention.
-   * *tail*, if ``"tail"`` it's a hint for the optimizer to perform
-     tail-call optimization. Use ``"musttail"`` to indicate the specified call must be tail-call optimized in order for the program to be correct. Use ``"notail"`` to indicate that the call should never be tail-call optimized. Alternatively, may provide ``False`` to indicate no specific tail-call optimization behavior, or ``True`` to request ``"tail"`` hint behavior (support for a boolean value is for backwards compatibility with the previous API).
+   * *tail* controls tail-call optimization behavior. It may be one of:
+
+     * ``None`` (the default): indicates no specific tail-call optimization
+       behavior.
+     * ``"tail"``: a hint that indicates that the call should be tail-call
+       optimized, but may be ignored.
+     * ``"musttail"``: indicates that the call must be tail-call optimized for
+       program correctness.
+     * ``"notail"``: indicate thats the call should never be tail-call
+       optimized.
+
+     For backwards compatibility with previous versions, the following values
+     are also accepted:
+
+     * ``False`` is equivalent to ``None``, indicating no specific behavior.
+     * ``True`` is equivalent to ``"tail"``, suggesting tail-call optimization.
    * *fastmath* is a string or a sequence of strings of names for
      `fast-math flags
      <http://llvm.org/docs/LangRef.html#fast-math-flags>`_.

--- a/docs/source/user-guide/ir/ir-builder.rst
+++ b/docs/source/user-guide/ir/ir-builder.rst
@@ -523,7 +523,7 @@ Function call
 
    * *cconv* is the optional calling convention.
    * *tail*, if ``"tail"`` it's a hint for the optimizer to perform
-     tail-call optimization. Use ``"musttail"`` to indicate the specified call must be tail-call optimized in order for the program to be correct. Use ``"notail"`` to indicate that the call should never be tail-call optimized. Alternatively, may provide ``False`` to indicate no specific tail-call optimization behavior, or ``True`` to request `"tail"`` hint behavior (use of a boolean is for backwards compatibility with the previous API).
+     tail-call optimization. Use ``"musttail"`` to indicate the specified call must be tail-call optimized in order for the program to be correct. Use ``"notail"`` to indicate that the call should never be tail-call optimized. Alternatively, may provide ``False`` to indicate no specific tail-call optimization behavior, or ``True`` to request ``"tail"`` hint behavior (support for a boolean value is for backwards compatibility with the previous API).
    * *fastmath* is a string or a sequence of strings of names for
      `fast-math flags
      <http://llvm.org/docs/LangRef.html#fast-math-flags>`_.

--- a/llvmlite/ir/instructions.py
+++ b/llvmlite/ir/instructions.py
@@ -72,7 +72,7 @@ class CallInstr(Instruction):
                       else cconv)
 
         # For backwards compatibility with previous API of accepting a "truthy"
-        # vaule for a hint to the optimizer to potentially tail optimize.
+        # value for a hint to the optimizer to potentially tail optimize.
         if isinstance(tail, str) and tail in TailMarkerOptions:
             pass
         elif tail:

--- a/llvmlite/ir/instructions.py
+++ b/llvmlite/ir/instructions.py
@@ -65,7 +65,7 @@ class FastMathFlags(AttributeSet):
 
 
 class CallInstr(Instruction):
-    def __init__(self, parent, func, args, name='', cconv=None, tail=False,
+    def __init__(self, parent, func, args, name='', cconv=None, tail=None,
                  fastmath=(), attrs=(), arg_attrs=None):
         self.cconv = (func.calling_convention
                       if cconv is None and isinstance(func, Function)


### PR DESCRIPTION
More background available in LLVM IR manual: https://llvm.org/docs/LangRef.html#call-instruction

API addition is backwards compatible with previous usage, so this doesn't break anyone.