### PR TITLE
Bump minimum supported Python version to 3.9

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -57,7 +57,7 @@ Key Benefits
 Compatibility
 =============
 
-llvmlite has been tested with Python 3.8 -- 3.12 and is likely to work with
+llvmlite has been tested with Python 3.9 -- 3.12 and is likely to work with
 greater versions.
 
 As of version 0.41.0, llvmlite requires LLVM 14.x.x on all architectures

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -5,9 +5,6 @@ jobs:
     name: macOS
     vmImage: macos-11
     matrix:
-      py38:
-        PYTHON: '3.8'
-        CONDA_ENV: cienv
       py39:
         PYTHON: '3.9'
         CONDA_ENV: cienv
@@ -23,10 +20,6 @@ jobs:
     name: Linux
     vmImage: ubuntu-20.04
     matrix:
-      py38:
-        PYTHON: '3.8'
-        CONDA_ENV: cienv
-        RUN_FLAKE8: yes
       py39:
         PYTHON: '3.9'
         CONDA_ENV: cienv
@@ -44,10 +37,6 @@ jobs:
 #       pypy:
 #         PYTHON: pypy
 #         CONDA_ENV: cienv
-      py38_wheel:
-        PYTHON: '3.8'
-        CONDA_ENV: cienv
-        WHEEL: 'yes'
       py39_wheel:
         PYTHON: '3.9'
         CONDA_ENV: cienv

--- a/buildscripts/manylinux_2_17/README.md
+++ b/buildscripts/manylinux_2_17/README.md
@@ -31,6 +31,8 @@ Available Python installations (`<pyver>`) are:
 
 - cp39-cp39
 - cp310-cp310
+- cp311-cp311
+- cp312-cp312
 
 
 Reference: https://github.com/pypa/manylinux

--- a/buildscripts/manylinux_2_17/README.md
+++ b/buildscripts/manylinux_2_17/README.md
@@ -29,7 +29,6 @@ The conda packages will be stored into `<llvmlite_source_root>/docker_output/dis
 
 Available Python installations (`<pyver>`) are:
 
-- cp38-cp38
 - cp39-cp39
 - cp310-cp310
 

--- a/conda-recipes/llvmlite/meta.yaml
+++ b/conda-recipes/llvmlite/meta.yaml
@@ -38,7 +38,7 @@ requirements:
     # requires libxml2
     - libxml2        # [win]
   run:
-    - python >=3.8
+    - python >=3.9
     - vs2015_runtime # [win]
     # osx has dynamically linked libstdc++
     - libcxx >=4.0.1 # [osx]

--- a/docs/source/contributing.rst
+++ b/docs/source/contributing.rst
@@ -95,7 +95,7 @@ you commit changes. You can skip this check with ``git commit --no-verify``.
 Platform support
 ----------------
 
-Llvmlite will be kept compatible with Python 3.8 and later
+Llvmlite will be kept compatible with Python 3.9 and later
 under at least Windows, macOS and Linux.
 
 We do not expect contributors to test their code on all platforms.  Pull

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ import os
 import sys
 
 
-min_python_version = (3, 8)
+min_python_version = (3, 9)
 
 
 def _version_info_str(int_tuple):
@@ -194,7 +194,6 @@ setup(name='llvmlite',
           "Operating System :: OS Independent",
           "Programming Language :: Python",
           "Programming Language :: Python :: 3",
-          "Programming Language :: Python :: 3.8",
           "Programming Language :: Python :: 3.9",
           "Programming Language :: Python :: 3.10",
           "Programming Language :: Python :: 3.11",


### PR DESCRIPTION
As titled,

This PR bumps the supported Python version to `3.9`.