### PR TITLE
Invalidate string cache for mutable instructions

### DIFF
--- a/llvmlite/ir/instructions.py
+++ b/llvmlite/ir/instructions.py
@@ -291,6 +291,7 @@ class SwitchInstr(PredictableInstr, Terminator):
         if not isinstance(val, Value):
             val = Constant(self.value.type, val)
         self.cases.append((val, block))
+        self._clear_string_cache()
 
     def descr(self, buf):
         cases = ["{0} {1}, label {2}".format(val.type, val.get_reference(),

--- a/llvmlite/ir/instructions.py
+++ b/llvmlite/ir/instructions.py
@@ -262,6 +262,7 @@ class IndirectBranch(PredictableInstr, Terminator):
     def add_destination(self, block):
         assert isinstance(block, Block)
         self.destinations.append(block)
+        self._clear_string_cache()
 
     def descr(self, buf):
         destinations = ["label {0}".format(blk.get_reference())

--- a/llvmlite/ir/instructions.py
+++ b/llvmlite/ir/instructions.py
@@ -215,6 +215,7 @@ class PredictableInstr(Instruction):
             operands.append(Constant(types.IntType(32), w))
         md = self.module.add_metadata(operands)
         self.set_metadata("prof", md)
+        self._clear_string_cache()
 
 
 class Ret(Terminator):

--- a/llvmlite/ir/instructions.py
+++ b/llvmlite/ir/instructions.py
@@ -124,6 +124,7 @@ class CallInstr(Instruction):
         if newfunc.function_type != self.callee.function_type:
             raise TypeError("New function has incompatible type")
         self.callee = newfunc
+        self._clear_string_cache()
 
     @property
     def called_function(self):

--- a/llvmlite/ir/instructions.py
+++ b/llvmlite/ir/instructions.py
@@ -835,6 +835,7 @@ class LandingPadInstr(Instruction):
     def add_clause(self, clause):
         assert isinstance(clause, _LandingPadClause)
         self.clauses.append(clause)
+        self._clear_string_cache()
 
     def descr(self, buf):
         fmt = "landingpad {type}{cleanup}{clauses}\n"

--- a/llvmlite/ir/instructions.py
+++ b/llvmlite/ir/instructions.py
@@ -584,10 +584,12 @@ class PhiInstr(Instruction):
     def add_incoming(self, value, block):
         assert isinstance(block, Block)
         self.incomings.append((value, block))
+        self._clear_string_cache()
 
     def replace_usage(self, old, new):
         self.incomings = [((new if val is old else val), blk)
                           for (val, blk) in self.incomings]
+        self._clear_string_cache()
 
 
 class ExtractElement(Instruction):

--- a/llvmlite/tests/test_ir.py
+++ b/llvmlite/tests/test_ir.py
@@ -1225,6 +1225,7 @@ my_block:
         builder = ir.IRBuilder(block)
         bb_1 = builder.function.append_basic_block(name='b_1')
         bb_2 = builder.function.append_basic_block(name='b_2')
+        bb_3 = builder.function.append_basic_block(name='b_3')
         indirectbr = builder.branch_indirect(
             ir.BlockAddress(builder.function, bb_1))
         indirectbr.add_destination(bb_1)
@@ -1233,6 +1234,11 @@ my_block:
         self.check_block(block, """\
             my_block:
                 indirectbr i8* blockaddress(@"my_func", %"b_1"), [label %"b_1", label %"b_2"]
+            """)  # noqa E501
+        indirectbr.add_destination(bb_3)
+        self.check_block(block, """\
+            my_block:
+                indirectbr i8* blockaddress(@"my_func", %"b_1"), [label %"b_1", label %"b_2", label %"b_3"]
             """)  # noqa E501
 
     def test_returns(self):

--- a/llvmlite/tests/test_ir.py
+++ b/llvmlite/tests/test_ir.py
@@ -1288,6 +1288,7 @@ my_block:
         bb_onzero = builder.function.append_basic_block(name='onzero')
         bb_onone = builder.function.append_basic_block(name='onone')
         bb_ontwo = builder.function.append_basic_block(name='ontwo')
+        bb_onfour = builder.function.append_basic_block(name='onfour')
         bb_else = builder.function.append_basic_block(name='otherwise')
         sw = builder.switch(a, bb_else)
         sw.add_case(ir.Constant(int32, 0), bb_onzero)
@@ -1298,6 +1299,11 @@ my_block:
         self.check_block(block, """\
             my_block:
                 switch i32 %".1", label %"otherwise" [i32 0, label %"onzero" i32 1, label %"onone" i32 2, label %"ontwo"]
+            """)  # noqa E501
+        sw.add_case(ir.Constant(int32, 4), bb_onfour)
+        self.check_block(block, """\
+            my_block:
+                switch i32 %".1", label %"otherwise" [i32 0, label %"onzero" i32 1, label %"onone" i32 2, label %"ontwo" i32 4, label %"onfour"]
             """)  # noqa E501
 
     def test_call(self):

--- a/llvmlite/tests/test_ir.py
+++ b/llvmlite/tests/test_ir.py
@@ -1209,6 +1209,7 @@ my_block:
         bb_true = builder.function.append_basic_block(name='b_true')
         bb_false = builder.function.append_basic_block(name='b_false')
         br = builder.cbranch(ir.Constant(int1, False), bb_true, bb_false)
+        self.assertNotIn('branch_weights', str(br))
         br.set_weights([5, 42])
         self.assertTrue(block.is_terminated)
         self.check_block(block, """\

--- a/llvmlite/tests/test_ir.py
+++ b/llvmlite/tests/test_ir.py
@@ -943,9 +943,10 @@ my_block:
     def test_phi(self):
         block = self.block(name='my_block')
         builder = ir.IRBuilder(block)
-        a, b = builder.function.args[:2]
+        a, b, c = builder.function.args[:3]
         bb2 = builder.function.append_basic_block('b2')
         bb3 = builder.function.append_basic_block('b3')
+        bb4 = builder.function.append_basic_block('b4')
         phi = builder.phi(int32, 'my_phi', flags=('fast',))
         phi.add_incoming(a, bb2)
         phi.add_incoming(b, bb3)
@@ -953,6 +954,16 @@ my_block:
         self.check_block(block, """\
             my_block:
                 %"my_phi" = phi fast i32 [%".1", %"b2"], [%".2", %"b3"]
+            """)
+        phi.add_incoming(a, bb4)
+        self.check_block(block, """\
+            my_block:
+                %"my_phi" = phi fast i32 [%".1", %"b2"], [%".2", %"b3"], [%".1", %"b4"]
+            """)
+        phi.replace_usage(a, c)
+        self.check_block(block, """\
+            my_block:
+                %"my_phi" = phi fast i32 [%".3", %"b2"], [%".2", %"b3"], [%".3", %"b4"]
             """)
 
     def test_mem_ops(self):

--- a/llvmlite/tests/test_ir.py
+++ b/llvmlite/tests/test_ir.py
@@ -2621,8 +2621,10 @@ class TestTransforms(TestBase):
         builder.position_at_end(foo.append_basic_block())
         call = builder.call(foo, ())
         self.assertEqual(call.callee, foo)
+        self.assertIn("call void @\"foo\"()", str(mod))
         modified = ir.replace_all_calls(mod, foo, bar)
         self.assertIn(call, modified)
+        self.assertNotIn("call void @\"foo\"()", str(mod))
         self.assertNotEqual(call.callee, foo)
         self.assertEqual(call.callee, bar)
 


### PR DESCRIPTION
This is a re-do of #661 and adds testing of all modifications. It addresses: Phi nodes, call, cbranch, indirect branch, switch, landing pad.

As mentioned in #675, there is also the issue of fastmath flags on floating point instructions. I'm thinking about how to do those next and will open a separate PR.