### PR TITLE
0.40.1 rel cherry pick

### DIFF
--- a/CHANGE_LOG
+++ b/CHANGE_LOG
@@ -1,3 +1,18 @@
+v0.40.1 (June 8, 2023)
+----------------------
+
+Pull-Requests:
+
+* PR `#945 <https://github.com/numba/llvmlite/pull/945>`_: Fix #944. Add `.argtypes` to prevent errors in pypy. (`Siu Kwan Lam <https://github.com/sklam>`_)
+* PR `#947 <https://github.com/numba/llvmlite/pull/947>`_: Update SVML patch for LLVM 14 (`Andre Masella <https://github.com/apmasell>`_)
+* PR `#949 <https://github.com/numba/llvmlite/pull/949>`_: Handle PowerPC synonyms (`Andre Masella <https://github.com/apmasell>`_)
+* PR `#950 <https://github.com/numba/llvmlite/pull/950>`_: Fix incorrect `byval` and other attributes on LLVM 14 (`Andre Masella <https://github.com/apmasell>`_)
+
+Authors:
+
+* `Andre Masella <https://github.com/apmasell>`_
+* `Siu Kwan Lam <https://github.com/sklam>`_
+
 v0.40.0 (May 1, 2023)
 ---------------------
 

--- a/conda-recipes/llvm14-svml.patch
+++ b/conda-recipes/llvm14-svml.patch
@@ -1,8 +1,9 @@
-From bc2dcd190b7148d04772fa7fcd18b5200b758d4a Mon Sep 17 00:00:00 2001
+From 9de32f5474f1f78990b399214bdbb6c21f8f098e Mon Sep 17 00:00:00 2001
 From: Ivan Butygin <ivan.butygin@gmail.com>
 Date: Sun, 24 Jul 2022 20:31:29 +0200
 Subject: [PATCH] Fixes vectorizer and extends SVML support
 
+Fixes vectorizer and extends SVML support
 Patch was updated to fix SVML calling convention issues uncovered by llvm 10.
 In previous versions of patch SVML calling convention was selected based on
 compilation settings. So if you try to call 256bit vector function from avx512
