### PR TITLE
Add a type hint for `IntType.width`

### DIFF
--- a/llvmlite/ir/types.py
+++ b/llvmlite/ir/types.py
@@ -201,6 +201,7 @@ class IntType(Type):
     """
     null = '0'
     _instance_cache = {}
+    width: int
 
     def __new__(cls, bits):
         # Cache all common integer types


### PR DESCRIPTION
Because the constructor is obsured, inference software really struggles with this particular field.