### PR TITLE
drop upper limit on Python for conda recipe

### DIFF
--- a/conda-recipes/llvmlite/meta.yaml
+++ b/conda-recipes/llvmlite/meta.yaml
@@ -37,7 +37,7 @@ requirements:
     # llvmdev is built with libz compression support
     - zlib           # [unix and not (armv6l or armv7l)]
   run:
-    - python >=3.8,<3.10
+    - python >=3.8
     - vs2015_runtime # [win]
     # osx has dynamically linked libstdc++
     - libcxx >=4.0.1 # [osx]


### PR DESCRIPTION
`conda-build` will override this setting anyway, when building for Python 3.10 using `--python` like we do for llvmlite. It is effectively a no-op under these circumstances.