### PR TITLE
Add ORCJITv2 support

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -60,14 +60,15 @@ Compatibility
 llvmlite works with Python 3.8 and greater. We attempt to test with the latest
 Python version, this can be checked by looking at the public CI builds.
 
-As of version 0.37.0, llvmlite requires LLVM 11.x.x on all architectures
+As of version 0.41.0, llvmlite requires LLVM 14.x.x on all architectures
 
 Historical compatibility table:
 
 =================  ========================
 llvmlite versions  compatible LLVM versions
 =================  ========================
-0.37.0 - ...       11.x.x
+0.41.0 - ...       14.x.x
+0.37.0 - 0.40.0    11.x.x-14.x.x
 0.34.0 - 0.36.0    10.0.x (9.0.x for  ``aarch64`` only)
 0.33.0             9.0.x
 0.29.0 - 0.32.0    7.0.x, 7.1.x, 8.0.x

--- a/examples/lljit.py
+++ b/examples/lljit.py
@@ -1,0 +1,46 @@
+# Tutorial example from
+# https://llvmlite.readthedocs.io/en/latest/user-guide/binding/examples.html
+# adapted to use LLJIT instead of MCJIT
+#
+# Additionally this example also demonstrates that typed pointers still work in
+# LLVM 14 (and 15, if built against that).
+
+from ctypes import CFUNCTYPE, c_double, c_int, c_uint64
+
+import llvmlite.binding as llvm
+import numpy as np
+
+llvm.initialize()
+llvm.initialize_native_target()
+llvm.initialize_native_asmprinter()  # yes, even this one
+
+llvm_ir = """
+   ; ModuleID = "examples/ir_fpadd.py"
+   target triple = "unknown-unknown-unknown"
+   target datalayout = ""
+
+   define double @"fpadd"(double %".1", double %".2", double* %"dummy")
+   {
+   entry:
+     %"res" = fadd double %".1", %".2"
+     %"val" = load double, double* %"dummy"
+     %"res2" = fadd double %"res", %"val"
+     ret double %"res2"
+   }
+   """
+
+lljit = llvm.create_lljit_compiler()
+rt = llvm.JITLibraryBuilder().add_ir(llvm_ir).export_symbol('fpadd').link(lljit, 'fpadd')
+
+cfunc = CFUNCTYPE(c_double, c_double, c_double, c_uint64)(rt['fpadd'])
+
+# Create some floating point data and get a pointer to it that we can pass in
+# to the jitted function
+x = np.asarray([7.2])
+data_ptr = x.__array_interface__['data'][0]
+
+
+args = (1.0, 3.5, data_ptr)
+res = cfunc(*args)
+print(f"x[0] = {x[0]}")
+print(f"fpadd({args[0]}, {args[1]}, &x[0]) = {res}")

--- a/ffi/CMakeLists.txt
+++ b/ffi/CMakeLists.txt
@@ -40,7 +40,7 @@ endif()
 add_library(llvmlite SHARED assembly.cpp bitcode.cpp core.cpp initfini.cpp
             module.cpp value.cpp executionengine.cpp transforms.cpp
             passmanagers.cpp targets.cpp dylib.cpp linker.cpp object_file.cpp
-            custom_passes.cpp)
+            custom_passes.cpp orcjit.cpp)
 
 # Find the libraries that correspond to the LLVM components
 # that we wish to use.

--- a/ffi/Makefile.linux
+++ b/ffi/Makefile.linux
@@ -13,7 +13,7 @@ LIBS = $(LLVM_LIBS)
 INCLUDE = core.h
 OBJ = assembly.o bitcode.o core.o initfini.o module.o value.o \
 	  executionengine.o transforms.o passmanagers.o targets.o dylib.o \
-	  linker.o object_file.o custom_passes.o
+	  linker.o object_file.o custom_passes.o orcjit.o
 OUTPUT = libllvmlite.so
 
 all: $(OUTPUT)

--- a/ffi/Makefile.osx
+++ b/ffi/Makefile.osx
@@ -8,7 +8,7 @@ LIBS = $(LLVM_LIBS)
 INCLUDE = core.h
 SRC = assembly.cpp bitcode.cpp core.cpp initfini.cpp module.cpp value.cpp \
 	  executionengine.cpp transforms.cpp passmanagers.cpp targets.cpp dylib.cpp \
-	  linker.cpp object_file.cpp custom_passes.cpp
+	  linker.cpp object_file.cpp custom_passes.cpp orcjit.cpp
 OUTPUT = libllvmlite.dylib
 MACOSX_DEPLOYMENT_TARGET ?= 10.9
 

