### PR TITLE
Add Instruction Namer pass to PassManager

### DIFF
--- a/docs/source/user-guide/binding/optimization-passes.rst
+++ b/docs/source/user-guide/binding/optimization-passes.rst
@@ -137,6 +137,10 @@ create and configure a :class:`PassManagerBuilder`.
 
         See `basicaa pass documentation <http://llvm.org/docs/AliasAnalysis.html#the-basicaa-pass>`_.
 
+   * .. function:: add_instruction_namer_pass()
+
+        See `instnamer pass documentation <http://llvm.org/docs/Passes.html#instnamer-assign-names-to-anonymous-instructions>`_.
+
 .. class:: ModulePassManager()
 
    Create a new pass manager to run optimization passes on a

--- a/ffi/passmanagers.cpp
+++ b/ffi/passmanagers.cpp
@@ -462,4 +462,9 @@ LLVMPY_LLVMAddLoopRotatePass(LLVMPassManagerRef PM) {
     LLVMAddLoopRotatePass(PM);
 }
 
+API_EXPORT(void)
+LLVMPY_AddInstructionNamerPass(LLVMPassManagerRef PM) {
+    unwrap(PM)->add(createInstructionNamerPass());
+}
+
 } // end extern "C"

--- a/llvmlite/binding/passmanagers.py
+++ b/llvmlite/binding/passmanagers.py
@@ -638,6 +638,14 @@ class PassManager(ffi.ObjectRef):
     def add_target_library_info(self, triple):
         ffi.lib.LLVMPY_AddTargetLibraryInfoPass(self, _encode_string(triple))
 
+    def add_instruction_namer_pass(self):
+        """
+        See https://llvm.org/docs/Passes.html#instnamer-assign-names-to-anonymous-instructions.
+
+        LLVM 14: `llvm::createInstructionNamerPass`
+        """  # noqa E501
+        ffi.lib.LLVMPY_AddInstructionNamerPass(self)
+
     # Non-standard LLVM passes
 
     def add_refprune_pass(self, subpasses_flags=RefPruneSubpasses.ALL,
@@ -916,6 +924,7 @@ ffi.lib.LLVMPY_AddTypeBasedAliasAnalysisPass.argtypes = [ffi.LLVMPassManagerRef]
 ffi.lib.LLVMPY_AddBasicAliasAnalysisPass.argtypes = [ffi.LLVMPassManagerRef]
 ffi.lib.LLVMPY_AddTargetLibraryInfoPass.argtypes = [ffi.LLVMPassManagerRef,
                                                     c_char_p]
+ffi.lib.LLVMPY_AddInstructionNamerPass.argtypes = [ffi.LLVMPassManagerRef]
 
 ffi.lib.LLVMPY_AddRefPrunePass.argtypes = [ffi.LLVMPassManagerRef, c_int,
                                            c_size_t]


### PR DESCRIPTION
This PR adds the built-in instruction namer pass to `PassManager`. The `instnamer` pass is very useful to work with the Python bindings, especially when value names are discarded during compilation and `ValueRef.name` is empty.