### PR TITLE
Upgrade to ubuntu-20.04 for azure pipeline CI

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -21,7 +21,7 @@ jobs:
 - template: buildscripts/azure/azure-linux-macos.yml
   parameters:
     name: Linux
-    vmImage: ubuntu-18.04
+    vmImage: ubuntu-20.04
     matrix:
       py37:
         PYTHON: '3.7'


### PR DESCRIPTION
ubuntu-18.04 is deprecated and will have scheduled brownouts until fully unsupported on 2023-04-01. See for more details actions/runner-images#6002

Microsoft-hosted pipelines supports the 2 latest versions of macOS, Windows and Ubuntu. Now that ubuntu-22.04 is available, ubuntu-20.04 will become the oldest supported version as ubuntu-18.04 is being deprecated.

This bump of the ubuntu version in the azure pipelines CI was also completed in https://github.com/numba/numba/commit/af758e009a6ec3821e77cb9d92a7e3a7265a9cbc.