### PR TITLE
llvmdev recipe: Add patch that clears GOTOffsetMap

### DIFF
--- a/conda-recipes/llvm14-clear-gotoffsetmap.patch
+++ b/conda-recipes/llvm14-clear-gotoffsetmap.patch
@@ -1,0 +1,31 @@
+From 322c79fff224389b4df9f24ac22965867007c2fa Mon Sep 17 00:00:00 2001
+From: Graham Markall <gmarkall@nvidia.com>
+Date: Mon, 13 Mar 2023 21:35:11 +0000
+Subject: [PATCH] RuntimeDyldELF: Clear the GOTOffsetMap when finalizing the
+ load
+
+This needs resetting so that stale entries are not left behind when the
+GOT section and index are reset.
+
+See llvm/llvm#61402: RuntimeDyldELF doesn't clear GOTOffsetMap in
+finalizeLoad(), leading to invalid GOT relocations on AArch64 -
+https://github.com/llvm/llvm-project/issues/61402.
+---
+ llvm/lib/ExecutionEngine/RuntimeDyld/RuntimeDyldELF.cpp | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/llvm/lib/ExecutionEngine/RuntimeDyld/RuntimeDyldELF.cpp b/llvm/lib/ExecutionEngine/RuntimeDyld/RuntimeDyldELF.cpp
+index f92618afdff6..eb3c27a9406a 100644
+--- a/llvm/lib/ExecutionEngine/RuntimeDyld/RuntimeDyldELF.cpp
++++ b/llvm/lib/ExecutionEngine/RuntimeDyld/RuntimeDyldELF.cpp
+@@ -2345,6 +2345,7 @@ Error RuntimeDyldELF::finalizeLoad(const ObjectFile &Obj,
+     }
+   }
+ 
++  GOTOffsetMap.clear();
+   GOTSectionID = 0;
+   CurrentGOTIndex = 0;
+ 
+-- 
+2.34.1
+

--- a/conda-recipes/llvmdev/meta_llvm14.yaml
+++ b/conda-recipes/llvmdev/meta_llvm14.yaml
@@ -3,7 +3,7 @@
 {% set sha256_llvm = "050922ecaaca5781fdf6631ea92bc715183f202f9d2f15147226f023414f619a" %}
 {% set sha256_lld = "0c28ce0496934d37d20fec96591032dd66af8d10178a45762e0e75e85cf95ad3" %}
 {% set sha256_libunwind = "3bbe9c23c73259fe39c045dc87d0b283236ba6e00750a226b2c2aeac4a51d86b" %}
-{% set build_number = "0" %}
+{% set build_number = "1" %}
 
 package:
   name: llvmdev

--- a/conda-recipes/llvmdev/meta_llvm14.yaml
+++ b/conda-recipes/llvmdev/meta_llvm14.yaml
@@ -14,6 +14,7 @@ source:
     fn: llvm-{{ version }}.src.tar.xz
     sha256: {{ sha256_llvm }}
     patches:
+    - ../llvm14-clear-gotoffsetmap.patch
     - ../llvm14-remove-use-of-clonefile.patch
     - ../llvm14-svml.patch
   - url: https://github.com/llvm/llvm-project/releases/download/llvmorg-{{ version }}/lld-{{ version }}.src.tar.xz


### PR DESCRIPTION
See:

- https://github.com/llvm/llvm-project/issues/61402
- https://github.com/numba/numba/issues/8738

Fixes numba/numba#8738.