--- a/ffi/orcjit.cpp
+++ b/ffi/orcjit.cpp
@@ -1,0 +1,337 @@
+#include "core.h"
+#include "llvm-c/LLJIT.h"
+#include "llvm-c/Orc.h"
+#include <sstream>
+
+#include "llvm/AsmParser/Parser.h"
+#include "llvm/ExecutionEngine/Orc/Core.h"
+#include "llvm/ExecutionEngine/Orc/ExecutionUtils.h"
+#include "llvm/ExecutionEngine/Orc/LLJIT.h"
+#include "llvm/ExecutionEngine/Orc/RTDyldObjectLinkingLayer.h"
+#include "llvm/ExecutionEngine/SectionMemoryManager.h"
+#include "llvm/IRReader/IRReader.h"
+#include "llvm/Support/MemoryBuffer.h"
+#include "llvm/Support/SourceMgr.h"
+using namespace llvm;
+using namespace llvm::orc;
+
+inline LLJIT *unwrap(LLVMOrcLLJITRef P) { return reinterpret_cast<LLJIT *>(P); }
+
+inline TargetMachine *unwrap(LLVMTargetMachineRef TM) {
+    return reinterpret_cast<TargetMachine *>(TM);
+}
+
+inline LLVMOrcJITTargetMachineBuilderRef wrap(JITTargetMachineBuilder *JTMB) {
+    return reinterpret_cast<LLVMOrcJITTargetMachineBuilderRef>(JTMB);
+}
+
+class JITDylibTracker {
+  public:
+    std::shared_ptr<LLJIT> lljit;
+    IntrusiveRefCntPtr<llvm::orc::ResourceTracker> tracker;
+    JITDylib &dylib;
+    JITDylibTracker(std::shared_ptr<LLJIT> &lljit_, JITDylib &dylib_,
+                    IntrusiveRefCntPtr<llvm::orc::ResourceTracker> &&tracker_)
+        : lljit(lljit_), dylib(dylib_), tracker(tracker_) {}
+};
+
+typedef struct {
+    uint8_t element_kind;
+    char *value;
+    size_t value_len;
+} LinkElement;
+typedef struct {
+    char *name;
+    uint64_t address;
+} SymbolAddress;
+extern "C" {
+
+API_EXPORT(std::shared_ptr<LLJIT> *)
+LLVMPY_CreateLLJITCompiler(LLVMTargetMachineRef tm, const char **OutError) {
+    LLJITBuilder builder;
+
+    if (tm) {
+        // The following is based on
+        // LLVMOrcJITTargetMachineBuilderCreateFromTargetMachine. However,
+        // we can't use that directly because it destroys the target
+        // machine, but we need to keep it alive because it is referenced by
+        // / shared with other objects on the Python side.
+        auto *template_tm = unwrap(tm);
+
+        builder.setJITTargetMachineBuilder(
+            JITTargetMachineBuilder(template_tm->getTargetTriple())
+                .setCPU(template_tm->getTargetCPU().str())
+                .setRelocationModel(template_tm->getRelocationModel())
+                .setCodeModel(template_tm->getCodeModel())
+                .setCodeGenOptLevel(template_tm->getOptLevel())
+                .setFeatures(template_tm->getTargetFeatureString())
+                .setOptions(template_tm->Options));
+    }
+    builder.setObjectLinkingLayerCreator(
+        [&](llvm::orc::ExecutionSession &session, const llvm::Triple &triple)
+            -> std::unique_ptr<llvm::orc::ObjectLayer> {
+            auto linkingLayer =
+                std::make_unique<llvm::orc::RTDyldObjectLinkingLayer>(
+                    session, []() {
+                        return std::make_unique<llvm::SectionMemoryManager>();
+                    });
+            if (triple.isOSBinFormatCOFF()) {
+                linkingLayer->setOverrideObjectFlagsWithResponsibilityFlags(
+                    true);
+                linkingLayer->setAutoClaimResponsibilityForObjectSymbols(true);
+            }
+            linkingLayer->registerJITEventListener(
+                *llvm::JITEventListener::createGDBRegistrationListener());
+            return linkingLayer;
+        });
+
+    auto jit = builder.create();
+
+    if (!jit) {
+        char *message = LLVMGetErrorMessage(wrap(jit.takeError()));
+        *OutError = LLVMPY_CreateString(message);
+        LLVMDisposeErrorMessage(message);
+        return nullptr;
+    }
+
+    return new std::shared_ptr<LLJIT>(std::move(*jit));
+}
+
+API_EXPORT(JITDylibTracker *)
+LLVMPY_LLJITLookup(std::shared_ptr<LLJIT> *lljit, const char *dylib_name,
+                   const char *name, uint64_t *addr, const char **OutError) {
+
+    auto dylib = (*lljit)->getJITDylibByName(dylib_name);
+    if (!dylib) {
+        *OutError = LLVMPY_CreateString("No such library");
+        return nullptr;
+    }
+
+    auto sym = (*lljit)->lookup(*dylib, name);
+    if (!sym) {
+        char *message = LLVMGetErrorMessage(wrap(sym.takeError()));
+        *OutError = LLVMPY_CreateString(message);
+        LLVMDisposeErrorMessage(message);
+        return nullptr;
+    }
+
+    *addr = sym->getAddress();
+    return new JITDylibTracker(*lljit, *dylib,
+                               std::move(dylib->createResourceTracker()));
+}
+
+API_EXPORT(LLVMTargetDataRef)
+LLVMPY_LLJITGetDataLayout(std::shared_ptr<LLJIT> *lljit) {
+    return wrap(&(*lljit)->getDataLayout());
+}
+
+API_EXPORT(void)
+LLVMPY_LLJITDispose(std::shared_ptr<LLJIT> *lljit) { delete lljit; }
+
+API_EXPORT(JITDylibTracker *)
+LLVMPY_LLJIT_Link(std::shared_ptr<LLJIT> *lljit, const char *libraryName,
+                  LinkElement *elements, size_t elements_length,
+                  SymbolAddress *imports, size_t imports_length,
+                  SymbolAddress *exports, size_t exports_length,
+                  const char **OutError) {
+    if ((*lljit)->getJITDylibByName(libraryName) != nullptr) {
+        std::stringstream err;
+        err << "Library name `" << libraryName << "' is already in use.";
+        *OutError = LLVMPY_CreateString(err.str().c_str());
+        return nullptr;
+    }
+    auto dylib = (*lljit)->createJITDylib(libraryName);
+
+    if (!dylib) {
+        char *message = LLVMGetErrorMessage(wrap(std::move(dylib.takeError())));
+        *OutError = LLVMPY_CreateString(message);
+        LLVMDisposeErrorMessage(message);
+        return nullptr;
+    }
+
+    for (size_t import_idx = 0; import_idx < imports_length; import_idx++) {
+        SymbolStringPtr mangled =
+            (*lljit)->mangleAndIntern(imports[import_idx].name);
+        JITEvaluatedSymbol symbol(imports[import_idx].address,
+                                  JITSymbolFlags::Exported);
+        auto error = dylib->define(absoluteSymbols({{mangled, symbol}}));
+
+        if (error) {
+            char *message = LLVMGetErrorMessage(wrap(std::move(error)));
+            *OutError = LLVMPY_CreateString(message);
+            LLVMDisposeErrorMessage(message);
+            return nullptr;
+        }
+    }
+
+    for (size_t element_idx = 0; element_idx < elements_length; element_idx++) {
+        switch (elements[element_idx].element_kind) {
+        case 0: // Adding IR
+        {
+            auto ctxt = std::make_unique<LLVMContext>();
+            SMDiagnostic error;
+            auto module =
+                parseIR(*MemoryBuffer::getMemBuffer(
+                            StringRef(elements[element_idx].value,
+                                      elements[element_idx].value_len),
+                            "ir", false),
+                        error, *ctxt);
+            if (!module) {
+                std::string osbuf;
+                raw_string_ostream os(osbuf);
+                error.print("", os);
+                os.flush();
+                *OutError = LLVMPY_CreateString(os.str().c_str());
+                return nullptr;
+            }
+            auto addError = (*lljit)->addIRModule(
+                *dylib, ThreadSafeModule(std::move(module), std::move(ctxt)));
+            if (addError) {
+                char *message = LLVMGetErrorMessage(wrap(std::move(addError)));
+                *OutError = LLVMPY_CreateString(message);
+                LLVMDisposeErrorMessage(message);
+                return nullptr;
+            }
+        }; break;
+        case 1: // Adding native assembly
+        {
+            auto ctxt = std::make_unique<LLVMContext>();
+            SMDiagnostic error;
+            auto module =
+                parseAssembly(*MemoryBuffer::getMemBuffer(
+                                  StringRef(elements[element_idx].value,
+                                            elements[element_idx].value_len),
+                                  "asm", false),
+                              error,
+
+                              *ctxt);
+            if (!module) {
+                std::string osbuf;
+                raw_string_ostream os(osbuf);
+                error.print("", os);
+                os.flush();
+                *OutError = LLVMPY_CreateString(os.str().c_str());
+                return nullptr;
+            }
+            auto addError = (*lljit)->addIRModule(
+                *dylib, ThreadSafeModule(std::move(module), std::move(ctxt)));
+            if (addError) {
+                char *message = LLVMGetErrorMessage(wrap(std::move(addError)));
+                *OutError = LLVMPY_CreateString(message);
+                LLVMDisposeErrorMessage(message);
+                return nullptr;
+            }
+        }; break;
+        case 2: // Adding object code
+        {
+            auto addError = (*lljit)->addObjectFile(
+                *dylib, MemoryBuffer::getMemBufferCopy(
+                            StringRef(elements[element_idx].value,
+                                      elements[element_idx].value_len)));
+            if (addError) {
+                char *message = LLVMGetErrorMessage(wrap(std::move(addError)));
+                *OutError = LLVMPY_CreateString(message);
+                LLVMDisposeErrorMessage(message);
+                return nullptr;
+            }
+        }; break;
+        case 3: // Adding existing library
+            // Take an empty name to be the current process
+            if (elements[element_idx].value_len) {
+                auto other = (*lljit)->getJITDylibByName(
+                    StringRef(elements[element_idx].value,
+                              elements[element_idx].value_len));
+                if (!other) {
+                    std::string osbuf;
+                    raw_string_ostream os(osbuf);
+                    os << "Failed to find library `"
+                       << StringRef(elements[element_idx].value,
+                                    elements[element_idx].value_len)
+                       << "'.";
+                    os.flush();
+                    *OutError = LLVMPY_CreateString(osbuf.c_str());
+                    return nullptr;
+                }
+                dylib->addToLinkOrder(*other);
+            } else {
+                auto prefix = (*lljit)->getDataLayout().getGlobalPrefix();
+                auto DLSGOrErr =
+                    DynamicLibrarySearchGenerator::GetForCurrentProcess(prefix);
+                if (DLSGOrErr) {
+                    dylib->addGenerator(std::move(*DLSGOrErr));
+                } else {
+                    char *message =
+                        LLVMGetErrorMessage(wrap(DLSGOrErr.takeError()));
+                    *OutError = LLVMPY_CreateString(message);
+                    LLVMDisposeErrorMessage(message);
+                    return nullptr;
+                }
+            }
+            break;
+
+        default:
+            *OutError = LLVMPY_CreateString("Unknown element type");
+            return nullptr;
+        }
+    }
+    auto initError = (*lljit)->initialize(*dylib);
+    if (initError) {
+        char *message = LLVMGetErrorMessage(wrap(std::move(initError)));
+        *OutError = LLVMPY_CreateString(message);
+        LLVMDisposeErrorMessage(message);
+
+        return nullptr;
+    }
+    for (size_t export_idx = 0; export_idx < exports_length; export_idx++) {
+        auto lookup = (*lljit)->lookup(*dylib, exports[export_idx].name);
+        if (!lookup) {
+            char *message =
+                LLVMGetErrorMessage(wrap(std::move(lookup.takeError())));
+            *OutError = LLVMPY_CreateString(message);
+            LLVMDisposeErrorMessage(message);
+            return nullptr;
+        }
+        exports[export_idx].address = lookup->getAddress();
+    }
+    return new JITDylibTracker(*lljit, *dylib,
+                               std::move(dylib->getDefaultResourceTracker()));
+}
+
+API_EXPORT(bool)
+LLVMPY_LLJIT_Dylib_Tracker_Dispose(JITDylibTracker *tracker,
+                                   const char **OutError) {
+    *OutError = nullptr;
+    auto result = false;
+    /* This is undoubtedly a really bad and fragile check. LLVM creates a bunch
+     * of platform support to know if there's deinitializers to run. If we try
+     * to run them when they aren't present, a bunch of junk will be printed to
+     * stderr. So, we're rummaging around for an internal symbol in its platform
+     * support library and skipping the deinitialization if we don't find. */
+    auto lookup = tracker->lljit->lookup(tracker->dylib,
+                                         "__lljit.platform_support_instance");
+    if (lookup) {
+        auto error = tracker->lljit->deinitialize(tracker->dylib);
+        if (error) {
+            char *message = LLVMGetErrorMessage(wrap(std::move(error)));
+            *OutError = LLVMPY_CreateString(message);
+            LLVMDisposeErrorMessage(message);
+            result = true;
+        }
+    } else {
+        /* LLVM's Expected type will abort if you don't read it. */
+        LLVMDisposeErrorMessage(
+            LLVMGetErrorMessage(wrap(std::move(lookup.takeError()))));
+    }
+    auto error = tracker->dylib.clear();
+    if (error && !result) {
+        char *message = LLVMGetErrorMessage(wrap(std::move(error)));
+        *OutError = LLVMPY_CreateString(message);
+        LLVMDisposeErrorMessage(message);
+        result = true;
+    }
+    delete tracker;
+
+    return result;
+}
+
+} // extern "C"

