### PR TITLE
add python 3.11 support

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ except ImportError:
 
 
 min_python_version = "3.7"
-max_python_version = "3.11"  # exclusive
+max_python_version = "3.12"  # exclusive
 
 
 def _guard_py_ver():


### PR DESCRIPTION
This likely needs testing, but python 3.11 just released and it doesn't appear to change much. llvmlite for 3.10 should likely be compatible for 3.11