### PR TITLE
adding sphinx_rtd_theme to RTD build to fix build

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -15,5 +15,6 @@ sphinx:
 
 python:
   install:
+    - requirements: docs/rtd-requirements.txt
     - method: pip
       path: .

--- a/docs/rtd-requirements.txt
+++ b/docs/rtd-requirements.txt
@@ -1,0 +1,1 @@
+sphinx_rtd_theme


### PR DESCRIPTION
As of recently, docs started failing:

https://readthedocs.org/projects/llvmlite/builds/22167903/

The error was:

```
Configuration error:
There is a programmable error in your configuration file:

Traceback (most recent call last):
  File "/home/docs/checkouts/readthedocs.org/user_builds/llvmlite/envs/latest/lib/python3.11/site-packages/sphinx/config.py", line 358, in eval_config_file
    exec(code, namespace)  # NoQA: S102
    ^^^^^^^^^^^^^^^^^^^^^
  File "/home/docs/checkouts/readthedocs.org/user_builds/llvmlite/checkouts/latest/docs/source/conf.py", line 20, in <module>
    import sphinx_rtd_theme
ModuleNotFoundError: No module named 'sphinx_rtd_theme'
```

This fixes that.