--- a/ffi/orcjit.cpp
+++ b/ffi/orcjit.cpp
@@ -119,6 +119,9 @@ LLVMPY_CreateLLJITCompiler(LLVMTargetMachineRef tm, bool suppressErrors,
                     true);
                 linkingLayer->setAutoClaimResponsibilityForObjectSymbols(true);
             }
+            linkingLayer->registerJITEventListener(
+                *llvm::JITEventListener::createGDBRegistrationListener());
+
             return linkingLayer;
         }
     });

--- a/llvmlite/binding/__init__.py
+++ b/llvmlite/binding/__init__.py
@@ -14,3 +14,4 @@ from .value import *
 from .analysis import *
 from .object_file import *
 from .context import *
+from .orcjit import *

--- a/llvmlite/binding/ffi.py
+++ b/llvmlite/binding/ffi.py
@@ -36,6 +36,8 @@ LLVMTypesIterator = _make_opaque_ref("LLVMTypesIterator")
 LLVMObjectCacheRef = _make_opaque_ref("LLVMObjectCache")
 LLVMObjectFileRef = _make_opaque_ref("LLVMObjectFile")
 LLVMSectionIteratorRef = _make_opaque_ref("LLVMSectionIterator")
+LLVMOrcLLJITRef = _make_opaque_ref("LLVMOrcLLJITRef")
+LLVMOrcDylibTrackerRef = _make_opaque_ref("LLVMOrcDylibTrackerRef")
 
 
 class _LLVMLock:

