### PR TITLE
Replace importlib-resources legacy API use

### DIFF
--- a/llvmlite/binding/ffi.py
+++ b/llvmlite/binding/ffi.py
@@ -1,6 +1,6 @@
 import ctypes
 import threading
-import importlib.resources
+import importlib.resources as _impres
 
 from llvmlite.binding.common import _decode_string, _is_shutting_down
 from llvmlite.utils import get_library_name
@@ -151,12 +151,26 @@ class _lib_fn_wrapper(object):
             return self._cfn(*args, **kwargs)
 
 
+def _importlib_resources_path(package, resource):
+    """Replacement implementation of `import.resources.path` to avoid
+    deprecation warning following code at importlib_resources/_legacy.py
+    as suggested by https://importlib-resources.readthedocs.io/en/latest/using.html#migrating-from-legacy
+
+    Notes on differences from importlib.resources implementation:
+
+    The `_common.normalize_path(resource)` call is skipped because it is an
+    internal API and it is unnecessary for the use here. What it does is
+    ensuring `resource` is a str and that it does not contain path separators.
+    """
+    return _impres.as_file(_impres.files(package) / resource)
+
+
 _lib_name = get_library_name()
 
 
 pkgname = ".".join(__name__.split(".")[0:-1])
 try:
-    _lib_handle = importlib.resources.path(pkgname, _lib_name)
+    _lib_handle = _importlib_resources_path(pkgname, _lib_name)
     lib = ctypes.CDLL(str(_lib_handle.__enter__()))
     # on windows file handles to the dll file remain open after
     # loading, therefore we can not exit the context manager


### PR DESCRIPTION
Suppress deprecation warnings due to use of legacy API in importlib-resources

The replacement implementation follows advice from https://importlib-resources.readthedocs.io/en/latest/using.html#migrating-from-legacy and adapts code from https://github.com/python/importlib_resources/blob/66ea2dc7eb12b1be2322b7ad002cefb12d364dff/importlib_resources/_legacy.py#L72-L84.

The DeprecationWarning was first noticed in numba test `numba.tests.test_import.TestNumbaImport.test_no_accidental_warnings`