### PR TITLE
add various bullets to release checklists and sync

### DIFF
--- a/.github/ISSUE_TEMPLATE/first_rc_checklist.md
+++ b/.github/ISSUE_TEMPLATE/first_rc_checklist.md
@@ -10,10 +10,13 @@ labels: task
 ## llvmlite X.Y.Z
 
 * [ ] Merge to `main`.
-    - [ ] "remaining Pull-Requests from milestone".
-* [ ] Merge change log changes.
-    - [ ] "PR with changelog entries".
+    * [ ] "remaining Pull-Requests from milestone".
 * [ ] Create X.Y release branch `releaseX.Y`
+    * [ ] Update `CHANGE_LOG` in a PR targeting the release branch.
+* [ ] Get the change-log-PR reviewed and merged.
+* [ ] Test `HEAD` of release branch on buildfarm (pre-tag testing):
+    * [ ] conda package build and test.
+    * [ ] wheel build.
 * [ ] Annotated tag `vX.Y.Zrc1` on release branch (`llvmlite` tags DO have a `v` prefix).
 * [ ] Build and upload conda packages on buildfarm (check "upload").
 * [ ] Build wheels and sdist on the buildfarm (check "upload").
@@ -22,11 +25,12 @@ labels: task
 * [ ] Verify wheels for all platforms arrived on PyPi.
 * [ ] Initialize and verify ReadTheDocs build.
 * [ ] Send RC announcement email / post announcement to discourse group.
-* [ ] Post link to Twitter.
+* [ ] Post link to Twitter and Mastodon and anywhere else that is appropriate.
 
 ### Post Release:
 
-* [ ] Clean up `ci_artifacts`.
+* [ ] Cherry-pick changes to the `CHANGE_LOG` to `main`
+* [ ] Clean up `ci_artifacts` by moving files to subdirectories
 * [ ] Tag X.Y+1.0dev0 to start new development cycle on `main`.
 * [ ] Update release checklist template with any additional bullet points that
       may have arisen during the release.

--- a/.github/ISSUE_TEMPLATE/sub_rc_checklist.md
+++ b/.github/ISSUE_TEMPLATE/sub_rc_checklist.md
@@ -9,10 +9,12 @@ labels: task
 
 ## llvmlite X.Y.Z
 
-* [ ] Cherry-pick items from the X.Y.Z milestone into a PR.
-* [ ] Approve change log modifications and cherry-pick.
-* [ ] Merge change log modifications and cherry-picks to X.Y release branch.
-  * [ ] https://github.com/numba/numba/pull/XXXX
+* [ ] Cherry-pick items from the X.Y.Z milestone into a PR targeting the release branch.
+* [ ] Update `CHANGE_LOG` on cherry-pick-PR.
+* [ ] Have cherry-pick-PR reviewed and merged.
+* [ ] Test `HEAD` of release branch on buildfarm (pre-tag testing):
+  * [ ] conda package build and test.
+  * [ ] wheel build.
 * [ ] Annotated tag `vX.Y.Z` on release branch (`llvmlite` tags DO have a `v` prefix).
 * [ ] Build and upload conda packages on buildfarm (check "upload").
 * [ ] Build wheels and sdist on the buildfarm (check "upload").
@@ -21,11 +23,13 @@ labels: task
 * [ ] Verify wheels for all platforms arrived on PyPi.
 * [ ] Verify ReadTheDocs build.
 * [ ] Send RC/FINAL announcement email / post announcement to discourse group.
-* [ ] Post link to Twitter.
+* [ ] Post link to Twitter and Mastodon and anywhere else that is appropriate.
 
 ### Post release
 
+* [ ] Cherry-pick changes to the `CHANGE_LOG` to `main`
 * [ ] Clean up `ci_artifacts` by moving files to subdirectories
-* [ ] Update release checklist template.
+* [ ] Update release checklist template with any additional bullet points that
+      may have arisen during the release.
 * [ ] Ping Anaconda Distro team to trigger a build for `defaults` (FINAL ONLY).
 * [ ] Close milestone (and then close this release issue).


### PR DESCRIPTION
Adding:

* Modifications of the change-log now happen on the release branch and are then cherry-picked back to main.
* Pre-tag-testing is now explicit.
* Post link to mastondon too.
* Minor synchronizations between the two checklists.