--- a/llvmlite/binding/orcjit.py
+++ b/llvmlite/binding/orcjit.py
@@ -1,0 +1,329 @@
+import ctypes
+from ctypes import POINTER, c_bool, c_char_p, c_uint8, c_uint64, c_size_t
+
+from llvmlite.binding import ffi, targets
+
+
+class _LinkElement(ctypes.Structure):
+    _fields_ = [("element_kind", c_uint8),
+                ("value", c_char_p),
+                ("value_len", c_size_t)]
+
+
+class _SymbolAddress(ctypes.Structure):
+    _fields_ = [("name", c_char_p), ("address", c_uint64)]
+
+
+class JITLibraryBuilder:
+    """
+    Create a library for linking by OrcJIT
+
+    OrcJIT operates like a linker: a number of compilation units and
+    dependencies are collected together and linked into a single dynamic library
+    that can export functions to other libraries or to be consumed directly as
+    entry points into JITted code. The native OrcJIT has a lot of memory
+    management complications so this API is designed to work well with Python's
+    garbage collection.
+
+    The creation of a new library is a bit like a linker command line where
+    compilation units, mostly as LLVM IR, and previously constructed libraries
+    are linked together, then loaded into memory, and the addresses of exported
+    symbols are extracted. Any static initializers are run and the exported
+    addresses and a resource tracker is produced. As long as the resource
+    tracker is referenced somewhere in Python, the exported addresses will be
+    valid. Once the resource tracker is garbage collected, the static
+    destructors will run and library will be unloaded from memory.
+    """
+    def __init__(self):
+        self.__entries = []
+        self.__exports = set()
+        self.__imports = {}
+
+    def add_ir(self, llvmir):
+        """
+        Adds a compilation unit to the library using LLVM IR as the input
+        format.
+
+        This takes a string or an object that can be converted to a string,
+        including IRBuilder, that contains LLVM IR.
+        """
+        self.__entries.append((0, str(llvmir).encode('utf-8')))
+        return self
+
+    def add_native_assembly(self, asm):
+        """
+        Adds a compilation unit to the library using native assembly as the
+        input format.
+
+        This takes a string or an object that can be converted to a string that
+        contains native assembly, which will be
+        parsed by LLVM.
+        """
+        self.__entries.append((1, str(asm).encode('utf-8')))
+        return self
+
+    def add_object_img(self, data):
+        """
+        Adds a compilation unit to the library using pre-compiled object code.
+
+        This takes the bytes of the contents of an object artifact which will be
+        loaded by LLVM.
+        """
+        self.__entries.append((2, bytes(data)))
+        return self
+
+    def add_object_file(self, file_path):
+        """
+        Adds a compilation unit to the library using pre-compiled object file.
+
+        This takes a string or path-like object that references an object file
+        which will be loaded by LLVM.
+        """
+        with open(file_path, "rb") as f:
+            self.__entries.append((2, f.read()))
+        return self
+
+    def add_jit_library(self, name):
+        """
+        Adds an existing JIT library as prerequisite.
+
+        The name of the library must match the one provided in a previous link
+        command.
+        """
+        self.__entries.append((3, str(name).encode('utf-8')))
+        return self
+
+    def add_current_process(self):
+        """
+        Allows the JITted library to access symbols in the current binary.
+
+        That is, it allows exporting the current binary's symbols, including
+        loaded libraries, as imports to the JITted
+        library.
+        """
+        self.__entries.append((3, b''))
+        return self
+
+    def import_symbol(self, name, address):
+        """
+        Register the *address* of global symbol *name*.  This will make
+        it usable (e.g. callable) from LLVM-compiled functions.
+        """
+        self.__imports[str(name)] = c_uint64(address)
+        return self
+
+    def export_symbol(self, name):
+        """
+        During linking, extract the address of a symbol that was defined in one
+        of the compilation units.
+
+        This allows getting symbols, functions or global variables, out of the
+        JIT linked library. The addresses will be
+        available when the link method is called.
+        """
+        self.__exports.add(str(name))
+        return self
+
+    def link(self, lljit, library_name):
+        """
+        Link all the current compilation units into a JITted library and extract
+        the address of exported symbols.
+
+        An instance of the OrcJIT instance must be provided and this will be the
+        scope that is used to find other JITted libraries that are dependencies
+        and also be the place where this library will be defined.
+
+        After linking, the method will return a resource tracker that keeps the
+        library alive. This tracker also knows the addresses of any exported
+        symbols that were requested.
+
+        The addresses will be valid as long as the resource tracker is
+        referenced.
+
+        When the resource tracker is destroyed, the library will be cleaned up,
+        however, the name of the library cannot be reused.
+        """
+        assert not lljit.closed, "Cannot add to closed JIT"
+        library_name = str(library_name).encode('utf-8')
+        assert len(library_name) > 0, "Library cannot be empty"
+        elements = (_LinkElement * len(self.__entries))()
+        for idx, (kind, value) in enumerate(self.__entries):
+            elements[idx].element_kind = c_uint8(kind)
+            elements[idx].value = c_char_p(value)
+            elements[idx].value_len = c_size_t(len(value))
+        exports = (_SymbolAddress * len(self.__exports))()
+        for idx, name in enumerate(self.__exports):
+            exports[idx].name = name.encode('utf-8')
+
+        imports = (_SymbolAddress * len(self.__imports))()
+        for idx, (name, addr) in enumerate(self.__imports.items()):
+            imports[idx].name = name.encode('utf-8')
+            imports[idx].address = addr
+
+        with ffi.OutputString() as outerr:
+            tracker = lljit._capi.LLVMPY_LLJIT_Link(
+                lljit._ptr,
+                library_name,
+                ctypes.cast(elements,POINTER(_LinkElement)),
+                len(self.__entries),
+                ctypes.cast(imports, POINTER(_SymbolAddress)),
+                len(self.__imports),
+                ctypes.cast(exports, POINTER(_SymbolAddress)),
+                len(self.__exports),
+                outerr)
+            if not tracker:
+                raise RuntimeError(str(outerr))
+        return ResourceTracker(tracker, {name: exports[idx].address
+                                         for idx, name in
+                                         enumerate(self.__exports)})
+
+
+class ResourceTracker(ffi.ObjectRef):
+    """
+    A resource tracker is created for each loaded JIT library and keeps the
+    module alive.
+
+    OrcJIT supports unloading libraries that are no longer used. This resource
+    tracker should be stored in any object that reference functions or constants
+    for a JITted library. When all references to the resource tracker are
+    dropped, this will trigger LLVM to unload the library and destroy any
+    functions.
+
+    Failure to keep resource trackers while holding on to function can result in
+    crashes or memory corruption.
+
+    LLVM internally tracks references between different libraries, so only
+    "leaf" libraries need to be tracked.
+    """
+    def __init__(self, ptr, addresses):
+        self.__addresses = addresses
+        ffi.ObjectRef.__init__(self, ptr)
+
+    def __getitem__(self, item):
+        """
+        Get the address of an exported symbol as an integer
+        """
+        return self.__addresses[item]
+
+    def _dispose(self):
+        with ffi.OutputString() as outerr:
+            if self._capi.LLVMPY_LLJIT_Dylib_Tracker_Dispose(self, outerr):
+                raise RuntimeError(str(outerr))
+
+
+class LLJIT(ffi.ObjectRef):
+    """
+    A OrcJIT-based LLVM JIT engine that can compile and run LLVM IR as a
+    collection of JITted dynamic libraries
+
+    The C++ OrcJIT API has a lot of memory ownership patterns that do not work
+    with Python. This API attempts to provide ones that are safe at the expense
+    of some features. Each LLJIT instance is a collection of JIT-compiled
+    libraries. In the C++ API, there is a "main" library; this API does not
+    provide access to the main library. Use the JITLibraryBuilder to create a
+    new named library instead.
+    """
+    def __init__(self, ptr):
+        self._td = None
+        ffi.ObjectRef.__init__(self, ptr)
+
+    def lookup(self, dylib, fn):
+        """
+        Find a function in this dynamic library and construct a new tracking
+        object for it
+
+        If the library or function do not exist, an exception will occur.
+
+        Parameters
+        ----------
+        dylib : str or None
+           the name of the library containing the symbol
+        fn : str
+           the name of the function to get
+        """
+        assert not self.closed, "Cannot lookup in closed JIT"
+        address = ctypes.c_uint64()
+        with ffi.OutputString() as outerr:
+            tracker = ffi.lib.LLVMPY_LLJITLookup(self,
+                                                 dylib.encode("utf-8"),
+                                                 fn.encode("utf-8"),
+                                                 ctypes.byref(address),
+                                                 outerr)
+            if not tracker:
+                raise RuntimeError(str(outerr))
+
+        return ResourceTracker(tracker, {fn: address.value})
+
+    @property
+    def target_data(self):
+        """
+        The TargetData for this LLJIT instance.
+        """
+        if self._td is not None:
+            return self._td
+        ptr = ffi.lib.LLVMPY_LLJITGetDataLayout(self)
+        self._td = targets.TargetData(ptr)
+        self._td._owned = True
+        return self._td
+
+    def _dispose(self):
+        if self._td is not None:
+            self._td.detach()
+        self._capi.LLVMPY_LLJITDispose(self)
+
+
+def create_lljit_compiler(target_machine=None):
+    """
+    Create an LLJIT instance
+    """
+    with ffi.OutputString() as outerr:
+        lljit = ffi.lib.LLVMPY_CreateLLJITCompiler(target_machine, outerr)
+        if not lljit:
+            raise RuntimeError(str(outerr))
+
+    return LLJIT(lljit)
+
+
+ffi.lib.LLVMPY_LLJITLookup.argtypes = [
+    ffi.LLVMOrcLLJITRef,
+    c_char_p,
+    c_char_p,
+    POINTER(c_uint64),
+    POINTER(c_char_p),
+]
+ffi.lib.LLVMPY_LLJITLookup.restype = ffi.LLVMOrcDylibTrackerRef
+
+ffi.lib.LLVMPY_LLJITGetDataLayout.argtypes = [
+    ffi.LLVMOrcLLJITRef,
+]
+ffi.lib.LLVMPY_LLJITGetDataLayout.restype = ffi.LLVMTargetDataRef
+
+ffi.lib.LLVMPY_CreateLLJITCompiler.argtypes = [
+    ffi.LLVMTargetMachineRef,
+    POINTER(c_char_p),
+]
+ffi.lib.LLVMPY_CreateLLJITCompiler.restype = ffi.LLVMOrcLLJITRef
+
+ffi.lib.LLVMPY_LLJITDispose.argtypes = [
+    ffi.LLVMOrcLLJITRef,
+]
+
+
+ffi.lib.LLVMPY_LLJIT_Link.argtypes = [
+    ffi.LLVMOrcLLJITRef,
+    c_char_p,
+    POINTER(_LinkElement),
+    c_size_t,
+    POINTER(_SymbolAddress),
+    c_size_t,
+    POINTER(_SymbolAddress),
+    c_size_t,
+    POINTER(c_char_p)
+]
+ffi.lib.LLVMPY_LLJIT_Link.restype = ffi.LLVMOrcDylibTrackerRef
+
+ffi.lib.LLVMPY_LLJIT_Dylib_Tracker_Dispose.argtypes = [
+    ffi.LLVMOrcDylibTrackerRef,
+    POINTER(c_char_p)
+]
+ffi.lib.LLVMPY_LLJIT_Dylib_Tracker_Dispose.restype = c_bool

