### PR TITLE
Add YouCompleteMe configuration file and ignore vim swap files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,4 +14,4 @@ coverage.xml
 MANIFEST
 docs/_build/
 docs/gh-pages/
-
+.*.swp

--- a/.ycm_extra_conf.py
+++ b/.ycm_extra_conf.py
@@ -1,0 +1,40 @@
+# YouCompleteMe (https://github.com/ycm-core/YouCompleteMe) configuration file
+# that enables it to find the LLVM and Python includes from a conda
+# environment, independent of the Conda environment location and Python and
+# LLVM versions.
+
+import os
+import sys
+
+from pathlib import Path
+
+CONDA_PREFIX = os.environ['CONDA_PREFIX']
+LLVMLITE_DIR = Path(__file__).parent
+VER = sys.version_info
+PYTHON_INCLUDE_NAME = f'python{VER.major}.{VER.minor}'
+
+CONDA_INCLUDE_DIR = Path(CONDA_PREFIX, 'include')
+PYTHON_INCLUDE_DIR = Path(CONDA_INCLUDE_DIR, PYTHON_INCLUDE_NAME)
+FFI_DIR = Path(LLVMLITE_DIR, 'ffi')
+
+flags = [
+    # Include dirs
+    f'-I{CONDA_INCLUDE_DIR}',
+    f'-I{PYTHON_INCLUDE_DIR}',
+    f'-I{FFI_DIR}',
+    # C++ standard to which LLVM 14 is developed
+    '-std=c++14',
+    # Force language to C++ so that core.h is treated as C++
+    '-x', 'c++',
+]
+
+
+# This function is called by YCM to obtain the config from this file.
+def Settings(**kwargs):
+    return {'flags': flags}
+
+
+# Executing this configuration file standalone outside of YCM prints the
+# settings to aid with debugging the configuration.
+if __name__ == '__main__':
+    print(Settings())


### PR DESCRIPTION
I've been working with this config locally for a long time, and I think it might be helpful to make more broadly available, as vim and YCM are a popular development combination. This PR has no effect on the code, the tests, or the build, but helps make llvmlite development on vim a smoother experience out-of-the-box for anyone using Vim + YCM, and working with Conda.

YouCompleteMe (https://github.com/ycm-core/YouCompleteMe) is a code-completion engine for vim. This PR adds a configuration file for it that enables it to understand the C++ FFI code in llvmlite by pointing to the correct include dirs (as long as one is working within a Conda environment), setting the relevant C++ standard, and ensuring that all header files are treated as C++.

Additionally, Vim swap files are added to the gitignore, so that they don't show up in `git status`.