### PR TITLE
[llvmlite] Support opaque pointers.

### DIFF
--- a/ffi/core.cpp
+++ b/ffi/core.cpp
@@ -1,6 +1,7 @@
 #include "core.h"
 
 #include "llvm-c/Support.h"
+#include "llvm/IR/LLVMContext.h"
 
 extern "C" {
 
@@ -21,10 +22,31 @@ API_EXPORT(void)
 LLVMPY_DisposeString(const char *msg) { free(const_cast<char *>(msg)); }
 
 API_EXPORT(LLVMContextRef)
-LLVMPY_GetGlobalContext() { return LLVMGetGlobalContext(); }
+LLVMPY_GetGlobalContext(bool enable_opaque_pointers) {
+    LLVMContextRef ctx = LLVMGetGlobalContext();
+#if LLVM_VERSION_MAJOR >= 14
+    if (enable_opaque_pointers) llvm::unwrap(ctx)->enableOpaquePointers();
+#endif
+    return ctx;
+}
 
 API_EXPORT(LLVMContextRef)
-LLVMPY_ContextCreate() { return LLVMContextCreate(); }
+LLVMPY_ContextCreate(bool enable_opaque_pointers) {
+    LLVMContextRef ctx = LLVMContextCreate();
+#if LLVM_VERSION_MAJOR >= 14
+    if (enable_opaque_pointers) llvm::unwrap(ctx)->enableOpaquePointers();
+#endif
+    return ctx;
+}
+
+API_EXPORT(bool)
+LLVMPY_SupportsTypedPointers(LLVMContextRef ctx) {
+#if LLVM_VERSION_MAJOR >= 13
+    return llvm::unwrap(ctx)->supportsTypedPointers();
+#else
+    return true;
+#endif
+}
 
 API_EXPORT(void)
 LLVMPY_ContextDispose(LLVMContextRef context) {

--- a/ffi/core.h
+++ b/ffi/core.h
@@ -27,10 +27,13 @@ API_EXPORT(void)
 LLVMPY_DisposeString(const char *msg);
 
 API_EXPORT(LLVMContextRef)
-LLVMPY_GetGlobalContext();
+LLVMPY_GetGlobalContext(bool enable_opaque_pointers);
 
 API_EXPORT(LLVMContextRef)
-LLVMPY_ContextCreate();
+LLVMPY_ContextCreate(bool enable_opaque_pointers);
+
+API_EXPORT(bool)
+LLVMPY_SupportsTypedPointers(LLVMContextRef ctx);
 
 } /* end extern "C" */
 

--- a/ffi/passmanagers.cpp
+++ b/ffi/passmanagers.cpp
@@ -17,9 +17,6 @@
 #include "llvm-c/Transforms/IPO.h"
 #include "llvm-c/Transforms/Scalar.h"
 #include "llvm/IR/LegacyPassManager.h"
-#if LLVM_VERSION_MAJOR > 11
-#include "llvm/IR/RemarkStreamer.h"
-#endif
 #include "llvm/IR/LLVMRemarkStreamer.h"
 #include "llvm/Remarks/RemarkStreamer.h"
 #include "llvm/Transforms/IPO.h"
@@ -220,7 +217,9 @@ LLVMPY_AddLazyValueInfoPass(LLVMPassManagerRef PM) {
 }
 API_EXPORT(void)
 LLVMPY_AddLintPass(LLVMPassManagerRef PM) {
+#if LLVM_VERSION_MAJOR < 12
     unwrap(PM)->add(llvm::createLintPass());
+#endif
 }
 API_EXPORT(void)
 LLVMPY_AddModuleDebugInfoPrinterPass(LLVMPassManagerRef PM) {

--- a/ffi/targets.cpp
+++ b/ffi/targets.cpp
@@ -6,7 +6,11 @@
 #include "llvm/IR/LegacyPassManager.h"
 #include "llvm/IR/Type.h"
 #include "llvm/Support/Host.h"
+#if LLVM_VERSION_MAJOR < 14
 #include "llvm/Support/TargetRegistry.h"
+#else
+#include "llvm/MC/TargetRegistry.h"
+#endif
 #include "llvm/Target/TargetMachine.h"
 
 #include <cstdio>
@@ -99,6 +103,12 @@ LLVMPY_CopyStringRepOfTargetData(LLVMTargetDataRef TD, char **Out) {
 
 API_EXPORT(void)
 LLVMPY_DisposeTargetData(LLVMTargetDataRef TD) { LLVMDisposeTargetData(TD); }
+
+
+API_EXPORT(long long)
+LLVMPY_ABIAlignmentOfType(LLVMTargetDataRef TD, LLVMTypeRef Ty) {
+    return (long long)LLVMABIAlignmentOfType(TD, Ty);
+}
 
 API_EXPORT(long long)
 LLVMPY_ABISizeOfType(LLVMTargetDataRef TD, LLVMTypeRef Ty) {
@@ -204,7 +214,9 @@ LLVMPY_CreateTargetMachine(LLVMTargetRef T, const char *Triple, const char *CPU,
         rm = Reloc::DynamicNoPIC;
 
     TargetOptions opt;
+#if LLVM_VERSION_MAJOR < 12
     opt.PrintMachineCode = PrintMC;
+#endif
     opt.MCOptions.ABIName = ABIName;
 
     bool jit = JIT;

--- a/ffi/value.cpp
+++ b/ffi/value.cpp
@@ -154,7 +154,11 @@ LLVMPY_ArgumentAttributesIter(LLVMValueRef A) {
     Argument *arg = unwrap<Argument>(A);
     unsigned argno = arg->getArgNo();
     AttributeSet attrs =
+#if LLVM_VERSION_MAJOR < 14
         arg->getParent()->getAttributes().getParamAttributes(argno);
+#else
+        arg->getParent()->getAttributes().getParamAttrs(argno);
+#endif
     return wrap(new AttributeSetIterator(attrs.begin(), attrs.end()));
 }
 
@@ -319,6 +323,16 @@ LLVMPY_SetValueName(LLVMValueRef Val, const char *Name) {
 
 API_EXPORT(LLVMModuleRef)
 LLVMPY_GetGlobalParent(LLVMValueRef Val) { return LLVMGetGlobalParent(Val); }
+
+API_EXPORT(LLVMTypeRef)
+LLVMPY_GlobalGetValueType(LLVMValueRef Val) {
+  llvm::Value *unwrapped = llvm::unwrap(Val);
+  llvm::GlobalValue *gv = llvm::dyn_cast<llvm::GlobalValue>(unwrapped);
+  if (!gv) {
+    return nullptr;
+  }
+  return llvm::wrap(gv->getValueType());
+}
 
 API_EXPORT(LLVMTypeRef)
 LLVMPY_TypeOf(LLVMValueRef Val) { return LLVMTypeOf(Val); }

--- a/llvmlite/binding/context.py
+++ b/llvmlite/binding/context.py
@@ -1,17 +1,22 @@
+from ctypes import c_bool
+
 from llvmlite.binding import ffi
 
 
 def create_context():
-    return ContextRef(ffi.lib.LLVMPY_ContextCreate())
+    return ContextRef(ffi.lib.LLVMPY_ContextCreate(True))
 
 
 def get_global_context():
-    return GlobalContextRef(ffi.lib.LLVMPY_GetGlobalContext())
+    return GlobalContextRef(ffi.lib.LLVMPY_GetGlobalContext(True))
 
 
 class ContextRef(ffi.ObjectRef):
     def __init__(self, context_ptr):
         super(ContextRef, self).__init__(context_ptr)
+
+    def supports_typed_pointers(self):
+        return ffi.lib.LLVMPY_SupportsTypedPointers(self)
 
     def _dispose(self):
         ffi.lib.LLVMPY_ContextDispose(self)
@@ -22,8 +27,13 @@ class GlobalContextRef(ContextRef):
         pass
 
 
+ffi.lib.LLVMPY_GetGlobalContext.argtypes = [c_bool]
 ffi.lib.LLVMPY_GetGlobalContext.restype = ffi.LLVMContextRef
 
+ffi.lib.LLVMPY_ContextCreate.argtypes = [c_bool]
 ffi.lib.LLVMPY_ContextCreate.restype = ffi.LLVMContextRef
+
+ffi.lib.LLVMPY_SupportsTypedPointers.argtypes = [ffi.LLVMContextRef]
+ffi.lib.LLVMPY_SupportsTypedPointers.restype = c_bool
 
 ffi.lib.LLVMPY_ContextDispose.argtypes = [ffi.LLVMContextRef]

--- a/llvmlite/binding/targets.py
+++ b/llvmlite/binding/targets.py
@@ -135,6 +135,12 @@ class TargetData(ffi.ObjectRef):
         """
         return ffi.lib.LLVMPY_ABISizeOfType(self, ty)
 
+    def get_abi_alignment(self, ty):
+        """
+        Get ABI size of LLVM type *ty*.
+        """
+        return ffi.lib.LLVMPY_ABIAlignmentOfType(self, ty)
+
     def get_element_offset(self, ty, position):
         """
         Get byte offset of type's ty element at the given position
@@ -362,6 +368,10 @@ ffi.lib.LLVMPY_CopyStringRepOfTargetData.argtypes = [
 ffi.lib.LLVMPY_DisposeTargetData.argtypes = [
     ffi.LLVMTargetDataRef,
 ]
+
+ffi.lib.LLVMPY_ABIAlignmentOfType.argtypes = [ffi.LLVMTargetDataRef,
+                                              ffi.LLVMTypeRef]
+ffi.lib.LLVMPY_ABIAlignmentOfType.restype = c_longlong
 
 ffi.lib.LLVMPY_ABISizeOfType.argtypes = [ffi.LLVMTargetDataRef,
                                          ffi.LLVMTypeRef]

--- a/llvmlite/binding/value.py
+++ b/llvmlite/binding/value.py
@@ -196,6 +196,13 @@ class ValueRef(ffi.ObjectRef):
         ffi.lib.LLVMPY_AddFunctionAttr(self, attrval)
 
     @property
+    def global_value_type(self):
+        """
+        This value's LLVM type, if it is a global value.
+        """
+        return TypeRef(ffi.lib.LLVMPY_GlobalGetValueType(self))
+
+    @property
     def type(self):
         """
         This value's LLVM type.
@@ -417,6 +424,9 @@ ffi.lib.LLVMPY_GetValueName.argtypes = [ffi.LLVMValueRef]
 ffi.lib.LLVMPY_GetValueName.restype = c_char_p
 
 ffi.lib.LLVMPY_SetValueName.argtypes = [ffi.LLVMValueRef, c_char_p]
+
+ffi.lib.LLVMPY_GlobalGetValueType.argtypes = [ffi.LLVMValueRef]
+ffi.lib.LLVMPY_GlobalGetValueType.restype = ffi.LLVMTypeRef
 
 ffi.lib.LLVMPY_TypeOf.argtypes = [ffi.LLVMValueRef]
 ffi.lib.LLVMPY_TypeOf.restype = ffi.LLVMTypeRef

--- a/llvmlite/ir/types.py
+++ b/llvmlite/ir/types.py
@@ -30,7 +30,7 @@ class Type(_StrCaching):
     def __ne__(self, other):
         return not (self == other)
 
-    def _get_ll_pointer_type(self, target_data, context=None):
+    def _get_ll_global_value_type(self, target_data, context=None):
         """
         Convert this type object to an LLVM type.
         """
@@ -43,22 +43,22 @@ class Type(_StrCaching):
             m = Module(context=context)
         foo = GlobalVariable(m, self, name="foo")
         with parse_assembly(str(m)) as llmod:
-            return llmod.get_global_variable(foo.name).type
+            return llmod.get_global_variable(foo.name).global_value_type
 
     def get_abi_size(self, target_data, context=None):
         """
         Get the ABI size of this type according to data layout *target_data*.
         """
-        llty = self._get_ll_pointer_type(target_data, context)
-        return target_data.get_pointee_abi_size(llty)
+        llty = self._get_ll_global_value_type(target_data, context)
+        return target_data.get_abi_size(llty)
 
     def get_abi_alignment(self, target_data, context=None):
         """
         Get the minimum ABI alignment of this type according to data layout
         *target_data*.
         """
-        llty = self._get_ll_pointer_type(target_data, context)
-        return target_data.get_pointee_abi_alignment(llty)
+        llty = self._get_ll_global_value_type(target_data, context)
+        return target_data.get_abi_alignment(llty)
 
     def format_constant(self, value):
         """

--- a/llvmlite/tests/test_refprune.py
+++ b/llvmlite/tests/test_refprune.py
@@ -210,7 +210,7 @@ define void @main(i8* %ptr) {
         mod, stats = self.check(self.per_bb_ir_2)
         self.assertEqual(stats.basicblock, 4)
         # not pruned
-        self.assertIn("call void @NRT_incref(i8* %ptr)", str(mod))
+        self.assertRegex(str(mod), r"call void @NRT_incref\((ptr|i8\*) %ptr\)")
 
     per_bb_ir_3 = r"""
 define void @main(i8* %ptr, i8* %other) {
@@ -226,7 +226,8 @@ define void @main(i8* %ptr, i8* %other) {
         mod, stats = self.check(self.per_bb_ir_3)
         self.assertEqual(stats.basicblock, 2)
         # not pruned
-        self.assertIn("call void @NRT_decref(i8* %other)", str(mod))
+        self.assertRegex(
+            str(mod), r"call void @NRT_decref\((ptr|i8\*) %other\)")
 
     per_bb_ir_4 = r"""
 ; reordered
@@ -244,7 +245,7 @@ define void @main(i8* %ptr, i8* %other) {
         mod, stats = self.check(self.per_bb_ir_4)
         self.assertEqual(stats.basicblock, 4)
         # not pruned
-        self.assertIn("call void @NRT_decref(i8* %other)", str(mod))
+        self.assertRegex(str(mod), "call void @NRT_decref\((ptr|i8\*) %other\)")
 
 
 class TestDiamond(BaseTestByIR):


### PR DESCRIPTION
Fix for issue #900 

LLVM 14 introduces optional opaque pointers. If opaque pointers are enabled then there is no way to determine the pointee type. LLVM 16 makes this the default.

In llvmlite and numba this is used to determine ABI size and alignment of types by creating a global variable and then asking for its pointee type in order to get a TypeRef. For global variables specifically this can be shortcut via gv->getValueType(),
and doing so removes the current issues when opaque pointers are enabled.

This change has been tested with LLVM 11-14 and so also includes some other changes required to make llvmlite compile on those versions.