### PR TITLE
Fix incorrect `byval` and other attributes on LLVM 14

### DIFF
--- a/llvmlite/binding/analysis.py
+++ b/llvmlite/binding/analysis.py
@@ -4,7 +4,6 @@ A collection of analysis utilities
 
 from ctypes import POINTER, c_char_p, c_int
 
-from llvmlite import ir
 from llvmlite.binding import ffi
 from llvmlite.binding.module import parse_assembly
 
@@ -17,6 +16,7 @@ def get_function_cfg(func, show_inst=True):
     are printed.
     """
     assert func is not None
+    from llvmlite import ir
     if isinstance(func, ir.Function):
         mod = parse_assembly(str(func.module))
         func = mod.get_function(func.name)

--- a/llvmlite/ir/instructions.py
+++ b/llvmlite/ir/instructions.py
@@ -133,7 +133,7 @@ class CallInstr(Instruction):
     def _descr(self, buf, add_metadata):
         def descr_arg(i, a):
             if i in self.arg_attributes:
-                attrs = ' '.join(self.arg_attributes[i]._to_list()) + ' '
+                attrs = ' '.join(self.arg_attributes[i]._to_list(a.type)) + ' '
             else:
                 attrs = ''
             return '{0} {1}{2}'.format(a.type, attrs, a.get_reference())
@@ -155,13 +155,19 @@ class CallInstr(Instruction):
         if self.tail:
             tail_marker = "{0} ".format(self.tail)
 
+        fn_attrs = ' ' + ' '.join(self.attributes._to_list(fnty.return_type))\
+            if self.attributes else ''
+
+        fm_attrs = ' ' + ' '.join(self.fastmath._to_list(fnty.return_type))\
+            if self.fastmath else ''
+
         buf.append("{tail}{op}{fastmath} {callee}({args}){attr}{meta}\n".format(
             tail=tail_marker,
             op=self.opname,
             callee=callee_ref,
-            fastmath=''.join([" " + attr for attr in self.fastmath]),
+            fastmath=fm_attrs,
             args=args,
-            attr=''.join([" " + attr for attr in self.attributes]),
+            attr=fn_attrs,
             meta=(self._stringify_metadata(leading_comma=True)
                   if add_metadata else ""),
         ))

--- a/llvmlite/ir/values.py
+++ b/llvmlite/ir/values.py
@@ -1020,18 +1020,30 @@ class Function(GlobalValue):
 
 
 class ArgumentAttributes(AttributeSet):
-    _known = MappingProxyType({'byval': True,
-                               'inalloca': False,
-                               'inreg': False,
-                               'nest': False,
-                               'noalias': False,
-                               'nocapture': False,
-                               'nonnull': False,
-                               'returned': False,
-                               'signext': False,
-                               'sret': True,
-                               'zeroext': False
-                               })
+    # List from
+    # https://releases.llvm.org/14.0.0/docs/LangRef.html#parameter-attributes
+    _known = MappingProxyType({
+        'byref': True,
+        'byval': True,
+        'elementtype': True,
+        'immarg': False,
+        'inalloca': True,
+        'inreg': False,
+        'nest': False,
+        'noalias': False,
+        'nocapture': False,
+        'nofree': False,
+        'nonnull': False,
+        'noundef': False,
+        'preallocated': True,
+        'returned': False,
+        'signext': False,
+        'sret': True,
+        'swiftasync': False,
+        'swifterror': False,
+        'swiftself': False,
+        'zeroext': False,
+    })
 
     def __init__(self, args=()):
         self._align = 0

--- a/llvmlite/ir/values.py
+++ b/llvmlite/ir/values.py
@@ -872,7 +872,7 @@ class AttributeSet(set):
         return super(AttributeSet, self).add(name)
 
     def _to_list(self, typ):
-        return list(map(lambda a: self._expand(a, typ), iter(sorted(self))))
+        return [self._expand(i, typ) for i in sorted(self)]
 
 
 class FunctionAttributes(AttributeSet):

--- a/llvmlite/ir/values.py
+++ b/llvmlite/ir/values.py
@@ -6,11 +6,11 @@ Instructions are in the instructions module.
 import functools
 import string
 import re
+from types import MappingProxyType
 
 from llvmlite.ir import values, types, _utils
 from llvmlite.ir._utils import (_StrCaching, _StringReferenceCaching,
                                 _HasMetadata)
-
 
 _VALID_CHARS = (frozenset(map(ord, string.ascii_letters)) |
                 frozenset(map(ord, string.digits)) |
@@ -863,14 +863,16 @@ class AttributeSet(set):
         for name in args:
             self.add(name)
 
+    def _expand(self, name, typ):
+        return name
+
     def add(self, name):
         if name not in self._known:
             raise ValueError('unknown attr {!r} for {}'.format(name, self))
         return super(AttributeSet, self).add(name)
 
-    def __iter__(self):
-        # In sorted order
-        return iter(sorted(super(AttributeSet, self).__iter__()))
+    def _to_list(self, typ):
+        return list(map(lambda a: self._expand(a, typ), iter(sorted(self))))
 
 
 class FunctionAttributes(AttributeSet):
@@ -914,15 +916,15 @@ class FunctionAttributes(AttributeSet):
         assert val is None or isinstance(val, GlobalValue)
         self._personality = val
 
-    def __repr__(self):
-        attrs = list(self)
+    def _to_list(self, ret_type):
+        attrs = super()._to_list(ret_type)
         if self.alignstack:
             attrs.append('alignstack({0:d})'.format(self.alignstack))
         if self.personality:
             attrs.append('personality {persty} {persfn}'.format(
                 persty=self.personality.type,
                 persfn=self.personality.get_reference()))
-        return ' '.join(attrs)
+        return attrs
 
 
 class Function(GlobalValue):
@@ -975,8 +977,8 @@ class Function(GlobalValue):
         ret = self.return_value
         args = ", ".join(str(a) for a in self.args)
         name = self.get_reference()
-        attrs = self.attributes
-        attrs = ' {}'.format(attrs) if attrs else ''
+        attrs = ' ' + ' '.join(self.attributes._to_list(
+            self.ftype.return_type)) if self.attributes else ''
         if any(self.args):
             vararg = ', ...' if self.ftype.var_arg else ''
         else:
@@ -1018,15 +1020,32 @@ class Function(GlobalValue):
 
 
 class ArgumentAttributes(AttributeSet):
-    _known = frozenset(['byval', 'inalloca', 'inreg', 'nest', 'noalias',
-                        'nocapture', 'nonnull', 'returned', 'signext',
-                        'sret', 'zeroext'])
+    _known = MappingProxyType({'byval': True,
+                               'inalloca': False,
+                               'inreg': False,
+                               'nest': False,
+                               'noalias': False,
+                               'nocapture': False,
+                               'nonnull': False,
+                               'returned': False,
+                               'signext': False,
+                               'sret': True,
+                               'zeroext': False
+                               })
 
     def __init__(self, args=()):
         self._align = 0
         self._dereferenceable = 0
         self._dereferenceable_or_null = 0
         super(ArgumentAttributes, self).__init__(args)
+
+    def _expand(self, name, typ):
+        import llvmlite.binding
+        if (llvmlite.binding.llvm_version_info[0] >= 14 and
+                self._known.get(name)):
+            return f"{name}({typ.pointee})"
+        else:
+            return name
 
     @property
     def align(self):
@@ -1055,8 +1074,8 @@ class ArgumentAttributes(AttributeSet):
         assert isinstance(val, int) and val >= 0
         self._dereferenceable_or_null = val
 
-    def _to_list(self):
-        attrs = sorted(self)
+    def _to_list(self, typ):
+        attrs = super()._to_list(typ)
         if self.align:
             attrs.append('align {0:d}'.format(self.align))
         if self.dereferenceable:
@@ -1088,7 +1107,7 @@ class Argument(_BaseArgument):
     """
 
     def __str__(self):
