### PR TITLE
Fix CI failing due to unsupported target triple on non-x86 platforms.

### DIFF
--- a/llvmlite/tests/test_binding.py
+++ b/llvmlite/tests/test_binding.py
@@ -1946,6 +1946,7 @@ class TestPasses(BaseTest, PassManagerTestMixin):
         pm.add_module_debug_info_pass()
         pm.add_refprune_pass()
 
+    @unittest.skipUnless(platform.machine().startswith("x86"), "x86 only")
     def test_target_library_info_behavior(self):
         """Test a specific situation that demonstrate TLI is affecting
         optimization. See https://github.com/numba/numba/issues/8898.


### PR DESCRIPTION
Fix test by only running on x86 platforms.