### PR TITLE
Add support for self referential metadata

### DIFF
--- a/llvmlite/ir/module.py
+++ b/llvmlite/ir/module.py
@@ -42,22 +42,32 @@ class Module(object):
             fixed_ops.append((name, op))
         return fixed_ops
 
-    def add_metadata(self, operands):
+    def add_metadata(self, operands, *, self_ref=False):
         """
         Add an unnamed metadata to the module with the given *operands*
         (a sequence of values) or return a previous equivalent metadata.
         A MDValue instance is returned, it can then be associated to
         e.g. an instruction.
+
+        A self referential metadata entry has itself as the first
+        operand to ensure uniquencess. These references are never
+        cached.
         """
         if not isinstance(operands, (list, tuple)):
             raise TypeError("expected a list or tuple of metadata values, "
                             "got %r" % (operands,))
         operands = self._fix_metadata_operands(operands)
         key = tuple(operands)
-        if key not in self._metadatacache:
+        if self_ref or key not in self._metadatacache:
             n = len(self.metadata)
-            md = values.MDValue(self, operands, name=str(n))
-            self._metadatacache[key] = md
+            md = values.MDValue(
+                self,
+                operands,
+                name=str(n),
+                self_ref=self_ref,
+            )
+            if not self_ref:
+                self._metadatacache[key] = md
         else:
             md = self._metadatacache[key]
         return md

--- a/llvmlite/ir/module.py
+++ b/llvmlite/ir/module.py
@@ -50,8 +50,11 @@ class Module(object):
         e.g. an instruction.
 
         A self referential metadata entry has itself as the first
-        operand to ensure uniquencess. These references are never
-        cached.
+        operand to ensure uniqueness. These references are never
+        cached. If `self_ref` is set, create a self referential
+        metadata entry by first creating a new metadata value
+        and then add itself as first argument. `operands` are then
+        added as additional operands.
         """
         if not isinstance(operands, (list, tuple)):
             raise TypeError("expected a list or tuple of metadata values, "

--- a/llvmlite/tests/test_ir.py
+++ b/llvmlite/tests/test_ir.py
@@ -323,6 +323,17 @@ class TestIR(TestBase):
         self.assert_ir_line('!1 = !{ i32 789 }', mod)
         self.assert_ir_line('!2 = !{ i32 123, !0, !1, !0 }', mod)
 
+    def test_self_relf_metadata(self):
+        mod = self.module()
+        value = mod.add_metadata((), self_ref=True)
+        self.assert_ir_line('!0 = !{ !0 }', mod)
+        value2 = mod.add_metadata((value,))
+        assert value is not value2
+        self.assert_ir_line('!1 = !{ !0 }', mod)
+        value3 = mod.add_metadata((), self_ref=True)
+        self.assert_ir_line('!2 = !{ !2 }', mod)
+        assert value is not value3
+
     def test_metadata_string(self):
         # Escaping contents of a metadata string
         mod = self.module()

--- a/llvmlite/tests/test_ir.py
+++ b/llvmlite/tests/test_ir.py
@@ -323,7 +323,7 @@ class TestIR(TestBase):
         self.assert_ir_line('!1 = !{ i32 789 }', mod)
         self.assert_ir_line('!2 = !{ i32 123, !0, !1, !0 }', mod)
 
-    def test_self_relf_metadata(self):
+    def test_self_ref_metadata(self):
         mod = self.module()
         value = mod.add_metadata((), self_ref=True)
         self.assert_ir_line('!0 = !{ !0 }', mod)
@@ -333,6 +333,8 @@ class TestIR(TestBase):
         value3 = mod.add_metadata((), self_ref=True)
         self.assert_ir_line('!2 = !{ !2 }', mod)
         assert value is not value3
+        value = mod.add_metadata([int32(123)], self_ref=True)
+        self.assert_ir_line('!3 = !{ !3, i32 123 }', mod)
 
     def test_metadata_string(self):
         # Escaping contents of a metadata string


### PR DESCRIPTION
Metadata definitions that refer to themselves like `!0 = { !0 }` are allowed by llvm, and used to make some metadata entries globally unique (see for instance https://llvm.org/docs/LangRef.html#noalias-and-alias-scope-metadata). It seems this isn't supported by llvmlite currently.

In this PR I add support for this by adding a new `self_ref` argument to `Model.add_metadata`, that will always return a new metadata entry, but prepending self as the first operand. So this only supports references to self as the first entry, I haven't seen any usage in llvm at other locations however.

*Update* I probably should also mention that I'm still pretty new to llvm, and this proposed API might not actually be the best as a result...