### PR TITLE
Remove suggestion that add_global_mapping() is unused

### DIFF
--- a/llvmlite/binding/executionengine.py
+++ b/llvmlite/binding/executionengine.py
@@ -71,7 +71,6 @@ class ExecutionEngine(ffi.ObjectRef):
         return ffi.lib.LLVMPY_GetGlobalValueAddress(self, name.encode("ascii"))
 
     def add_global_mapping(self, gv, addr):
-        # XXX unused?
         ffi.lib.LLVMPY_AddGlobalMapping(self, gv, addr)
 
     def add_module(self, module):


### PR DESCRIPTION
It is used in various places in Numba. The comment here forces the reader to do a little pointless investigation, so remove it.