-        attrs = self.attributes._to_list()
+        attrs = self.attributes._to_list(self.type)
         if attrs:
             return "{0} {1} {2}".format(self.type, ' '.join(attrs),
                                         self.get_reference())
@@ -1102,7 +1121,7 @@ class ReturnValue(_BaseArgument):
     """
 
     def __str__(self):
-        attrs = self.attributes._to_list()
+        attrs = self.attributes._to_list(self.type)
         if attrs:
             return "{0} {1}".format(' '.join(attrs), self.type)
         else:

--- a/llvmlite/tests/test_ir.py
+++ b/llvmlite/tests/test_ir.py
@@ -1827,10 +1827,14 @@ insert_block:
 
             return str(module)
 
+        llvm_major = llvm.llvm_version_info[0]
+        if llvm_major >= 14:
+            supplemental = ('byref', 'swiftasync', 'elementtype')
+        else:
+            supplemental = ()
+
         for attr_name in (
-            'byref',
             'byval',
-            'elementtype',
             'immarg',
             'inalloca',
             'inreg',
@@ -1843,11 +1847,10 @@ insert_block:
             'preallocated',
             'returned',
             'signext',
-            'swiftasync',
             'swifterror',
             'swiftself',
             'zeroext',
-        ):
+        ) + supplemental:
             # If this parses, we emitted the right byval attribute format
             llvm.parse_assembly(gen_code(attr_name))
         # sret doesn't fit this pattern and is tested in test_call_attributes

--- a/llvmlite/tests/test_ir.py
+++ b/llvmlite/tests/test_ir.py
@@ -84,12 +84,19 @@ class TestBase(TestCase):
         asm = asm.replace("\n    ", "\n  ")
         return asm
 
+    def check_descr_regex(self, descr, asm):
+        expected = self._normalize_asm(asm)
+        self.assertRegex(descr, expected)
+
     def check_descr(self, descr, asm):
         expected = self._normalize_asm(asm)
         self.assertEqual(descr, expected)
 
     def check_block(self, block, asm):
         self.check_descr(self.descr(block), asm)
+
+    def check_block_regex(self, block, asm):
+        self.check_descr_regex(self.descr(block), asm)
 
     def check_module_body(self, module, asm):
         expected = self._normalize_asm(asm)
@@ -1366,11 +1373,11 @@ my_block:
                 2: 'noalias'
             }
         )
-        self.check_block(block, """\
+        self.check_block_regex(block, """\
         my_block:
             %"retval" = alloca i32
             %"other" = alloca i32
-            call void @"fun"(i32* noalias sret %"retval", i32 42, i32* noalias %"other")
+            call void @"fun"\\(i32\\* noalias sret(\\(i32\\))? %"retval", i32 42, i32\\* noalias %"other"\\)
         """)  # noqa E501
 
     def test_call_tail(self):
