### PR TITLE
Speeds up module.add_debug_info and add_metadata by 2x

### DIFF
--- a/llvmlite/ir/_utils.py
+++ b/llvmlite/ir/_utils.py
@@ -1,4 +1,3 @@
-from collections import defaultdict
 
 
 class DuplicatedNameError(NameError):
@@ -8,7 +7,7 @@ class DuplicatedNameError(NameError):
 class NameScope(object):
     def __init__(self):
         self._useset = set([''])
-        self._basenamemap = defaultdict(int)
+        self._basenamemap = {}
 
     def is_used(self, name):
         return name in self._useset
@@ -23,10 +22,18 @@ class NameScope(object):
 
     def deduplicate(self, name):
         basename = name
+
+        try:
+            ident = self._basenamemap[basename]
+        except KeyError:
+            ident = 0
+
         while self.is_used(name):
-            ident = self._basenamemap[basename] + 1
-            self._basenamemap[basename] = ident
+            ident += 1
             name = "{0}.{1}".format(basename, ident)
+
+        self._basenamemap[basename] = ident
+
         return name
 
     def get_child(self):

--- a/llvmlite/ir/module.py
+++ b/llvmlite/ir/module.py
@@ -53,14 +53,14 @@ class Module(object):
             raise TypeError("expected a list or tuple of metadata values, "
                             "got %r" % (operands,))
 
-        key = hash(tuple(operands))
+        fixed_operands = self._fix_metadata_operands(operands)
+        key = hash(tuple(fixed_operands))
         try:
             return self._metadatacache[key]
         except KeyError:
             pass
 
         n = len(self.metadata)
-        fixed_operands = self._fix_metadata_operands(operands)
         md = values.MDValue(self, fixed_operands, name=str(n))
         self._metadatacache[key] = md
         return md

--- a/llvmlite/ir/module.py
+++ b/llvmlite/ir/module.py
@@ -75,8 +75,8 @@ class Module(object):
         A DIValue instance is returned, it can then be associated to e.g.
         an instruction.
         """
-        sorted_operands = sorted(operands.items())
-        key = hash((kind, tuple(sorted_operands), is_distinct))
+        fixed_operands = self._fix_di_operands(sorted(operands.items()))
+        key = hash((kind, tuple(fixed_operands), is_distinct))
 
         try:
             return self._metadatacache[key]
@@ -84,7 +84,6 @@ class Module(object):
             pass
 
         n = len(self.metadata)
-        fixed_operands = self._fix_di_operands(sorted_operands)
         di = values.DIValue(
             self, is_distinct, kind, fixed_operands, name=str(n))
         self._metadatacache[key] = di

--- a/llvmlite/ir/module.py
+++ b/llvmlite/ir/module.py
@@ -52,11 +52,11 @@ class Module(object):
         if not isinstance(operands, (list, tuple)):
             raise TypeError("expected a list or tuple of metadata values, "
                             "got %r" % (operands,))
-        operands = self._fix_metadata_operands(operands)
-        key = tuple(operands)
+        key = hash(tuple(operands))
         if key not in self._metadatacache:
             n = len(self.metadata)
-            md = values.MDValue(self, operands, name=str(n))
+            fixed_operands = self._fix_metadata_operands(operands)
+            md = values.MDValue(self, fixed_operands, name=str(n))
             self._metadatacache[key] = md
         else:
             md = self._metadatacache[key]
@@ -72,11 +72,13 @@ class Module(object):
         A DIValue instance is returned, it can then be associated to e.g.
         an instruction.
         """
-        operands = tuple(sorted(self._fix_di_operands(operands.items())))
-        key = (kind, operands, is_distinct)
+        sorted_operands = sorted(operands.items())
+        key = hash((kind, tuple(sorted_operands), is_distinct))
         if key not in self._metadatacache:
             n = len(self.metadata)
-            di = values.DIValue(self, is_distinct, kind, operands, name=str(n))
+            fixed_operands = self._fix_di_operands(sorted_operands)
+            di = values.DIValue(
+                self, is_distinct, kind, fixed_operands, name=str(n))
             self._metadatacache[key] = di
         else:
             di = self._metadatacache[key]

--- a/llvmlite/ir/module.py
+++ b/llvmlite/ir/module.py
@@ -53,13 +53,15 @@ class Module(object):
             raise TypeError("expected a list or tuple of metadata values, "
                             "got %r" % (operands,))
         key = hash(tuple(operands))