@@ -29,41 +30,6 @@ patch addresses this issue by adding a legality check during code generation and
 replaces the illegal SVML call with corresponding legalized instructions.
 (RFC: http://lists.llvm.org/pipermail/llvm-dev/2018-June/124357.html)
 Author: Karthik Senthil
----
- .../include/llvm/Analysis/TargetLibraryInfo.h |  22 +-
- llvm/include/llvm/AsmParser/LLToken.h         |   3 +
- llvm/include/llvm/IR/CMakeLists.txt           |   4 +
- llvm/include/llvm/IR/CallingConv.h            |   5 +
- llvm/include/llvm/IR/SVML.td                  |  62 +++
- llvm/lib/Analysis/CMakeLists.txt              |   1 +
- llvm/lib/Analysis/TargetLibraryInfo.cpp       |  55 +-
- llvm/lib/AsmParser/LLLexer.cpp                |   3 +
- llvm/lib/AsmParser/LLParser.cpp               |   6 +
- llvm/lib/CodeGen/ReplaceWithVeclib.cpp        |   2 +-
- llvm/lib/IR/AsmWriter.cpp                     |   3 +
- llvm/lib/IR/Verifier.cpp                      |   3 +
- llvm/lib/Target/X86/X86CallingConv.td         |  70 +++
- llvm/lib/Target/X86/X86ISelLowering.cpp       |   3 +-
- llvm/lib/Target/X86/X86RegisterInfo.cpp       |  46 ++
- llvm/lib/Target/X86/X86Subtarget.h            |   3 +
- .../Transforms/Utils/InjectTLIMappings.cpp    |   2 +-
- .../Transforms/Vectorize/LoopVectorize.cpp    | 269 +++++++++
- .../Generic/replace-intrinsics-with-veclib.ll |   4 +-
- .../LoopVectorize/X86/svml-calls-finite.ll    |  24 +-
- .../LoopVectorize/X86/svml-calls.ll           | 108 ++--
- .../LoopVectorize/X86/svml-legal-calls.ll     | 513 ++++++++++++++++++
- .../LoopVectorize/X86/svml-legal-codegen.ll   |  61 +++
- llvm/test/Transforms/Util/add-TLI-mappings.ll |  18 +-
- llvm/utils/TableGen/CMakeLists.txt            |   1 +
- llvm/utils/TableGen/SVMLEmitter.cpp           | 110 ++++
- llvm/utils/TableGen/TableGen.cpp              |   8 +-
- llvm/utils/TableGen/TableGenBackends.h        |   1 +
- llvm/utils/vim/syntax/llvm.vim                |   1 +
- 29 files changed, 1341 insertions(+), 70 deletions(-)
- create mode 100644 llvm/include/llvm/IR/SVML.td
- create mode 100644 llvm/test/Transforms/LoopVectorize/X86/svml-legal-calls.ll
- create mode 100644 llvm/test/Transforms/LoopVectorize/X86/svml-legal-codegen.ll
- create mode 100644 llvm/utils/TableGen/SVMLEmitter.cpp
 
 diff --git a/llvm-14.0.6.src/include/llvm/Analysis/TargetLibraryInfo.h b/llvm-14.0.6.src/include/llvm/Analysis/TargetLibraryInfo.h
 index 17d1e3f770c14..110ff08189867 100644
@@ -922,6 +888,42 @@ index 46ff0994e04e7..f472af5e1a835 100644
  }
  
  void LoopVectorizationCostModel::collectLoopScalars(ElementCount VF) {
+diff --git a/llvm-14.0.6.src/lib/Transforms/Vectorize/SLPVectorizer.cpp b/llvm-14.0.6.src/lib/Transforms/Vectorize/SLPVectorizer.cpp
+index 644372483edde..342f018b92184 100644
+--- a/llvm-14.0.6.src/lib/Transforms/Vectorize/SLPVectorizer.cpp
++++ b/llvm-14.0.6.src/lib/Transforms/Vectorize/SLPVectorizer.cpp
+@@ -6322,6 +6322,17 @@ Value *BoUpSLP::vectorizeTree(ArrayRef<Value *> VL) {
+   return Vec;
+ }
+ 
++static void setVectorFunctionCallingConv(CallInst &CI, const DataLayout &DL,
++                                         const TargetLibraryInfo &TLI) {
++  Function *VectorF = CI.getCalledFunction();
++  FunctionType *FTy = VectorF->getFunctionType();
++  StringRef VFName = VectorF->getName();
++  auto CC = TLI.getVectorizedFunctionCallingConv(VFName, *FTy, DL);
++  if (CC) {
++    CI.setCallingConv(*CC);
++  }
++}
++
+ Value *BoUpSLP::vectorizeTree(TreeEntry *E) {
+   IRBuilder<>::InsertPointGuard Guard(Builder);
+ 
+@@ -6794,7 +6805,12 @@ Value *BoUpSLP::vectorizeTree(TreeEntry *E) {
+ 
+       SmallVector<OperandBundleDef, 1> OpBundles;
+       CI->getOperandBundlesAsDefs(OpBundles);
+-      Value *V = Builder.CreateCall(CF, OpVecs, OpBundles);
++
++      CallInst *NewCall = Builder.CreateCall(CF, OpVecs, OpBundles);
++      const DataLayout &DL = NewCall->getModule()->getDataLayout();
++      setVectorFunctionCallingConv(*NewCall, DL, *TLI);
++
++      Value *V = NewCall;
+ 
+       // The scalar argument uses an in-tree scalar so we add the new vectorized
+       // call to ExternalUses list to make sure that an extract will be
 diff --git a/llvm-14.0.6.src/test/CodeGen/Generic/replace-intrinsics-with-veclib.ll b/llvm-14.0.6.src/test/CodeGen/Generic/replace-intrinsics-with-veclib.ll
 index df8b7c498bd00..63a36549f18fd 100644
 --- a/llvm-14.0.6.src/test/CodeGen/Generic/replace-intrinsics-with-veclib.ll

--- a/conda-recipes/llvmdev/meta.yaml
+++ b/conda-recipes/llvmdev/meta.yaml
@@ -3,7 +3,7 @@
 {% set sha256_llvm = "050922ecaaca5781fdf6631ea92bc715183f202f9d2f15147226f023414f619a" %}
 {% set sha256_lld = "0c28ce0496934d37d20fec96591032dd66af8d10178a45762e0e75e85cf95ad3" %}
 {% set sha256_libunwind = "3bbe9c23c73259fe39c045dc87d0b283236ba6e00750a226b2c2aeac4a51d86b" %}
-{% set build_number = "2" %}
+{% set build_number = "3" %}
 
 package:
   name: llvmdev

--- a/conda-recipes/llvmlite/meta.yaml
+++ b/conda-recipes/llvmlite/meta.yaml
@@ -30,7 +30,7 @@ requirements:
   host:
     - python
     # On channel https://anaconda.org/numba/
-    - llvmdev 14.* *2
+    - llvmdev 14.* *3
     - vs2015_runtime # [win]
     # llvmdev is built with libz compression support
     - zlib           # [unix and not (armv6l or armv7l)]

--- a/llvmlite/binding/analysis.py
+++ b/llvmlite/binding/analysis.py
@@ -4,7 +4,6 @@ A collection of analysis utilities
 
 from ctypes import POINTER, c_char_p, c_int
 
-from llvmlite import ir
 from llvmlite.binding import ffi
 from llvmlite.binding.module import parse_assembly
 
@@ -17,6 +16,7 @@ def get_function_cfg(func, show_inst=True):
     are printed.
     """
     assert func is not None
+    from llvmlite import ir
     if isinstance(func, ir.Function):
         mod = parse_assembly(str(func.module))
         func = mod.get_function(func.name)

--- a/llvmlite/binding/passmanagers.py
+++ b/llvmlite/binding/passmanagers.py
@@ -1,4 +1,5 @@
-from ctypes import c_bool, c_char_p, c_int, c_size_t, c_uint, Structure, byref
+from ctypes import (c_bool, c_char_p, c_int, c_size_t, c_uint, Structure, byref,
+                    POINTER)
 from collections import namedtuple
 from enum import IntFlag
 from llvmlite.binding import ffi
@@ -914,3 +915,5 @@ ffi.lib.LLVMPY_AddBasicAliasAnalysisPass.argtypes = [ffi.LLVMPassManagerRef]
 
 ffi.lib.LLVMPY_AddRefPrunePass.argtypes = [ffi.LLVMPassManagerRef, c_int,
                                            c_size_t]
+
+ffi.lib.LLVMPY_DumpRefPruneStats.argtypes = [POINTER(_c_PruneStats), c_bool]

--- a/llvmlite/ir/instructions.py
+++ b/llvmlite/ir/instructions.py
@@ -133,7 +133,7 @@ class CallInstr(Instruction):
     def _descr(self, buf, add_metadata):
         def descr_arg(i, a):
             if i in self.arg_attributes:
-                attrs = ' '.join(self.arg_attributes[i]._to_list()) + ' '
+                attrs = ' '.join(self.arg_attributes[i]._to_list(a.type)) + ' '
             else:
                 attrs = ''
             return '{0} {1}{2}'.format(a.type, attrs, a.get_reference())
@@ -155,13 +155,19 @@ class CallInstr(Instruction):
         if self.tail:
             tail_marker = "{0} ".format(self.tail)
 
+        fn_attrs = ' ' + ' '.join(self.attributes._to_list(fnty.return_type))\
+            if self.attributes else ''
+
+        fm_attrs = ' ' + ' '.join(self.fastmath._to_list(fnty.return_type))\
+            if self.fastmath else ''
+
         buf.append("{tail}{op}{fastmath} {callee}({args}){attr}{meta}\n".format(
             tail=tail_marker,
             op=self.opname,
             callee=callee_ref,
-            fastmath=''.join([" " + attr for attr in self.fastmath]),
+            fastmath=fm_attrs,
             args=args,
-            attr=''.join([" " + attr for attr in self.attributes]),
+            attr=fn_attrs,
             meta=(self._stringify_metadata(leading_comma=True)
                   if add_metadata else ""),
         ))

--- a/llvmlite/tests/test_binding.py
+++ b/llvmlite/tests/test_binding.py
@@ -576,15 +576,22 @@ class TestMisc(BaseTest):
         self.assertTrue(triple)
 
     def test_get_process_triple(self):
+        # Sometimes we get synonyms for PPC
+        def normalize_ppc(arch):
+            if arch == 'powerpc64le':
+                return 'ppc64le'
+            else:
+                return arch
+
         triple = llvm.get_process_triple()
         default = llvm.get_default_triple()
         self.assertIsInstance(triple, str)
         self.assertTrue(triple)
 
-        default_parts = default.split('-')
-        triple_parts = triple.split('-')
+        default_arch = normalize_ppc(default.split('-')[0])
+        triple_arch = normalize_ppc(triple.split('-')[0])
         # Arch must be equal
-        self.assertEqual(default_parts[0], triple_parts[0])
+        self.assertEqual(default_arch, triple_arch)
 
     def test_get_host_cpu_features(self):
         features = llvm.get_host_cpu_features()

--- a/llvmlite/tests/test_ir.py
+++ b/llvmlite/tests/test_ir.py
@@ -84,12 +84,19 @@ class TestBase(TestCase):
         asm = asm.replace("\n    ", "\n  ")
         return asm
 
+    def check_descr_regex(self, descr, asm):
+        expected = self._normalize_asm(asm)
+        self.assertRegex(descr, expected)
+
     def check_descr(self, descr, asm):
         expected = self._normalize_asm(asm)
         self.assertEqual(descr, expected)
 
     def check_block(self, block, asm):
         self.check_descr(self.descr(block), asm)
+
+    def check_block_regex(self, block, asm):
+        self.check_descr_regex(self.descr(block), asm)
 
     def check_module_body(self, module, asm):
         expected = self._normalize_asm(asm)
@@ -1366,11 +1373,11 @@ my_block:
                 2: 'noalias'
             }
         )
-        self.check_block(block, """\
+        self.check_block_regex(block, """\
         my_block:
             %"retval" = alloca i32
             %"other" = alloca i32
-            call void @"fun"(i32* noalias sret %"retval", i32 42, i32* noalias %"other")
+            call void @"fun"\\(i32\\* noalias sret(\\(i32\\))? %"retval", i32 42, i32\\* noalias %"other"\\)
         """)  # noqa E501
 
     def test_call_tail(self):
@@ -1449,11 +1456,11 @@ my_block:
                 2: 'noalias'
             }
         )
-        self.check_block(block, """\
+        self.check_block_regex(block, """\
         my_block:
             %"retval" = alloca i32
             %"other" = alloca i32
-            invoke fast fastcc void @"fun"(i32* noalias sret %"retval", i32 42, i32* noalias %"other") noinline
+            invoke fast fastcc void @"fun"\\(i32\\* noalias sret(\\(i32\\))? %"retval", i32 42, i32\\* noalias %"other"\\) noinline
                 to label %"normal" unwind label %"unwind"
         """)  # noqa E501
 
@@ -1778,6 +1785,75 @@ insert_block:
         self.assertIn(
             "expected types to be the same, got float, double, float",
             str(raises.exception))
+
+    def test_arg_attributes(self):
+        def gen_code(attr_name):
+            fnty = ir.FunctionType(ir.IntType(32), [ir.IntType(32).as_pointer(),
+                                                    ir.IntType(32)])
+            module = ir.Module()
+
+            func = ir.Function(module, fnty, name="sum")
+
+            bb_entry = func.append_basic_block()
+            bb_loop = func.append_basic_block()
+            bb_exit = func.append_basic_block()
+
+            builder = ir.IRBuilder()
+            builder.position_at_end(bb_entry)
+
+            builder.branch(bb_loop)
+            builder.position_at_end(bb_loop)
+
+            index = builder.phi(ir.IntType(32))
+            index.add_incoming(ir.Constant(index.type, 0), bb_entry)
+            accum = builder.phi(ir.IntType(32))
+            accum.add_incoming(ir.Constant(accum.type, 0), bb_entry)
+
+            func.args[0].add_attribute(attr_name)
+            ptr = builder.gep(func.args[0], [index])
+            value = builder.load(ptr)
+
+            added = builder.add(accum, value)
+            accum.add_incoming(added, bb_loop)
+
+            indexp1 = builder.add(index, ir.Constant(index.type, 1))
+            index.add_incoming(indexp1, bb_loop)
+
+            cond = builder.icmp_unsigned('<', indexp1, func.args[1])
+            builder.cbranch(cond, bb_loop, bb_exit)
+
+            builder.position_at_end(bb_exit)
+            builder.ret(added)
+
+            return str(module)
+
+        llvm_major = llvm.llvm_version_info[0]
+        if llvm_major >= 14:
+            supplemental = ('byref', 'swiftasync', 'elementtype')
+        else:
+            supplemental = ()
+
+        for attr_name in (
+            'byval',
+            'immarg',
+            'inalloca',
+            'inreg',
+            'nest',
+            'noalias',
+            'nocapture',
+            'nofree',
+            'nonnull',
+            'noundef',
+            'preallocated',
+            'returned',
+            'signext',
+            'swifterror',
+            'swiftself',
+            'zeroext',
+        ) + supplemental:
+            # If this parses, we emitted the right byval attribute format
+            llvm.parse_assembly(gen_code(attr_name))
+        # sret doesn't fit this pattern and is tested in test_call_attributes
 
 
 class TestBuilderMisc(TestBase):


### PR DESCRIPTION
Using the table at:

https://github.com/numba/llvmlite/issues/955#issue-1741319800

I put the following merge commits for the PRs that are to be backported in a file `0.40.1-cp`:

```
70f057b59a
e2dd7b0bb0
f2aa9a7f12
cb78125cd7
```

And then to cherry-pick them all at once:

```
cat 0.40.1-cp | xargs git cp -m1
```

The request for review is to ensure that the PRs required are correctly cherry-picked.