### PR TITLE
Simplify setup.py Python version guard

### DIFF
--- a/llvmlite/tests/test_setup.py
+++ b/llvmlite/tests/test_setup.py
@@ -1,0 +1,71 @@
+"""
+Tests for setup.py behavior
+"""
+
+import distutils.core
+try:
+    import setuptools
+except ImportError:
+    setuptools = None
+import sys
+import unittest
+from collections import namedtuple
+from importlib.util import spec_from_file_location, module_from_spec
+from pathlib import Path
+
+from . import TestCase
+
+setup_path = Path(__file__).parent.parent.parent / "setup.py"
+
+
+class TestSetup(TestCase):
+
+    @unittest.skipUnless(setup_path.is_file(), 'Need setup.py from source tree')
+    def test_guard_py_ver(self):
+        """
+        Ensure setup.py's _guard_py_ver aborts setup for an unsupported version
+        """
+        # NOTE: Adjust this when max_python_version in setup.py changes.
+        unsupported_version = (3, 11, 0)
+        unsupported_version_info = namedtuple(
+            "version_info",
+            (
+                "major", "minor", "micro", "releaselevel",
+                "serial", "n_fields", "n_sequence_fields", "n_unnamed_fields"
+            )
+        )(*unsupported_version, 'final', 0, 5, 5, 0)
+
+        sys_version_info = sys.version_info
+
+        # We run setup.py code! Since _guard_py_ver should fail, setup() should
+        # never be invoked. But let's be extra sure it isn't and replace it.
+        def failing_setup(*args, **kwargs):
+            raise RuntimeError("This should not be reached!")
+
+        distutils_core_setup = distutils.core.setup
+        if setuptools:
+            setuptools_setup = setuptools.setup
+
+        spec = spec_from_file_location("__main__", str(setup_path))
+        setup_module = module_from_spec(spec)
+        try:
+            sys.version_info = unsupported_version_info
+            distutils.core.setup = failing_setup
+            if setuptools:
+                setuptools.setup = failing_setup
+
+            msg = ("Cannot install on Python version {}; only versions "
+                   ">=[0-9]+\\.[0-9]+,<[0-9]+\\.[0-9]+ are supported"
+                   ).format(".".join(map(str, unsupported_version_info[:3])))
+            with self.assertRaisesRegex(RuntimeError, msg):
+                spec.loader.exec_module(setup_module)
+        finally:
+            # Restore anything we replaced.
+            sys.version_info = sys_version_info
+            distutils.core.setup = distutils_core_setup
+            if setuptools:
+                setuptools.setup = setuptools_setup
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/setup.py
+++ b/setup.py
@@ -22,31 +22,21 @@ import os
 import sys
 
 
-_version_module = None
-try:
-    from packaging import version as _version_module
-except ImportError:
-    try:
-        from setuptools._vendor.packaging import version as _version_module
-    except ImportError:
-        pass
+min_python_version = (3, 7)
+max_python_version = (3, 11)  # exclusive
 
 
-min_python_version = "3.7"
-max_python_version = "3.11"  # exclusive
+def _version_info_str(int_tuple):
+    return ".".join(map(str, int_tuple))
 
 
 def _guard_py_ver():
-    if _version_module is None:
-        return
+    currrent_python_version = sys.version_info[:3]
+    min_py = _version_info_str(min_python_version)
+    max_py = _version_info_str(max_python_version)
+    cur_py = _version_info_str(currrent_python_version)
 
-    parse = _version_module.parse
-
-    min_py = parse(min_python_version)
-    max_py = parse(max_python_version)
-    cur_py = parse('.'.join(map(str, sys.version_info[:3])))
-
-    if not min_py <= cur_py < max_py:
+    if not min_python_version <= currrent_python_version < max_python_version:
         msg = ('Cannot install on Python version {}; only versions >={},<{} '
                'are supported.')
         raise RuntimeError(msg.format(cur_py, min_py, max_py))
@@ -226,5 +216,5 @@ setup(name='llvmlite',
       license="BSD",
       cmdclass=cmdclass,
       long_description=long_description,
-      python_requires=">={}".format(min_python_version),
+      python_requires=">={}".format(_version_info_str(min_python_version)),
       )


### PR DESCRIPTION
Over at the conda-forge feedstock we [noticed](https://github.com/conda-forge/llvmlite-feedstock/pull/66#issuecomment-1292357510) that the build ignored the version guard since we didn't have `setuptools`/`packaging` installed.
Since we're only comparing "simple" versions and `sys.version_info` is a tuple already, we can simplify the logic by omitting version string parsing overall and just compare the tuples.

cc @jakirkham 