-        if key not in self._metadatacache:
-            n = len(self.metadata)
-            fixed_operands = self._fix_metadata_operands(operands)
-            md = values.MDValue(self, fixed_operands, name=str(n))
-            self._metadatacache[key] = md
-        else:
-            md = self._metadatacache[key]
+        try:
+            return self._metadatacache[key]
+        except KeyError:
+            pass
+
+        n = len(self.metadata)
+        fixed_operands = self._fix_metadata_operands(operands)
+        md = values.MDValue(self, fixed_operands, name=str(n))
+        self._metadatacache[key] = md
         return md
 
     def add_debug_info(self, kind, operands, is_distinct=False):
@@ -74,14 +76,17 @@ class Module(object):
         """
         sorted_operands = sorted(operands.items())
         key = hash((kind, tuple(sorted_operands), is_distinct))
-        if key not in self._metadatacache:
-            n = len(self.metadata)
-            fixed_operands = self._fix_di_operands(sorted_operands)
-            di = values.DIValue(
-                self, is_distinct, kind, fixed_operands, name=str(n))
-            self._metadatacache[key] = di
-        else:
-            di = self._metadatacache[key]
+
+        try:
+            return self._metadatacache[key]
+        except KeyError:
+            pass
+
+        n = len(self.metadata)
+        fixed_operands = self._fix_di_operands(sorted_operands)
+        di = values.DIValue(
+            self, is_distinct, kind, fixed_operands, name=str(n))
+        self._metadatacache[key] = di
         return di
 
     def add_named_metadata(self, name, element=None):

--- a/llvmlite/ir/module.py
+++ b/llvmlite/ir/module.py
@@ -52,6 +52,7 @@ class Module(object):
         if not isinstance(operands, (list, tuple)):
             raise TypeError("expected a list or tuple of metadata values, "
                             "got %r" % (operands,))
+
         key = hash(tuple(operands))
         try:
             return self._metadatacache[key]

--- a/llvmlite/ir/values.py
+++ b/llvmlite/ir/values.py
@@ -667,6 +667,7 @@ class MDValue(NamedValue):
                                       types.MetaDataType(),
                                       name=name)
         self.operands = tuple(values)
+        self.hash_cache = None
         parent.metadata.append(self)
 
     def descr(self, buf):
@@ -694,8 +695,17 @@ class MDValue(NamedValue):
     def __ne__(self, other):
         return not self.__eq__(other)
 
+    def __getstate__(self):
+        # Ensure that the hash is not cached between Python invocations
+        # due to pickling or other serialization. The hash seed changes
+        # which will cause these not to match.
+        self.hash_cache = None
+        return self.__dict__
+
     def __hash__(self):
-        return hash(self.operands)
+        if self.hash_cache is None:
+            self.hash_cache = hash(self.operands)
+        return self.hash_cache
 
 
 class DIToken:
@@ -725,6 +735,7 @@ class DIValue(NamedValue):
         self.is_distinct = is_distinct
         self.kind = kind
         self.operands = tuple(operands)
+        self.hash_cache = None
         parent.metadata.append(self)
 
     def descr(self, buf):
@@ -767,8 +778,17 @@ class DIValue(NamedValue):
     def __ne__(self, other):
         return not self.__eq__(other)
 
+    def __getstate__(self):
+        # Ensure that the hash is not cached between Python invocations
+        # due to pickling or other serialization. The hash seed changes
+        # which will cause these not to match.
+        self.hash_cache = None
+        return self.__dict__
+
     def __hash__(self):
-        return hash((self.is_distinct, self.kind, self.operands))
+        if self.hash_cache is None:
+            self.hash_cache = hash(self.operands)
+        return self.hash_cache
 
 
 class GlobalValue(NamedValue, _ConstOpMixin, _HasMetadata):

--- a/llvmlite/tests/test_ir.py
+++ b/llvmlite/tests/test_ir.py
@@ -610,6 +610,26 @@ class TestIR(TestBase):
 
         self.assertEqual(503, len(mod._metadatacache))
 
+    def test_debug_info_pickle(self):
+        mod = self.module()
+
+        di_file = mod.add_debug_info(
+                'DIFile',
+                {
+                    'directory': 'my_directory',
+                    'filename': 'my_path.foo',
+                })
+        self.assertEqual(hash(di_file), di_file.hash_cache)
+        found_di_file = pickle.loads(pickle.dumps(di_file))
+        self.assertIsNone(found_di_file.hash_cache)
+        self.assertEqual(di_file, found_di_file)
+
+        meta = mod.add_metadata([di_file])
+        self.assertEqual(hash(meta), meta.hash_cache)
+        found_meta = pickle.loads(pickle.dumps(meta))
+        self.assertIsNone(found_meta.hash_cache)
+        self.assertEqual(meta, found_meta)
+
     def test_inline_assembly(self):
         mod = self.module()
         foo = ir.Function(mod, ir.FunctionType(ir.VoidType(), []), 'foo')

--- a/llvmlite/tests/test_ir.py
+++ b/llvmlite/tests/test_ir.py
@@ -566,8 +566,7 @@ class TestIR(TestBase):
                         'scope': di_file,
                         'scopeLine': 123,
                         'unit': di_compile_unit,
-                    },
-                    is_distinct=True)
+                    })
 
                 di_location = mod.add_debug_info(
                     'DILocation',
@@ -584,28 +583,30 @@ class TestIR(TestBase):
                     ir.Constant(ir.IntType(bits=32), i + 1))
 
         # Use this section to measure overall performance
-        total_time = timeit.timeit(
-            'do_test()',
-            'setup_test()',
-            number=500,
-            globals=locals())
+        # total_time = timeit.timeit(
+        #     'do_test()',
+        #     'setup_test()',
+        #     number=500,
+        #     globals=locals())
 
-        print(f'test_debug_info_performance took {total_time} to finish')
+        # print(f'test_debug_info_performance took {total_time} to finish')
+
+        print(mod)
 
         # Use this section to profile the caching behavior
-        # setup_test()
+        setup_test()
 
-        # import cProfile, pstats
-        # from pstats import SortKey
-        # with cProfile.Profile() as pr:
-        #     for i in range(200):
-        #         do_test()
+        import cProfile, pstats
+        from pstats import SortKey
+        with cProfile.Profile() as pr:
+            for i in range(500):
+                do_test()
 
-        # stats = pstats.Stats(pr)
-        # stats = stats.strip_dirs()
-        # stats = stats.sort_stats(SortKey.CUMULATIVE, SortKey.TIME, SortKey.NAME)
-        # stats.print_stats()
-        # stats.print_callers()
+        stats = pstats.Stats(pr)
+        stats = stats.strip_dirs()
+        stats = stats.sort_stats(SortKey.CUMULATIVE, SortKey.TIME, SortKey.NAME)
+        stats.print_stats()
+        stats.print_callers()
 
         self.assertEqual(750001, len(mod._metadatacache))
 

--- a/llvmlite/tests/test_ir.py
+++ b/llvmlite/tests/test_ir.py
@@ -569,13 +569,14 @@ class TestIR(TestBase):
             builder = ir.IRBuilder(foo.append_basic_block(''))
 
         def do_test():
-            for i in range(500):
+            for i in range(100_000):
                 di_location = mod.add_debug_info(
                     'DILocation',
                     {
                         'scope': di_subprogram,
                         'line': i,
-                        'column': 15
+                        'column': 15,
+                        'other': [di_subprogram, di_subprogram],
                     })
 
                 builder.debug_metadata = di_location
@@ -588,10 +589,10 @@ class TestIR(TestBase):
         total_time = timeit.timeit(
             'do_test()',
             'setup_test()',
-            number=1000,
+            number=10,
             globals=locals())
 
-        # print(f'test_debug_info_performance took {total_time} to finish')
+        print(f'test_debug_info_performance took {total_time} to finish')
 
         # Use this section to profile the caching behavior
         # setup_test()
@@ -599,7 +600,7 @@ class TestIR(TestBase):
         # import cProfile, pstats
         # from pstats import SortKey
         # with cProfile.Profile() as pr:
-        #     for i in range(1000):
+        #     for i in range(10):
         #         do_test()
 
         # stats = pstats.Stats(pr)
@@ -608,7 +609,7 @@ class TestIR(TestBase):
         # stats.print_stats()
         # stats.print_callers()
 
-        self.assertEqual(503, len(mod._metadatacache))
+        self.assertEqual(100004, len(mod._metadatacache))
 
     def test_debug_info_pickle(self):
         mod = self.module()

--- a/llvmlite/tests/test_ir.py
+++ b/llvmlite/tests/test_ir.py
@@ -585,29 +585,13 @@ class TestIR(TestBase):
                     ir.Constant(ir.IntType(bits=32), i),
                     ir.Constant(ir.IntType(bits=32), i + 1))
 
-        # Use this section to measure overall performance
         total_time = timeit.timeit(
             'do_test()',
             'setup_test()',
             number=10,
             globals=locals())
 
-        # print('test_debug_info_performance took', total_time, 'to finish')
-
-        # Use this section to profile the caching behavior
-        # setup_test()
-
-        # import cProfile, pstats
-        # from pstats import SortKey
-        # with cProfile.Profile() as pr:
-        #     for i in range(10):
-        #         do_test()
-
-        # stats = pstats.Stats(pr)
-        # stats = stats.strip_dirs()
-        # stats = stats.sort_stats(SortKey.CUMULATIVE, SortKey.TIME, SortKey.NAME)
-        # stats.print_stats()
-        # stats.print_callers()
+        print('test_debug_info_performance took', total_time, 'to finish')
 
         self.assertEqual(100004, len(mod._metadatacache))
 

--- a/llvmlite/tests/test_ir.py
+++ b/llvmlite/tests/test_ir.py
@@ -588,12 +588,10 @@ class TestIR(TestBase):
         total_time = timeit.timeit(
             'do_test()',
             'setup_test()',
-            number=500,
+            number=1000,
             globals=locals())
 
-        print(f'test_debug_info_performance took {total_time} to finish')
-
-        print(mod)
+        # print(f'test_debug_info_performance took {total_time} to finish')
 
         # Use this section to profile the caching behavior
         # setup_test()
@@ -601,7 +599,7 @@ class TestIR(TestBase):
         # import cProfile, pstats
         # from pstats import SortKey
         # with cProfile.Profile() as pr:
-        #     for i in range(500):
+        #     for i in range(1000):
         #         do_test()
 
         # stats = pstats.Stats(pr)

--- a/llvmlite/tests/test_ir.py
+++ b/llvmlite/tests/test_ir.py
@@ -584,30 +584,30 @@ class TestIR(TestBase):
                     ir.Constant(ir.IntType(bits=32), i + 1))
 
         # Use this section to measure overall performance
-        # total_time = timeit.timeit(
-        #     'do_test()',
-        #     'setup_test()',
-        #     number=200,
-        #     globals=locals())
+        total_time = timeit.timeit(
+            'do_test()',
+            'setup_test()',
+            number=500,
+            globals=locals())
 
-        # print(f'test_debug_info_performance took {total_time} to finish')
+        print(f'test_debug_info_performance took {total_time} to finish')
 
         # Use this section to profile the caching behavior
-        setup_test()
+        # setup_test()
 
-        import cProfile, pstats
-        from pstats import SortKey
-        with cProfile.Profile() as pr:
-            for i in range(200):
-                do_test()
+        # import cProfile, pstats
+        # from pstats import SortKey
+        # with cProfile.Profile() as pr:
+        #     for i in range(200):
+        #         do_test()
 
-        stats = pstats.Stats(pr)
-        stats = stats.strip_dirs()
-        stats = stats.sort_stats(SortKey.CUMULATIVE, SortKey.TIME, SortKey.NAME)
-        stats.print_stats()
-        stats.print_callers()
+        # stats = pstats.Stats(pr)
+        # stats = stats.strip_dirs()
+        # stats = stats.sort_stats(SortKey.CUMULATIVE, SortKey.TIME, SortKey.NAME)
+        # stats.print_stats()
+        # stats.print_callers()
 
-        self.assertEqual(300001, len(mod._metadatacache))
+        self.assertEqual(750001, len(mod._metadatacache))
 
     def test_inline_assembly(self):
         mod = self.module()

--- a/llvmlite/tests/test_ir.py
+++ b/llvmlite/tests/test_ir.py
@@ -585,30 +585,30 @@ class TestIR(TestBase):
                     ir.Constant(ir.IntType(bits=32), i + 1))
 
         # Use this section to measure overall performance
-        # total_time = timeit.timeit(
-        #     'do_test()',
-        #     'setup_test()',
-        #     number=500,
-        #     globals=locals())
+        total_time = timeit.timeit(
+            'do_test()',
+            'setup_test()',
+            number=500,
+            globals=locals())
 
-        # print(f'test_debug_info_performance took {total_time} to finish')
+        print(f'test_debug_info_performance took {total_time} to finish')
 
         print(mod)
 
         # Use this section to profile the caching behavior
-        setup_test()
+        # setup_test()
 
-        import cProfile, pstats
-        from pstats import SortKey
-        with cProfile.Profile() as pr:
-            for i in range(500):
-                do_test()
+        # import cProfile, pstats
+        # from pstats import SortKey
+        # with cProfile.Profile() as pr:
+        #     for i in range(500):
+        #         do_test()
 
-        stats = pstats.Stats(pr)
-        stats = stats.strip_dirs()
-        stats = stats.sort_stats(SortKey.CUMULATIVE, SortKey.TIME, SortKey.NAME)
-        stats.print_stats()
-        stats.print_callers()
+        # stats = pstats.Stats(pr)
+        # stats = stats.strip_dirs()
+        # stats = stats.sort_stats(SortKey.CUMULATIVE, SortKey.TIME, SortKey.NAME)
+        # stats.print_stats()
+        # stats.print_callers()
 
         self.assertEqual(503, len(mod._metadatacache))
 

--- a/llvmlite/tests/test_ir.py
+++ b/llvmlite/tests/test_ir.py
@@ -531,43 +531,45 @@ class TestIR(TestBase):
         mod = None
         foo = None
         builder = None
+        di_subprogram = None
 
         def setup_test():
-            nonlocal mod, foo, builder
+            nonlocal mod, foo, builder, di_subprogram
             mod = self.module()
+
+            di_file = mod.add_debug_info(
+                'DIFile',
+                {
+                    'directory': 'my_directory',
+                    'filename': 'my_path.foo',
+                })
+
+            di_compile_unit = mod.add_debug_info(
+                'DICompileUnit',
+                {
+                    'emissionKind': ir.DIToken('FullDebug'),
+                    'file': di_file,
+                    'isOptimized': False,
+                    'language': ir.DIToken('DW_LANG_C99'),
+                    'producer': 'llvmlite-test',
+                })
+
+            di_subprogram = mod.add_debug_info(
+                'DISubprogram',
+                {
+                    'file': di_file,
+                    'line': 123,
+                    'name': 'my function',
+                    'scope': di_file,
+                    'scopeLine': 123,
+                    'unit': di_compile_unit,
+                })
+
             foo = ir.Function(mod, ir.FunctionType(ir.VoidType(), []), 'foo')
             builder = ir.IRBuilder(foo.append_basic_block(''))
 
         def do_test():
             for i in range(500):
-                di_file = mod.add_debug_info(
-                    'DIFile',
-                    {
-                        'directory': 'my_directory',
-                        'filename': 'my_path.foo',
-                    })
-
-                di_compile_unit = mod.add_debug_info(
-                    'DICompileUnit',
-                    {
-                        'emissionKind': ir.DIToken('FullDebug'),
-                        'file': di_file,
-                        'isOptimized': False,
-                        'language': ir.DIToken('DW_LANG_C99'),
-                        'producer': 'llvmlite-test',
-                    })
-
-                di_subprogram = mod.add_debug_info(
-                    'DISubprogram',
-                    {
-                        'file': di_file,
-                        'line': 123,
-                        'name': 'my function',
-                        'scope': di_file,
-                        'scopeLine': 123,
-                        'unit': di_compile_unit,
-                    })
-
                 di_location = mod.add_debug_info(
                     'DILocation',
                     {
@@ -608,7 +610,7 @@ class TestIR(TestBase):
         stats.print_stats()
         stats.print_callers()
 
-        self.assertEqual(750001, len(mod._metadatacache))
+        self.assertEqual(503, len(mod._metadatacache))
 
     def test_inline_assembly(self):
         mod = self.module()

--- a/llvmlite/tests/test_ir.py
+++ b/llvmlite/tests/test_ir.py
@@ -592,7 +592,7 @@ class TestIR(TestBase):
             number=10,
             globals=locals())
 
-        print(f'test_debug_info_performance took {total_time} to finish')
+        # print('test_debug_info_performance took', total_time, 'to finish')
 
         # Use this section to profile the caching behavior
         # setup_test()


### PR DESCRIPTION
- Only generates the hash for the key for module._metadatacache a single time instead of twice
- Avoids extra assignments in NameScope._basenamemap when there are name conflicts
- Caches computed hashes for MDValue and DIValue instances, while ensuring they'll still pickle
- Adds a test to measure performance of this path so regressions will be easy to spot
- Adds a test to make sure pickling behavior continues to work

In my own compiler's codebase, this change reduces the time it takes for my debug info regression test to complete from 180 seconds down to 20 seconds. The more nesting of metadata there is, the larger the effect.