### PR TITLE
Fix / workaround for OrcJIT blocking issues

### DIFF
--- a/llvmlite/tests/test_binding.py
+++ b/llvmlite/tests/test_binding.py
@@ -1222,6 +1222,11 @@ class TestMCJit(BaseTest, JITWithTMTestMixin):
         return llvm.create_mcjit_compiler(mod, target_machine)
 
 
+# There are some memory corruption issues with OrcJIT on AArch64 - see Issue
+# #1000. Since OrcJIT is experimental, and we don't test regularly during
+# llvmlite development on non-x86 platforms, it seems safest to skip these
+# tests on non-x86 platforms.
+@unittest.skipUnless(platform.machine().startswith("x86"), "x86 only")
 class TestOrcLLJIT(BaseTest):
 
     def jit(self, asm=asm_sum, func_name="sum", target_machine=None,

--- a/llvmlite/tests/test_binding.py
+++ b/llvmlite/tests/test_binding.py
@@ -112,6 +112,9 @@ asm_getversion = r"""
     }}
     """
 
+if platform.python_implementation() == 'PyPy':
+    asm_getversion = asm_getversion.replace('Py_GetVersion', 'PyPy_GetVersion')
+
 # `fadd` used on integer inputs
 asm_parse_error = r"""
     ; ModuleID = '<string>'


### PR DESCRIPTION
Since OrcJIT is still experimental, and there seem to be some issues on platforms we don't regularly test on (e.g. Issue #1000), it seems prudent to simply skip the OrcJIT tests on non-x86 platforms.

It also deals with the lack of `Py_GetVersion()`, on PyPy, which causes an error running the tests - on PyPy `PyPy_GetVersion()` is used instead.

Fixes #1003.