### PR TITLE
Expose library name in OrcJIT tracker

### DIFF
--- a/llvmlite/binding/orcjit.py
+++ b/llvmlite/binding/orcjit.py
@@ -144,8 +144,8 @@ class JITLibraryBuilder:
         however, the name of the library cannot be reused.
         """
         assert not lljit.closed, "Cannot add to closed JIT"
-        library_name = str(library_name).encode('utf-8')
-        assert len(library_name) > 0, "Library cannot be empty"
+        encoded_library_name = str(library_name).encode('utf-8')
+        assert len(encoded_library_name) > 0, "Library cannot be empty"
         elements = (_LinkElement * len(self.__entries))()
         for idx, (kind, value) in enumerate(self.__entries):
             elements[idx].element_kind = c_uint8(kind)
@@ -163,7 +163,7 @@ class JITLibraryBuilder:
         with ffi.OutputString() as outerr:
             tracker = lljit._capi.LLVMPY_LLJIT_Link(
                 lljit._ptr,
-                library_name,
+                encoded_library_name,
                 elements,
                 len(self.__entries),
                 imports,
@@ -173,9 +173,10 @@ class JITLibraryBuilder:
                 outerr)
             if not tracker:
                 raise RuntimeError(str(outerr))
-        return ResourceTracker(tracker, {name: exports[idx].address
-                                         for idx, name in
-                                         enumerate(self.__exports)})
+        return ResourceTracker(tracker,
+                               library_name,
+                               {name: exports[idx].address
+                                for idx, name in enumerate(self.__exports)})
 
 
 class ResourceTracker(ffi.ObjectRef):
@@ -195,8 +196,9 @@ class ResourceTracker(ffi.ObjectRef):
     LLVM internally tracks references between different libraries, so only
     "leaf" libraries need to be tracked.
     """
-    def __init__(self, ptr, addresses):
+    def __init__(self, ptr, name, addresses):
         self.__addresses = addresses
+        self.__name = name
         ffi.ObjectRef.__init__(self, ptr)
 
     def __getitem__(self, item):
@@ -204,6 +206,10 @@ class ResourceTracker(ffi.ObjectRef):
         Get the address of an exported symbol as an integer
         """
         return self.__addresses[item]
+
+    @property
+    def name(self):
+        return self.__name
 
     def _dispose(self):
         with ffi.OutputString() as outerr:
@@ -252,7 +258,7 @@ class LLJIT(ffi.ObjectRef):
             if not tracker:
                 raise RuntimeError(str(outerr))
 
-        return ResourceTracker(tracker, {fn: address.value})
+        return ResourceTracker(tracker, dylib, {fn: address.value})
 
     @property
     def target_data(self):

--- a/llvmlite/tests/test_binding.py
+++ b/llvmlite/tests/test_binding.py
@@ -1183,6 +1183,7 @@ class TestOrcLLJIT(BaseTest):
             .link(lljit, func_name)
         cfptr = rt[func_name]
         self.assertTrue(cfptr)
+        self.assertEqual(func_name, rt.name)
         return lljit, rt, func_type(cfptr)
 
     # From test_dylib_symbols


### PR DESCRIPTION
Add a `name` property with the OrcJIT library name in the tracker object.