### PR TITLE
Add convergent as a supported FunctionAttribute and CallInstrAttribute.

### DIFF
--- a/llvmlite/ir/instructions.py
+++ b/llvmlite/ir/instructions.py
@@ -52,8 +52,8 @@ class Instruction(NamedValue, _HasMetadata):
 
 
 class CallInstrAttributes(AttributeSet):
-    _known = frozenset(['noreturn', 'nounwind', 'readonly', 'readnone',
-                        'noinline', 'alwaysinline'])
+    _known = frozenset(['convergent', 'noreturn', 'nounwind', 'readonly',
+                        'readnone', 'noinline', 'alwaysinline'])
 
 
 TailMarkerOptions = frozenset(['tail', 'musttail', 'notail'])

--- a/llvmlite/ir/values.py
+++ b/llvmlite/ir/values.py
@@ -878,7 +878,7 @@ class AttributeSet(set):
 
 class FunctionAttributes(AttributeSet):
     _known = frozenset([
-        'argmemonly', 'alwaysinline', 'builtin', 'cold',
+        'argmemonly', 'alwaysinline', 'builtin', 'cold', 'convergent',
         'inaccessiblememonly', 'inaccessiblemem_or_argmemonly', 'inlinehint',
         'jumptable', 'minsize', 'naked', 'nobuiltin', 'noduplicate',
         'noimplicitfloat', 'noinline', 'nonlazybind', 'norecurse',

--- a/llvmlite/tests/test_ir.py
+++ b/llvmlite/tests/test_ir.py
@@ -133,13 +133,15 @@ class TestFunction(TestBase):
         func = self.function()
         func.attributes.add("optsize")
         func.attributes.add("alwaysinline")
+        func.attributes.add("convergent")
         func.attributes.alignstack = 16
         tp_pers = ir.FunctionType(int8, (), var_arg=True)
         pers = ir.Function(self.module(), tp_pers, '__gxx_personality_v0')
         func.attributes.personality = pers
         asm = self.descr(func).strip()
         self.assertEqual(asm,
-                         ("declare %s alwaysinline optsize alignstack(16) "
+                         ("declare %s alwaysinline convergent optsize "
+                          "alignstack(16) "
                           "personality i8 (...)* @\"__gxx_personality_v0\"") %
                          self.proto)
         # Check pickling
@@ -1322,6 +1324,7 @@ my_block:
         builder.call(f, (a, b), 'res_alwaysinline', attrs='alwaysinline')
         builder.call(f, (a, b), 'res_noinline_ro', attrs=('noinline',
                                                           'readonly'))
+        builder.call(f, (a, b), 'res_convergent', attrs='convergent')
         self.check_block(block, """\
         my_block:
             %"res_f" = call float @"f"(i32 %".1", i32 %".2")
@@ -1334,6 +1337,7 @@ my_block:
             %"res_noinline" = call float @"f"(i32 %".1", i32 %".2") noinline
             %"res_alwaysinline" = call float @"f"(i32 %".1", i32 %".2") alwaysinline
             %"res_noinline_ro" = call float @"f"(i32 %".1", i32 %".2") noinline readonly
+            %"res_convergent" = call float @"f"(i32 %".1", i32 %".2") convergent
         """) # noqa E501
 
     def test_call_metadata(self):


### PR DESCRIPTION
The PR adds a new attribute string to the set of known FunctionAttributes and CallInstrAttributes.

The convergent attribute is needed for certain function declarations and call instructions to generate correct SPMD code for OpenCL. Refer: https://llvm.org/docs/ConvergentOperations.html

Supersedes #1016 

PS: #1016 was opened from the `main` branch of my fork. I have moved the changes to a feature branch whose name better indicates the intent of these changes. I will close the PR #1016.