### PR TITLE
build: support building on GNU/Hurd

### DIFF
--- a/ffi/build.py
+++ b/ffi/build.py
@@ -213,7 +213,8 @@ def main_posix(kind, library_ext):
 def main():
     if sys.platform == 'win32':
         main_windows()
-    elif sys.platform.startswith('linux'):
+    elif sys.platform.startswith(('linux', 'gnu')):
+        # Linux and GNU-based OSes (e.g. GNU/Hurd), using the same Makefile
         main_posix('linux', '.so')
     elif sys.platform.startswith(('freebsd','openbsd')):
         main_posix('freebsd', '.so')

--- a/setup.py
+++ b/setup.py
@@ -64,9 +64,9 @@ build_ext = cmdclass.get('build_ext', build_ext)
 
 def build_library_files(dry_run):
     cmd = [sys.executable, os.path.join(here_dir, 'ffi', 'build.py')]
-    # Turn on -fPIC for building on Linux, BSD, and OS X
+    # Turn on -fPIC for building on Linux, BSD, OS X, and GNU platforms
     plt = sys.platform
-    if 'linux' in plt or 'bsd' in plt or 'darwin' in plt:
+    if 'linux' in plt or 'bsd' in plt or 'darwin' in plt or 'gnu' in plt:
         os.environ['CXXFLAGS'] = os.environ.get('CXXFLAGS', '') + ' -fPIC'
     spawn(cmd, dry_run=dry_run)
 


### PR DESCRIPTION
LLVM is ported on the Hurd, and the Hurd has the same GNU toolchain that
is also generally used on Linux. Since build & the tests work fine,
apply/use some Linux build tweaks also on any GNU platform (including
the Hurd):
- the Linux `Makefile`
- `-fPIC` in `CXXFLAGS`