@@ -1449,11 +1456,11 @@ my_block:
                 2: 'noalias'
             }
         )
-        self.check_block(block, """\
+        self.check_block_regex(block, """\
         my_block:
             %"retval" = alloca i32
             %"other" = alloca i32
-            invoke fast fastcc void @"fun"(i32* noalias sret %"retval", i32 42, i32* noalias %"other") noinline
+            invoke fast fastcc void @"fun"\\(i32\\* noalias sret(\\(i32\\))? %"retval", i32 42, i32\\* noalias %"other"\\) noinline
                 to label %"normal" unwind label %"unwind"
         """)  # noqa E501
 
@@ -1778,6 +1785,50 @@ insert_block:
         self.assertIn(
             "expected types to be the same, got float, double, float",
             str(raises.exception))
+
+    def test_arg_attributes(self):
+        def gen_code():
+            fnty = ir.FunctionType(ir.IntType(32), [ir.IntType(32).as_pointer(),
+                                                    ir.IntType(32)])
+            module = ir.Module()
+
+            func = ir.Function(module, fnty, name="sum")
+
+            bb_entry = func.append_basic_block()
+            bb_loop = func.append_basic_block()
+            bb_exit = func.append_basic_block()
+
+            builder = ir.IRBuilder()
+            builder.position_at_end(bb_entry)
+
+            builder.branch(bb_loop)
+            builder.position_at_end(bb_loop)
+
+            index = builder.phi(ir.IntType(32))
+            index.add_incoming(ir.Constant(index.type, 0), bb_entry)
+            accum = builder.phi(ir.IntType(32))
+            accum.add_incoming(ir.Constant(accum.type, 0), bb_entry)
+
+            func.args[0].add_attribute('byval')
+            ptr = builder.gep(func.args[0], [index])
+            value = builder.load(ptr)
+
+            added = builder.add(accum, value)
+            accum.add_incoming(added, bb_loop)
+
+            indexp1 = builder.add(index, ir.Constant(index.type, 1))
+            index.add_incoming(indexp1, bb_loop)
+
+            cond = builder.icmp_unsigned('<', indexp1, func.args[1])
+            builder.cbranch(cond, bb_loop, bb_exit)
+
+            builder.position_at_end(bb_exit)
+            builder.ret(added)
+
+            return str(module)
+
+        # If this parses, we emitted the right byval attribute format
+        llvm.parse_assembly(gen_code())
 
 
 class TestBuilderMisc(TestBase):

--- a/llvmlite/tests/test_ir.py
+++ b/llvmlite/tests/test_ir.py
@@ -1787,7 +1787,7 @@ insert_block:
             str(raises.exception))
 
     def test_arg_attributes(self):
-        def gen_code():
+        def gen_code(attr_name):
             fnty = ir.FunctionType(ir.IntType(32), [ir.IntType(32).as_pointer(),
                                                     ir.IntType(32)])
             module = ir.Module()
@@ -1809,7 +1809,7 @@ insert_block:
             accum = builder.phi(ir.IntType(32))
             accum.add_incoming(ir.Constant(accum.type, 0), bb_entry)
 
-            func.args[0].add_attribute('byval')
+            func.args[0].add_attribute(attr_name)
             ptr = builder.gep(func.args[0], [index])
             value = builder.load(ptr)
 
@@ -1827,8 +1827,30 @@ insert_block:
 
             return str(module)
 
-        # If this parses, we emitted the right byval attribute format
-        llvm.parse_assembly(gen_code())
+        for attr_name in (
+            'byref',
+            'byval',
+            'elementtype',
+            'immarg',
+            'inalloca',
+            'inreg',
+            'nest',
+            'noalias',
+            'nocapture',
+            'nofree',
+            'nonnull',
+            'noundef',
+            'preallocated',
+            'returned',
+            'signext',
+            'swiftasync',
+            'swifterror',
+            'swiftself',
+            'zeroext',
+        ):
+            # If this parses, we emitted the right byval attribute format
+            llvm.parse_assembly(gen_code(attr_name))
+        # sret doesn't fit this pattern and is tested in test_call_attributes
 
 
 class TestBuilderMisc(TestBase):


### PR DESCRIPTION
Some attributes now need type information. This preserves it.

Closes #946