### PR TITLE
update changelog on main for v0.40.1

### DIFF
--- a/CHANGE_LOG
+++ b/CHANGE_LOG
@@ -1,3 +1,19 @@
+v0.40.1 (June 21, 2023)
+-----------------------
+
+Pull-Requests:
+
+* PR `#945 <https://github.com/numba/llvmlite/pull/945>`_: Fix #944. Add `.argtypes` to prevent errors in pypy. (`Siu Kwan Lam <https://github.com/sklam>`_)
+* PR `#947 <https://github.com/numba/llvmlite/pull/947>`_: Update SVML patch for LLVM 14 (`Andre Masella <https://github.com/apmasell>`_)
+* PR `#949 <https://github.com/numba/llvmlite/pull/949>`_: Handle PowerPC synonyms (`Andre Masella <https://github.com/apmasell>`_)
+* PR `#950 <https://github.com/numba/llvmlite/pull/950>`_: Fix incorrect `byval` and other attributes on LLVM 14 (`Andre Masella <https://github.com/apmasell>`_)
+
+Authors:
+
+* `Andre Masella <https://github.com/apmasell>`_
+* `Siu Kwan Lam <https://github.com/sklam>`_
+
+
 v0.40.0 (May 1, 2023)
 ---------------------
 


### PR DESCRIPTION
As per:

```
# current branch is the tag
 💣 zsh» git --no-pager log -1 --decorate --oneline
a4e5632677 (HEAD -> release0.40, tag: v0.40.1, origin/release0.40) Merge pull request #965 from esc/change_log_0.40.1

# this is the state of main
 💣 zsh» git --no-pager log -1 --decorate --oneline main
2bfc31a009 (origin/main, origin/HEAD, main) Merge pull request #966 from pinotree/hurd

# diff for the change log
 💣 zsh» git --no-pager diff main -- CHANGE_LOG
diff --git c/CHANGE_LOG w/CHANGE_LOG
index 57e08e4398..9a9206c01a 100644
--- c/CHANGE_LOG
+++ w/CHANGE_LOG
@@ -1,3 +1,18 @@
+v0.40.1 (June 21, 2023)
+-----------------------
+
+Pull-Requests:
+
+* PR `#945 <https://github.com/numba/llvmlite/pull/945>`_: Fix #944. Add `.argtypes` to prevent errors in pypy. (`Siu Kwan Lam <https://github.com/sklam>`_)
+* PR `#947 <https://github.com/numba/llvmlite/pull/947>`_: Update SVML patch for LLVM 14 (`Andre Masella <https://github.com/apmasell>`_)
+* PR `#949 <https://github.com/numba/llvmlite/pull/949>`_: Handle PowerPC synonyms (`Andre Masella <https://github.com/apmasell>`_)
+* PR `#950 <https://github.com/numba/llvmlite/pull/950>`_: Fix incorrect `byval` and other attributes on LLVM 14 (`Andre Masella <https://github.com/apmasell>`_)
+
+Authors:
+
+* `Andre Masella <https://github.com/apmasell>`_
+* `Siu Kwan Lam <https://github.com/sklam>`_
+
 v0.40.0 (May 1, 2023)
 ---------------------
