### PR TITLE
skip `raise` basic blocks in `verifyFanoutBackward`

### DIFF
--- a/ffi/custom_passes.cpp
+++ b/ffi/custom_passes.cpp
@@ -400,7 +400,7 @@ struct RefPrunePass : public FunctionPass {
                     SmallBBSet tail_nodes;
                     tail_nodes.insert(decref->getParent());
                     if (!verifyFanoutBackward(incref, incref->getParent(),
-                                              &tail_nodes))
+                                              &tail_nodes, false))
                         continue;
 
                     // scan the CFG between the incref and decref BBs, if
@@ -671,10 +671,12 @@ struct RefPrunePass : public FunctionPass {
                 for (BasicBlock *bb : *decref_blocks) {
                     raising_blocks.insert(bb);
                 }
-                if (verifyFanoutBackward(incref, head_node, p_raising_blocks))
+                if (verifyFanoutBackward(incref, head_node, p_raising_blocks,
+                                         prune_raise_exit))
                     return true;
 
-            } else if (verifyFanoutBackward(incref, head_node, decref_blocks)) {
+            } else if (verifyFanoutBackward(incref, head_node, decref_blocks,
+                                            prune_raise_exit)) {
                 return true;
             }
         }
@@ -867,7 +869,7 @@ struct RefPrunePass : public FunctionPass {
      *
      */
     bool verifyFanoutBackward(CallInst *incref, BasicBlock *head_node,
-                              const SmallBBSet *tail_nodes) {
+                              const SmallBBSet *tail_nodes, bool prune_raise_exit) {
         // push the tail nodes into a work list
         SmallVector<BasicBlock *, 10> todo;
         for (BasicBlock *bb : *tail_nodes) {
@@ -888,7 +890,7 @@ struct RefPrunePass : public FunctionPass {
                 // Get a basic block
                 BasicBlock *cur_node = workstack.pop_back_val();
                 // If cur_node is a raising block, then skip it
-                if (isRaising(cur_node)) {
+                if (prune_raise_exit && isRaising(cur_node)) {
                     continue;
                 }
                 // if the block has been seen before then skip

--- a/ffi/custom_passes.cpp
+++ b/ffi/custom_passes.cpp
@@ -401,6 +401,7 @@ struct RefPrunePass : public FunctionPass {
                     tail_nodes.insert(decref->getParent());
                     if (!verifyFanoutBackward(incref, incref->getParent(),
                                               &tail_nodes, false))
+
                         continue;
 
                     // scan the CFG between the incref and decref BBs, if
@@ -869,7 +870,8 @@ struct RefPrunePass : public FunctionPass {
      *
      */
     bool verifyFanoutBackward(CallInst *incref, BasicBlock *head_node,
-                              const SmallBBSet *tail_nodes, bool prune_raise_exit) {
+                              const SmallBBSet *tail_nodes,
+                              bool prune_raise_exit) {
         // push the tail nodes into a work list
         SmallVector<BasicBlock *, 10> todo;
         for (BasicBlock *bb : *tail_nodes) {


### PR DESCRIPTION
I provide a potential fix for #1023 .
But I can't prove it in theory, maybe you can give a counterexample against this PR.
Will provide a test case for this.

fix #1023 