--- a/llvmlite/binding/orcjit.py
+++ b/llvmlite/binding/orcjit.py
@@ -272,12 +272,14 @@ class LLJIT(ffi.ObjectRef):
         self._capi.LLVMPY_LLJITDispose(self)
 
 
-def create_lljit_compiler(target_machine=None):
+def create_lljit_compiler(target_machine=None, suppress_errors=False):
     """
     Create an LLJIT instance
     """
     with ffi.OutputString() as outerr:
-        lljit = ffi.lib.LLVMPY_CreateLLJITCompiler(target_machine, outerr)
+        lljit = ffi.lib.LLVMPY_CreateLLJITCompiler(target_machine,
+                                                   suppress_errors,
+                                                   outerr)
         if not lljit:
             raise RuntimeError(str(outerr))
 
@@ -300,6 +302,7 @@ ffi.lib.LLVMPY_LLJITGetDataLayout.restype = ffi.LLVMTargetDataRef
 
 ffi.lib.LLVMPY_CreateLLJITCompiler.argtypes = [
     ffi.LLVMTargetMachineRef,
+    c_bool,
     POINTER(c_char_p),
 ]
 ffi.lib.LLVMPY_CreateLLJITCompiler.restype = ffi.LLVMOrcLLJITRef

--- a/llvmlite/binding/orcjit.py
+++ b/llvmlite/binding/orcjit.py
@@ -272,7 +272,7 @@ class LLJIT(ffi.ObjectRef):
         self._capi.LLVMPY_LLJITDispose(self)
 
 
