### PR TITLE
conda-recipe cleanups

### DIFF
--- a/conda-recipes/llvmlite/bld.bat
+++ b/conda-recipes/llvmlite/bld.bat
@@ -20,6 +20,3 @@ if exist ffi\build rmdir /S /Q ffi\build
 
 %PYTHON% -S setup.py install
 if errorlevel 1 exit 1
-
-%PYTHON% runtests.py
-if errorlevel 1 exit 1

--- a/conda-recipes/llvmlite/meta.yaml
+++ b/conda-recipes/llvmlite/meta.yaml
@@ -21,19 +21,20 @@ requirements:
     # We cannot do this on macOS as the llvm-config from the
     # toolchain conflicts with the same from llvmdev, the
     # build.sh deals with it!
-    - {{ compiler('c') }}    # [not (osx or armv6l or armv7l or win)]
-    - {{ compiler('cxx') }}  # [not (osx or armv6l or armv7l or win)]
+    - {{ compiler('c') }}  # not [osx]
+    - {{ compiler('cxx') }}  # not [osx]
     - vs2015_{{ target_platform  }}    # [win]
     # The DLL build uses cmake on Windows
     - cmake          # [win]
-    - make           # [unix and not (armv6l or armv7l or aarch64)]
+    - make           # [unix]
   host:
     - python
+    - setuptools
     # On channel https://anaconda.org/numba/
     - llvmdev 14.* *3
     - vs2015_runtime # [win]
     # llvmdev is built with libz compression support
-    - zlib           # [unix and not (armv6l or armv7l)]
+    - zlib           # [unix]
     # requires libxml2
     - libxml2        # [win]
   run:
@@ -46,8 +47,6 @@ test:
   imports:
     - llvmlite
     - llvmlite.binding
-  commands:
-    - python -m llvmlite.tests
 
 about:
   home: https://github.com/numba/llvmlite

--- a/llvmlite/tests/test_binding.py
+++ b/llvmlite/tests/test_binding.py
@@ -567,7 +567,7 @@ class TestDependencies(BaseTest):
         out, _ = p.communicate()
         self.assertEqual(0, p.returncode)
         # Parse library dependencies
-        lib_pat = re.compile(r'^([-_a-zA-Z0-9]+)\.so(?:\.\d+){0,3}$')
+        lib_pat = re.compile(r'^([+-_a-zA-Z0-9]+)\.so(?:\.\d+){0,3}$')
         deps = set()
         for line in out.decode().splitlines():
             parts = line.split()


### PR DESCRIPTION
Don't duplicate testing. Remove old architectures and fix one regex typo in a test.