### PR TITLE
Run Minconda install with bash

### DIFF
--- a/buildscripts/incremental/install_miniconda.sh
+++ b/buildscripts/incremental/install_miniconda.sh
@@ -10,4 +10,4 @@ else
   echo Error
 fi
 chmod +x miniconda.sh
-bash ./miniconda.sh
+bash ./miniconda.sh -b

--- a/buildscripts/incremental/install_miniconda.sh
+++ b/buildscripts/incremental/install_miniconda.sh
@@ -10,4 +10,4 @@ else
   echo Error
 fi
 chmod +x miniconda.sh
-./miniconda.sh -b
+bash ./miniconda.sh


### PR DESCRIPTION
The Minconda installer seems to expect that `[[` can be used in all sh implementations, which is not necessarily the case (there are some discussions around this issue e.g. in https://github.com/conda/conda/issues/10431).

To attempt to work around this, we run the installer with bash instead.