-def create_lljit_compiler(target_machine=None,
+def create_lljit_compiler(target_machine=None, *,
                           use_jit_link=False,
                           suppress_errors=False):
     """

--- a/llvmlite/binding/orcjit.py
+++ b/llvmlite/binding/orcjit.py
@@ -164,11 +164,11 @@ class JITLibraryBuilder:
             tracker = lljit._capi.LLVMPY_LLJIT_Link(
                 lljit._ptr,
                 library_name,
-                ctypes.cast(elements,POINTER(_LinkElement)),
+                elements,
                 len(self.__entries),
-                ctypes.cast(imports, POINTER(_SymbolAddress)),
+                imports,
                 len(self.__imports),
-                ctypes.cast(exports, POINTER(_SymbolAddress)),
+                exports,
                 len(self.__exports),
                 outerr)
             if not tracker:
@@ -189,8 +189,8 @@ class ResourceTracker(ffi.ObjectRef):
     dropped, this will trigger LLVM to unload the library and destroy any
     functions.
 
-    Failure to keep resource trackers while holding on to function can result in
-    crashes or memory corruption.
+    Failure to keep resource trackers while calling a function or accessing a
+    symbol can result in crashes or memory corruption.
 
     LLVM internally tracks references between different libraries, so only
     "leaf" libraries need to be tracked.

--- a/llvmlite/binding/orcjit.py
+++ b/llvmlite/binding/orcjit.py
@@ -272,13 +272,16 @@ class LLJIT(ffi.ObjectRef):
         self._capi.LLVMPY_LLJITDispose(self)
 
 
-def create_lljit_compiler(target_machine=None, suppress_errors=False):
+def create_lljit_compiler(target_machine=None,
+                          use_jit_link=False,
+                          suppress_errors=False):
     """
     Create an LLJIT instance
     """
     with ffi.OutputString() as outerr:
         lljit = ffi.lib.LLVMPY_CreateLLJITCompiler(target_machine,
                                                    suppress_errors,
+                                                   use_jit_link,
                                                    outerr)
         if not lljit:
             raise RuntimeError(str(outerr))
@@ -302,6 +305,7 @@ ffi.lib.LLVMPY_LLJITGetDataLayout.restype = ffi.LLVMTargetDataRef
 
 ffi.lib.LLVMPY_CreateLLJITCompiler.argtypes = [
     ffi.LLVMTargetMachineRef,
+    c_bool,
     c_bool,
     POINTER(c_char_p),
 ]

--- a/llvmlite/tests/test_binding.py
+++ b/llvmlite/tests/test_binding.py
@@ -1145,8 +1145,9 @@ class TestMCJit(BaseTest, JITWithTMTestMixin):
 class TestOrcLLJIT(BaseTest):
 
     def jit(self, asm=asm_sum, func_name="sum", target_machine=None,
-            add_process=False, func_type=CFUNCTYPE(c_int, c_int, c_int)):
-        lljit = llvm.create_lljit_compiler(target_machine)
+            add_process=False, func_type=CFUNCTYPE(c_int, c_int, c_int),
+            suppress_errors=False):
+        lljit = llvm.create_lljit_compiler(target_machine, suppress_errors)
         builder = llvm.JITLibraryBuilder()
         if add_process:
             builder.add_current_process()
@@ -1264,7 +1265,7 @@ class TestOrcLLJIT(BaseTest):
         # enabled searching the current process for symbols.
         msg = 'Failed to materialize symbols:.*getversion'
         with self.assertRaisesRegex(RuntimeError, msg):
-            self.jit(asm_getversion, "getversion")
+            self.jit(asm_getversion, "getversion", suppress_errors=True)
 
     def test_lookup_current_process_symbol(self):
         self.jit(asm_getversion, "getversion", None, True)

--- a/llvmlite/tests/test_binding.py
+++ b/llvmlite/tests/test_binding.py
@@ -1,5 +1,6 @@
 import ctypes
-from ctypes import CFUNCTYPE, c_int
+import threading
+from ctypes import CFUNCTYPE, c_int, c_int32
 from ctypes.util import find_library
 import gc
 import locale
@@ -71,6 +72,31 @@ asm_mul = r"""
     define i32 @mul(i32 %.1, i32 %.2) {{
       %.3 = mul i32 %.1, %.2
       ret i32 %.3
+    }}
+    """
+
+asm_square_sum = r"""
+    ; ModuleID = '<string>'
+    target triple = "{triple}"
+    @mul_glob = global i32 0
+
+    declare i32 @sum(i32, i32)
+    define i32 @square_sum(i32 %.1, i32 %.2) {{
+      %.3 = call i32 @sum(i32 %.1, i32 %.2)
+      %.4 = mul i32 %.3, %.3
+      ret i32 %.4
+    }}
+    """
+
+asm_getversion = r"""
+    ; ModuleID = '<string>'
+    target triple = "{triple}"
+
+    declare i8* @Py_GetVersion()
+
+    define void @getversion(i32 %.1, i32 %.2) {{
+      %1 = call i8* @Py_GetVersion()
+      ret void
     }}
     """
 
@@ -260,6 +286,35 @@ asm_global_ctors = r"""
     target triple = "{triple}"
 
     @A = global i32 undef
+
+    define void @ctor_A()
+    {{
+      store i32 10, i32* @A
+      ret void
+    }}
+
+    define void @dtor_A()
+    {{
+      store i32 20, i32* @A
+      ret void
+    }}
+
+    define i32 @foo()
+    {{
+      %.2 = load i32, i32* @A
+      %.3 = add i32 %.2, 2
+      ret i32 %.3
+    }}
+
+    @llvm.global_ctors = appending global [1 x {{i32, void ()*, i8*}}] [{{i32, void ()*, i8*}} {{i32 0, void ()* @ctor_A, i8* null}}]
+    @llvm.global_dtors = appending global [1 x {{i32, void ()*, i8*}}] [{{i32, void ()*, i8*}} {{i32 0, void ()* @dtor_A, i8* null}}]
+    """  # noqa E501
+
+asm_ext_ctors = r"""
+    ; ModuleID = "<string>"
+    target triple = "{triple}"
+
+    @A = external global i32
 
     define void @ctor_A()
     {{
@@ -640,7 +695,7 @@ class TestMisc(BaseTest):
     def test_version(self):
         major, minor, patch = llvm.llvm_version_info
         # one of these can be valid
-        valid = [(11,), (12, ), (13, ), (14, )]
+        valid = [(14, )]
         self.assertIn((major,), valid)
         self.assertIn(patch, range(10))
 
@@ -1085,6 +1140,186 @@ class TestMCJit(BaseTest, JITWithTMTestMixin):
         if target_machine is None:
             target_machine = self.target_machine(jit=True)
         return llvm.create_mcjit_compiler(mod, target_machine)
+
+
+class TestOrcLLJIT(BaseTest):
+
+    def jit(self, asm=asm_sum, func_name="sum", target_machine=None,
+            add_process=False, func_type=CFUNCTYPE(c_int, c_int, c_int)):
+        lljit = llvm.create_lljit_compiler(target_machine)
+        builder = llvm.JITLibraryBuilder()
+        if add_process:
+            builder.add_current_process()
+        rt = builder\
+            .add_ir(asm.format(triple=llvm.get_default_triple()))\
+            .export_symbol(func_name)\
+            .link(lljit, func_name)
+        cfptr = rt[func_name]
+        self.assertTrue(cfptr)
+        return lljit, rt, func_type(cfptr)
+
+    # From test_dylib_symbols
+    def test_define_symbol(self):
+        lljit = llvm.create_lljit_compiler()
+        rt = llvm.JITLibraryBuilder().import_symbol("__xyzzy", 1234)\
+            .export_symbol("__xyzzy").link(lljit, "foo")
+        self.assertEqual(rt["__xyzzy"], 1234)
+
+    def test_lookup_undefined_symbol_fails(self):
+        lljit = llvm.create_lljit_compiler()
+        with self.assertRaisesRegex(RuntimeError, 'No such library'):
+            lljit.lookup("foo", "__foobar")
+        rt = llvm.JITLibraryBuilder().import_symbol("__xyzzy", 1234)\
+            .export_symbol("__xyzzy").link(lljit, "foo")
+        self.assertNotEqual(rt["__xyzzy"], 0)
+        with self.assertRaisesRegex(RuntimeError,
+                                    'Symbols not found.*__foobar'):
+            lljit.lookup("foo", "__foobar")
+
+    def test_run_code(self):
+        (lljit, rt, cfunc) = self.jit()
+        with lljit:
+            res = cfunc(2, -5)
+            self.assertEqual(-3, res)
+
+    def test_close(self):
+        (lljit, rt, cfunc) = self.jit()
+        lljit.close()
+        lljit.close()
+        with self.assertRaises(AssertionError):
+            lljit.lookup("foo", "fn")
+
+    def test_with(self):
+        (lljit, rt, cfunc) = self.jit()
+        with lljit:
+            pass
+        with self.assertRaises(RuntimeError):
+            with lljit:
+                pass
+        with self.assertRaises(AssertionError):
+            lljit.lookup("foo", "fn")
+
+    def test_add_ir_module(self):
+        (lljit, rt_sum, cfunc_sum) = self.jit()
+        rt_mul = llvm.JITLibraryBuilder() \
+            .add_ir(asm_mul.format(triple=llvm.get_default_triple())) \
+            .export_symbol("mul") \
+            .link(lljit, "mul")
+        res = CFUNCTYPE(c_int, c_int, c_int)(rt_mul["mul"])(2, -5)
+        self.assertEqual(-10, res)
+        self.assertNotEqual(lljit.lookup("sum", "sum")["sum"], 0)
+        self.assertNotEqual(lljit.lookup("mul", "mul")["mul"], 0)
+        with self.assertRaises(RuntimeError):
+            lljit.lookup("sum", "mul")
+        with self.assertRaises(RuntimeError):
+            lljit.lookup("mul", "sum")
+
+    def test_remove_module(self):
+        (lljit, rt_sum, _) = self.jit()
+        del rt_sum
+        gc.collect()
+        with self.assertRaises(RuntimeError):
+            lljit.lookup("sum", "sum")
+        lljit.close()
+
+    def test_lib_depends(self):
+        (lljit, rt_sum, cfunc_sum) = self.jit()
+        rt_mul = llvm.JITLibraryBuilder() \
+            .add_ir(asm_square_sum.format(triple=llvm.get_default_triple())) \
+            .export_symbol("square_sum") \
+            .add_jit_library("sum") \
+            .link(lljit, "square_sum")
+        res = CFUNCTYPE(c_int, c_int, c_int)(rt_mul["square_sum"])(2, -5)
+        self.assertEqual(9, res)
+
+    def test_target_data(self):
+        (lljit, rt, _) = self.jit()
+        td = lljit.target_data
+        # A singleton is returned
+        self.assertIs(lljit.target_data, td)
+        str(td)
+        del lljit
+        str(td)
+
+    def test_global_ctors_dtors(self):
+        # test issue #303
+        # (https://github.com/numba/llvmlite/issues/303)
+        shared_value = c_int32(0)
+        lljit = llvm.create_lljit_compiler()
+        builder = llvm.JITLibraryBuilder()
+        rt = builder \
+            .add_ir(asm_ext_ctors.format(triple=llvm.get_default_triple())) \
+            .import_symbol("A", ctypes.addressof(shared_value)) \
+            .export_symbol("foo") \
+            .link(lljit, "foo")
+        foo = rt["foo"]
+        self.assertTrue(foo)
+        self.assertEqual(CFUNCTYPE(c_int)(foo)(), 12)
+        del rt
+        self.assertNotEqual(shared_value.value, 20)
+
+    def test_lookup_current_process_symbol_fails(self):
+        # An attempt to lookup a symbol in the current process (Py_GetVersion,
+        # in this case) should fail with an appropriate error if we have not
+        # enabled searching the current process for symbols.
+        msg = 'Failed to materialize symbols:.*getversion'
+        with self.assertRaisesRegex(RuntimeError, msg):
+            self.jit(asm_getversion, "getversion")
+
+    def test_lookup_current_process_symbol(self):
+        self.jit(asm_getversion, "getversion", None, True)
+
+    def test_thread_safe(self):
+        lljit = llvm.create_lljit_compiler()
+        llvm_ir = asm_sum.format(triple=llvm.get_default_triple())
+
+        def compile_many(i):
+            def do_work():
+                tracking = []
+                for c in range(50):
+                    tracking.append(llvm.JITLibraryBuilder()
+                                    .add_ir(llvm_ir)
+                                    .export_symbol("sum")
+                                    .link(lljit, f"sum_{i}_{c}"))
+
+            return do_work
+
+        ths = [threading.Thread(target=compile_many(i))
+               for i in range(os.cpu_count())]
+        for th in ths:
+            th.start()
+        for th in ths:
+            th.join()
+
+    def test_add_object_file(self):
+        target_machine = self.target_machine(jit=False)
+        mod = self.module()
+        lljit = llvm.create_lljit_compiler(target_machine)
+        rt = llvm.JITLibraryBuilder()\
+            .add_object_img(target_machine.emit_object(mod))\
+            .export_symbol("sum")\
+            .link(lljit, "sum")
+        sum = CFUNCTYPE(c_int, c_int, c_int)(rt["sum"])
+        self.assertEqual(sum(2, 3), 5)
+
+    def test_add_object_file_from_filesystem(self):
+        target_machine = self.target_machine(jit=False)
+        mod = self.module()
+        obj_bin = target_machine.emit_object(mod)
+        temp_desc, temp_path = mkstemp()
+
+        try:
+            with os.fdopen(temp_desc, "wb") as f:
+                f.write(obj_bin)
+            lljit = llvm.create_lljit_compiler(target_machine)
+            rt = llvm.JITLibraryBuilder() \
+                .add_object_file(temp_path) \
+                .export_symbol("sum") \
+                .link(lljit, "sum")
+            sum = CFUNCTYPE(c_int, c_int, c_int)(rt["sum"])
+            self.assertEqual(sum(2, 3), 5)
+        finally:
+            os.unlink(temp_path)
 
 
 class TestValueRef(BaseTest):

--- a/llvmlite/tests/test_binding.py
+++ b/llvmlite/tests/test_binding.py
@@ -1147,7 +1147,8 @@ class TestOrcLLJIT(BaseTest):
     def jit(self, asm=asm_sum, func_name="sum", target_machine=None,
             add_process=False, func_type=CFUNCTYPE(c_int, c_int, c_int),
             suppress_errors=False):
-        lljit = llvm.create_lljit_compiler(target_machine, suppress_errors)
+        lljit = llvm.create_lljit_compiler(target_machine, False,
+                                           suppress_errors)
         builder = llvm.JITLibraryBuilder()
         if add_process:
             builder.add_current_process()
@@ -1176,6 +1177,14 @@ class TestOrcLLJIT(BaseTest):
         with self.assertRaisesRegex(RuntimeError,
                                     'Symbols not found.*__foobar'):
             lljit.lookup("foo", "__foobar")
+
+    def test_jit_link(self):
+        if sys.platform == "win32":
+            with self.assertRaisesRegex(RuntimeError,
+                                        'JITLink .* Windows'):
+                llvm.create_lljit_compiler(use_jit_link=True)
+        else:
+            self.assertIsNotNone(llvm.create_lljit_compiler(use_jit_link=True))
 
     def test_run_code(self):
         (lljit, rt, cfunc) = self.jit()

--- a/llvmlite/tests/test_binding.py
+++ b/llvmlite/tests/test_binding.py
@@ -1147,8 +1147,9 @@ class TestOrcLLJIT(BaseTest):
     def jit(self, asm=asm_sum, func_name="sum", target_machine=None,
             add_process=False, func_type=CFUNCTYPE(c_int, c_int, c_int),
             suppress_errors=False):
-        lljit = llvm.create_lljit_compiler(target_machine, False,
-                                           suppress_errors)
+        lljit = llvm.create_lljit_compiler(target_machine,
+                                           use_jit_link=False,
+                                           suppress_errors=suppress_errors)
         builder = llvm.JITLibraryBuilder()
         if add_process:
             builder.add_current_process()


### PR DESCRIPTION
This mainly uses LLJIT through the C++ API avaiable in LLVM 14.

Create an API that allows creation of individual JITDylib as garbage-tracked Python objects so that life-cycle management of JITted code can be easily performed in Python.

Based-on: Graham Markall <gmarkall@nvidia.com>