### PR TITLE
Add convergent as a supported FunctionAttribute and CallInstrAttribute.

### DIFF
--- a/llvmlite/ir/instructions.py
+++ b/llvmlite/ir/instructions.py
@@ -52,8 +52,8 @@ class Instruction(NamedValue, _HasMetadata):
 
 
 class CallInstrAttributes(AttributeSet):
-    _known = frozenset(['noreturn', 'nounwind', 'readonly', 'readnone',
-                        'noinline', 'alwaysinline'])
+    _known = frozenset(['convergent', 'noreturn', 'nounwind', 'readonly',
+                        'readnone', 'noinline', 'alwaysinline'])
 
 
 TailMarkerOptions = frozenset(['tail', 'musttail', 'notail'])

--- a/llvmlite/ir/values.py
+++ b/llvmlite/ir/values.py
@@ -878,7 +878,7 @@ class AttributeSet(set):
 
 class FunctionAttributes(AttributeSet):
     _known = frozenset([
-        'argmemonly', 'alwaysinline', 'builtin', 'cold',
+        'argmemonly', 'alwaysinline', 'builtin', 'cold', 'convergent',
         'inaccessiblememonly', 'inaccessiblemem_or_argmemonly', 'inlinehint',
         'jumptable', 'minsize', 'naked', 'nobuiltin', 'noduplicate',
         'noimplicitfloat', 'noinline', 'nonlazybind', 'norecurse',


### PR DESCRIPTION
The PR adds a new attribute string to the set of known `FunctionAttributes` and `CallInstrAttributes`.

The `convergent` attribute is needed for certain function declarations and call instructions to generate correct SPMD code for OpenCL. Refer: https://llvm.org/docs/ConvergentOperations.html

