### PR TITLE
Update llvmlite to be compatible with llvm-17

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -8,15 +8,19 @@ jobs:
       py39:
         PYTHON: '3.9'
         CONDA_ENV: cienv
+        LLVM: '17'
       py310:
         PYTHON: '3.10'
         CONDA_ENV: cienv
+        LLVM: '17'
       py311:
         PYTHON: '3.11'
         CONDA_ENV: cienv
+        LLVM: '17'
       py312:
         PYTHON: '3.12'
         CONDA_ENV: cienv
+        LLVM: '17'
 
 - template: buildscripts/azure/azure-linux-macos.yml
   parameters:
@@ -27,20 +31,24 @@ jobs:
         PYTHON: '3.9'
         CONDA_ENV: cienv
         RUN_FLAKE8: yes
+        LLVM: '17'
       py310:
         PYTHON: '3.10'
         CONDA_ENV: cienv
         RUN_FLAKE8: yes
+        LLVM: '17'
       py311:
         PYTHON: '3.11'
         CONDA_ENV: cienv
         RUN_FLAKE8: yes
         RUN_CLANG_FORMAT: yes
+        LLVM: '17'
       py312:
         PYTHON: '3.12'
         CONDA_ENV: cienv
         RUN_FLAKE8: yes
         RUN_CLANG_FORMAT: yes
+        LLVM: '17'
 # temporarily disabled
 #       pypy:
 #         PYTHON: pypy
@@ -49,18 +57,22 @@ jobs:
         PYTHON: '3.9'
         CONDA_ENV: cienv
         WHEEL: 'yes'
+        LLVM: '17'
       py310_wheel:
         PYTHON: '3.10'
         CONDA_ENV: cienv
         WHEEL: 'yes'
+        LLVM: '17'
       py311_wheel:
         PYTHON: '3.11'
         CONDA_ENV: cienv
         WHEEL: 'yes'
+        LLVM: '17'
       py312_wheel:
         PYTHON: '3.12'
         CONDA_ENV: cienv
         WHEEL: 'yes'
+        LLVM: '17'
 
       py39_docs:
         PYTHON: '3.9'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -18,10 +18,10 @@ jobs:
         PYTHON: '3.12'
         CONDA_ENV: cienv
 
-      llvm15:
+      llvm17:
         PYTHON: '3.12'
         CONDA_ENV: cienv
-        LLVM: '15'
+        LLVM: '17'
 
 - template: buildscripts/azure/azure-linux-macos.yml
   parameters:
@@ -72,10 +72,10 @@ jobs:
         CONDA_ENV: cienv
         BUILD_DOCS: 'yes'
 
-      llvm15:
+      llvm17:
         PYTHON: '3.12'
         CONDA_ENV: cienv
-        LLVM: '15'
+        LLVM: '17'
 
 - template: buildscripts/azure/azure-windows.yml
   parameters:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -18,11 +18,6 @@ jobs:
         PYTHON: '3.12'
         CONDA_ENV: cienv
 
-      llvm17:
-        PYTHON: '3.12'
-        CONDA_ENV: cienv
-        LLVM: '17'
-
 - template: buildscripts/azure/azure-linux-macos.yml
   parameters:
     name: Linux
@@ -71,11 +66,6 @@ jobs:
         PYTHON: '3.9'
         CONDA_ENV: cienv
         BUILD_DOCS: 'yes'
-
-      llvm17:
-        PYTHON: '3.12'
-        CONDA_ENV: cienv
-        LLVM: '17'
 
 - template: buildscripts/azure/azure-windows.yml
   parameters:

--- a/buildscripts/azure/azure-windows.yml
+++ b/buildscripts/azure/azure-windows.yml
@@ -12,15 +12,19 @@ jobs:
       py39:
         PYTHON: '3.9'
         CONDA_ENV: cienv
+        LLVM: '17'
       py310:
         PYTHON: '3.10'
         CONDA_ENV: cienv
+        LLVM: '17'
       py311:
         PYTHON: '3.11'
         CONDA_ENV: cienv
+        LLVM: '17'
       py312:
         PYTHON: '3.12'
         CONDA_ENV: cienv
+        LLVM: '17'
 
   steps:
 

--- a/buildscripts/azure/azure-windows.yml
+++ b/buildscripts/azure/azure-windows.yml
@@ -22,10 +22,10 @@ jobs:
         PYTHON: '3.12'
         CONDA_ENV: cienv
 
-      llvm15:
+      llvm17:
         PYTHON: '3.12'
         CONDA_ENV: cienv
-        LLVM: '15'
+        LLVM: '17'
 
   steps:
 

--- a/buildscripts/azure/azure-windows.yml
+++ b/buildscripts/azure/azure-windows.yml
@@ -22,11 +22,6 @@ jobs:
         PYTHON: '3.12'
         CONDA_ENV: cienv
 
-      llvm17:
-        PYTHON: '3.12'
-        CONDA_ENV: cienv
-        LLVM: '17'
-
   steps:
 
     - powershell: |

--- a/buildscripts/incremental/build.cmd
+++ b/buildscripts/incremental/build.cmd
@@ -15,9 +15,7 @@ call activate %CONDA_ENV%
 @rem - https://github.com/conda-forge/llvmdev-feedstock/issues/175
 @rem - https://github.com/conda-forge/llvmdev-feedstock/pull/223
 @rem - https://github.com/MicrosoftDocs/visualstudio-docs/issues/7774
-if "%LLVM%"=="17" (
-  call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\Common7\Tools\VsDevCmd.bat"
-  if %errorlevel% neq 0 exit /b %errorlevel%
-)
+call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\Common7\Tools\VsDevCmd.bat"
+if %errorlevel% neq 0 exit /b %errorlevel%
 
 python setup.py build

--- a/buildscripts/incremental/build.cmd
+++ b/buildscripts/incremental/build.cmd
@@ -15,7 +15,7 @@ call activate %CONDA_ENV%
 @rem - https://github.com/conda-forge/llvmdev-feedstock/issues/175
 @rem - https://github.com/conda-forge/llvmdev-feedstock/pull/223
 @rem - https://github.com/MicrosoftDocs/visualstudio-docs/issues/7774
-if "%LLVM%"=="15" (
+if "%LLVM%"=="17" (
   call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\Common7\Tools\VsDevCmd.bat"
   if %errorlevel% neq 0 exit /b %errorlevel%
 )

--- a/buildscripts/incremental/setup_conda_environment.cmd
+++ b/buildscripts/incremental/setup_conda_environment.cmd
@@ -14,7 +14,7 @@ call activate %CONDA_ENV%
 if %errorlevel% neq 0 exit /b %errorlevel%
 
 @rem Install llvmdev
-if "%LLVM%"=="15" (
+if "%LLVM%"=="17" (
   set LLVMDEV_CHANNEL="conda-forge"
 ) else (
   set LLVMDEV_CHANNEL="numba/label/dev"

--- a/buildscripts/incremental/setup_conda_environment.cmd
+++ b/buildscripts/incremental/setup_conda_environment.cmd
@@ -14,11 +14,7 @@ call activate %CONDA_ENV%
 if %errorlevel% neq 0 exit /b %errorlevel%
 
 @rem Install llvmdev
-if "%LLVM%"=="17" (
-  set LLVMDEV_CHANNEL="conda-forge"
-) else (
-  set LLVMDEV_CHANNEL="numba/label/dev"
-)
+set LLVMDEV_CHANNEL="conda-forge"
 
 call conda install -y -q -c %LLVMDEV_CHANNEL% llvmdev="%LLVM%" libxml2
 if %errorlevel% neq 0 exit /b %errorlevel%

--- a/buildscripts/incremental/setup_conda_environment.sh
+++ b/buildscripts/incremental/setup_conda_environment.sh
@@ -27,8 +27,8 @@ source activate $CONDA_ENV
 set -v
 
 # Install llvmdev (separate channel, for now)
-if [ "$LLVM" == "15" ]; then
-    $CONDA_INSTALL -c conda-forge llvmdev="15"
+if [ "$LLVM" == "17" ]; then
+    $CONDA_INSTALL -c conda-forge llvmdev="17"
 else
     $CONDA_INSTALL -c numba/label/dev llvmdev="14.*"
 fi

--- a/buildscripts/incremental/setup_conda_environment.sh
+++ b/buildscripts/incremental/setup_conda_environment.sh
@@ -27,11 +27,7 @@ source activate $CONDA_ENV
 set -v
 
 # Install llvmdev (separate channel, for now)
-if [ "$LLVM" == "17" ]; then
-    $CONDA_INSTALL -c conda-forge llvmdev="17"
-else
-    $CONDA_INSTALL -c numba/label/dev llvmdev="14.*"
-fi
+$CONDA_INSTALL -c conda-forge llvmdev="17"
 
 # Install the compiler toolchain, for osx, bootstrapping needed
 # which happens in build.sh

--- a/buildscripts/incremental/setup_conda_environment.sh
+++ b/buildscripts/incremental/setup_conda_environment.sh
@@ -27,7 +27,7 @@ source activate $CONDA_ENV
 set -v
 
 # Install llvmdev (separate channel, for now)
-$CONDA_INSTALL -c conda-forge llvmdev="17"
+$CONDA_INSTALL -c conda-forge llvmdev="%LLVM%"
 
 # Install the compiler toolchain, for osx, bootstrapping needed
 # which happens in build.sh

--- a/buildscripts/incremental/setup_conda_environment.sh
+++ b/buildscripts/incremental/setup_conda_environment.sh
@@ -27,7 +27,7 @@ source activate $CONDA_ENV
 set -v
 
 # Install llvmdev (separate channel, for now)
-$CONDA_INSTALL -c conda-forge llvmdev="%LLVM%"
+$CONDA_INSTALL -c conda-forge llvmdev=17
 
 # Install the compiler toolchain, for osx, bootstrapping needed
 # which happens in build.sh

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -302,5 +302,5 @@ texinfo_documents = [
 # Example configuration for intersphinx: refer to the Python standard library.
 intersphinx_mapping = {
     'python': ('https://docs.python.org/3', None),
-    'llvm': ('http://llvm.org/releases/14.0.0/docs', None),
+    'llvm': ('http://llvm.org/releases/17.0.0/docs', None),
     }

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -302,5 +302,5 @@ texinfo_documents = [
 # Example configuration for intersphinx: refer to the Python standard library.
 intersphinx_mapping = {
     'python': ('https://docs.python.org/3', None),
-    'llvm': ('http://llvm.org/releases/17.0.0/docs', None),
+    'llvm': ('http://llvm.org/releases/17.0.1/docs', None),
     }

--- a/ffi/CMakeLists.txt
+++ b/ffi/CMakeLists.txt
@@ -6,6 +6,10 @@ project(llvmlite_ffi)
 
 include(CheckIncludeFiles)
 
+# LLVM-17 needs C++17 to compile successfully
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
 if(NOT MSVC)
   set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fno-rtti -g")
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-rtti -g")

--- a/ffi/build.py
+++ b/ffi/build.py
@@ -167,13 +167,9 @@ def main_posix(kind, library_ext):
     else:
         (version, _) = out.split('.', 1)
         version = int(version)
-        if version == 17:
-            msg = ("Building with LLVM 17; note that LLVM 17 support is "
-                   "presently experimental")
-            show_warning(msg)
-        elif version != 14:
+        if version != 17:
 
-            msg = ("Building llvmlite requires LLVM 14, got "
+            msg = ("Building llvmlite requires LLVM 17, got "
                    "{!r}. Be sure to set LLVM_CONFIG to the right executable "
                    "path.\nRead the documentation at "
                    "http://llvmlite.pydata.org/ for more information about "

--- a/ffi/build.py
+++ b/ffi/build.py
@@ -167,8 +167,8 @@ def main_posix(kind, library_ext):
     else:
         (version, _) = out.split('.', 1)
         version = int(version)
-        if version == 15:
-            msg = ("Building with LLVM 15; note that LLVM 15 support is "
+        if version == 17:
+            msg = ("Building with LLVM 17; note that LLVM 17 support is "
                    "presently experimental")
             show_warning(msg)
         elif version != 14:

--- a/ffi/core.cpp
+++ b/ffi/core.cpp
@@ -23,18 +23,12 @@ LLVMPY_DisposeString(const char *msg) { free(const_cast<char *>(msg)); }
 API_EXPORT(LLVMContextRef)
 LLVMPY_GetGlobalContext() {
     auto context = LLVMGetGlobalContext();
-#if LLVM_VERSION_MAJOR > 14
-    LLVMContextSetOpaquePointers(context, false);
-#endif
     return context;
 }
 
 API_EXPORT(LLVMContextRef)
 LLVMPY_ContextCreate() {
     LLVMContextRef context = LLVMContextCreate();
-#if LLVM_VERSION_MAJOR > 14
-    LLVMContextSetOpaquePointers(context, false);
-#endif
     return context;
 }
 

--- a/ffi/custom_passes.cpp
+++ b/ffi/custom_passes.cpp
@@ -1186,11 +1186,6 @@ class RefNormalizePass : public PassInfoMixin<RefNormalizePass> {
     }
 };
 
-PreservedAnalyses AAEvaluator::run(Function &F, FunctionAnalysisManager &AM) {
-
-    return PreservedAnalyses::all();
-}
-
 class RefNormalizeLegacyPass : public FunctionPass {
   public:
     static char ID;

--- a/ffi/custom_passes.cpp
+++ b/ffi/custom_passes.cpp
@@ -1,5 +1,5 @@
 
-#include "core.h"
+#include "ffi_types.h"
 
 #include "llvm/IR/BasicBlock.h"
 #include "llvm/IR/Function.h"
@@ -1252,10 +1252,6 @@ INITIALIZE_PASS_DEPENDENCY(PostDominatorTreeWrapperPass)
 
 INITIALIZE_PASS_END(RefPruneLegacyPass, "RefPruneLegacyPass",
                     "Prune NRT refops", false, false)
-
-typedef llvm::ModulePassManager *LLVMModulePassManager;
-
-typedef llvm::FunctionAnalysisManager *LLVMFunctionAnalysisManager;
 
 extern "C" {
 

--- a/ffi/ffi_types.h
+++ b/ffi/ffi_types.h
@@ -3,9 +3,9 @@
 
 #include "core.h"
 
-#include "llvm/Passes/PassBuilder.h"
 #include "llvm/IR/PassManager.h"
 #include "llvm/IR/PassTimingInfo.h"
+#include "llvm/Passes/PassBuilder.h"
 
 typedef llvm::PassBuilder *LLVMPassBuilder;
 

--- a/ffi/ffi_types.h
+++ b/ffi/ffi_types.h
@@ -1,0 +1,28 @@
+
+#pragma once
+
+#include "core.h"
+
+#include "llvm/Passes/PassBuilder.h"
+#include "llvm/IR/PassManager.h"
+#include "llvm/IR/PassTimingInfo.h"
+
+typedef llvm::PassBuilder *LLVMPassBuilder;
+
+typedef llvm::FunctionPassManager *LLVMFunctionPassManager;
+
+typedef llvm::ModulePassManager *LLVMModulePassManager;
+
+typedef llvm::FunctionAnalysisManager *LLVMFunctionAnalysisManager;
+
+typedef llvm::ModuleAnalysisManager *LLVMModuleAnalysisManager;
+
+typedef llvm::CGSCCAnalysisManager *LLVMCGSCCAnalysisManager;
+
+typedef llvm::LoopAnalysisManager *LLVMLoopAnalysisManager;
+
+typedef llvm::PassInstrumentationCallbacks *LLVMPassInstrumentationCallbacks;
+
+typedef llvm::TimePassesHandler *LLVMTimePassesHandler;
+
+typedef llvm::OptimizationLevel const *LLVMOptimizationLevel;

--- a/ffi/initfini.cpp
+++ b/ffi/initfini.cpp
@@ -1,27 +1,30 @@
 #include "llvm-c/Core.h"
-#include "llvm-c/Initialization.h"
 #include "llvm-c/Target.h"
 
 #include "core.h"
 #include "llvm/Config/llvm-config.h"
+#include "llvm/InitializePasses.h"
+#include "llvm/PassRegistry.h"
 
 extern "C" {
 
 #define INIT(F)                                                                \
     API_EXPORT(void) LLVMPY_Initialize##F() {                                  \
-        LLVMInitialize##F(LLVMGetGlobalPassRegistry());                        \
+        llvm::initialize##F(*llvm::PassRegistry::getPassRegistry());           \
     }
 
 INIT(Core)
 INIT(TransformUtils)
 INIT(ScalarOpts)
-INIT(ObjCARCOpts)
+// https://github.com/llvm/llvm-project/commit/4153f989bab0f2f300fa8d3001ebeef7b6d9672c
+// INIT(ObjCARCOpts)
 INIT(Vectorization)
 INIT(InstCombine)
 INIT(IPO)
 // INIT(Instrumentation)
 INIT(Analysis)
-INIT(IPA)
+// https://reviews.llvm.org/D145043, done in Analysis
+// INIT(IPA)
 INIT(CodeGen)
 INIT(Target)
 

--- a/ffi/initfini.cpp
+++ b/ffi/initfini.cpp
@@ -8,28 +8,6 @@
 
 extern "C" {
 
-#define INIT(F)                                                                \
-    API_EXPORT(void) LLVMPY_Initialize##F() {                                  \
-        llvm::initialize##F(*llvm::PassRegistry::getPassRegistry());           \
-    }
-
-INIT(Core)
-INIT(TransformUtils)
-INIT(ScalarOpts)
-// https://github.com/llvm/llvm-project/commit/4153f989bab0f2f300fa8d3001ebeef7b6d9672c
-// INIT(ObjCARCOpts)
-INIT(Vectorization)
-INIT(InstCombine)
-INIT(IPO)
-// INIT(Instrumentation)
-INIT(Analysis)
-// https://reviews.llvm.org/D145043, done in Analysis
-// INIT(IPA)
-INIT(CodeGen)
-INIT(Target)
-
-#undef INIT
-
 API_EXPORT(void)
 LLVMPY_Shutdown() { LLVMShutdown(); }
 

--- a/ffi/memorymanager.h
+++ b/ffi/memorymanager.h
@@ -174,11 +174,10 @@ class API_EXPORT(LlvmliteMemoryManager : public RTDyldMemoryManager) {
 
     virtual bool needsToReserveAllocationSpace() override { return true; }
 
-    virtual void reserveAllocationSpace(uintptr_t CodeSize, uint32_t CodeAlign,
-                                        uintptr_t RODataSize,
-                                        uint32_t RODataAlign,
+    virtual void reserveAllocationSpace(uintptr_t CodeSize, Align CodeAlign,
+                                        uintptr_t RODataSize, Align RODataAlign,
                                         uintptr_t RWDataSize,
-                                        uint32_t RWDataAlign) override;
+                                        Align RWDataAlign) override;
 
   private:
     struct FreeMemBlock {

--- a/ffi/orcjit.cpp
+++ b/ffi/orcjit.cpp
@@ -200,8 +200,8 @@ LLVMPY_LLJIT_Link(std::shared_ptr<LLJIT> *lljit, const char *libraryName,
     for (size_t import_idx = 0; import_idx < imports_length; import_idx++) {
         SymbolStringPtr mangled =
             (*lljit)->mangleAndIntern(imports[import_idx].name);
-        JITEvaluatedSymbol symbol(imports[import_idx].address,
-                                  JITSymbolFlags::Exported);
+        ExecutorSymbolDef symbol(ExecutorAddr(imports[import_idx].address),
+                                 JITSymbolFlags::Exported);
         auto error = dylib->define(absoluteSymbols({{mangled, symbol}}));
 
         if (error) {

--- a/ffi/passmanagers.cpp
+++ b/ffi/passmanagers.cpp
@@ -2,8 +2,6 @@
 
 #include "core.h"
 
-#include "llvm-c/Transforms/IPO.h"
-#include "llvm-c/Transforms/Scalar.h"
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/IR/DiagnosticInfo.h"
 #include "llvm/IR/DiagnosticPrinter.h"
@@ -14,8 +12,253 @@
 #include "llvm/Support/YAMLTraits.h"
 #include "llvm/Support/raw_ostream.h"
 
-#include "llvm-c/Transforms/IPO.h"
-#include "llvm-c/Transforms/Scalar.h"
+// From PassBuilder.cpp
+#include "llvm/Analysis/AliasAnalysisEvaluator.h"
+#include "llvm/Analysis/AliasSetTracker.h"
+#include "llvm/Analysis/AssumptionCache.h"
+#include "llvm/Analysis/BasicAliasAnalysis.h"
+#include "llvm/Analysis/BlockFrequencyInfo.h"
+#include "llvm/Analysis/BranchProbabilityInfo.h"
+#include "llvm/Analysis/CFGPrinter.h"
+#include "llvm/Analysis/CFGSCCPrinter.h"
+#include "llvm/Analysis/CGSCCPassManager.h"
+#include "llvm/Analysis/CallGraph.h"
+#include "llvm/Analysis/CallPrinter.h"
+#include "llvm/Analysis/CostModel.h"
+#include "llvm/Analysis/CycleAnalysis.h"
+#include "llvm/Analysis/DDG.h"
+#include "llvm/Analysis/DDGPrinter.h"
+#include "llvm/Analysis/Delinearization.h"
+#include "llvm/Analysis/DemandedBits.h"
+#include "llvm/Analysis/DependenceAnalysis.h"
+#include "llvm/Analysis/DomPrinter.h"
+#include "llvm/Analysis/DominanceFrontier.h"
+#include "llvm/Analysis/FunctionPropertiesAnalysis.h"
+#include "llvm/Analysis/GlobalsModRef.h"
+#include "llvm/Analysis/IRSimilarityIdentifier.h"
+#include "llvm/Analysis/IVUsers.h"
+#include "llvm/Analysis/InlineAdvisor.h"
+#include "llvm/Analysis/InlineSizeEstimatorAnalysis.h"
+#include "llvm/Analysis/InstCount.h"
+#include "llvm/Analysis/LazyCallGraph.h"
+#include "llvm/Analysis/LazyValueInfo.h"
+#include "llvm/Analysis/Lint.h"
+#include "llvm/Analysis/LoopAccessAnalysis.h"
+#include "llvm/Analysis/LoopCacheAnalysis.h"
+#include "llvm/Analysis/LoopInfo.h"
+#include "llvm/Analysis/LoopNestAnalysis.h"
+#include "llvm/Analysis/MemDerefPrinter.h"
+#include "llvm/Analysis/MemoryDependenceAnalysis.h"
+#include "llvm/Analysis/MemorySSA.h"
+#include "llvm/Analysis/ModuleDebugInfoPrinter.h"
+#include "llvm/Analysis/ModuleSummaryAnalysis.h"
+#include "llvm/Analysis/MustExecute.h"
+#include "llvm/Analysis/ObjCARCAliasAnalysis.h"
+#include "llvm/Analysis/OptimizationRemarkEmitter.h"
+#include "llvm/Analysis/PhiValues.h"
+#include "llvm/Analysis/PostDominators.h"
+#include "llvm/Analysis/ProfileSummaryInfo.h"
+#include "llvm/Analysis/RegionInfo.h"
+#include "llvm/Analysis/ScalarEvolution.h"
+#include "llvm/Analysis/ScalarEvolutionAliasAnalysis.h"
+#include "llvm/Analysis/ScopedNoAliasAA.h"
+#include "llvm/Analysis/StackLifetime.h"
+#include "llvm/Analysis/StackSafetyAnalysis.h"
+#include "llvm/Analysis/TargetLibraryInfo.h"
+#include "llvm/Analysis/TargetTransformInfo.h"
+#include "llvm/Analysis/TypeBasedAliasAnalysis.h"
+#include "llvm/Analysis/UniformityAnalysis.h"
+#include "llvm/CodeGen/HardwareLoops.h"
+#include "llvm/CodeGen/TypePromotion.h"
+#include "llvm/IR/DebugInfo.h"
+#include "llvm/IR/Dominators.h"
+#include "llvm/IR/PassManager.h"
+#include "llvm/IR/PrintPasses.h"
+#include "llvm/IR/SafepointIRVerifier.h"
+#include "llvm/IR/Verifier.h"
+#include "llvm/IRPrinter/IRPrintingPasses.h"
+#include "llvm/Passes/OptimizationLevel.h"
+#include "llvm/Passes/PassBuilder.h"
+#include "llvm/Support/CommandLine.h"
+#include "llvm/Support/Debug.h"
+#include "llvm/Support/ErrorHandling.h"
+#include "llvm/Support/FormatVariadic.h"
+#include "llvm/Support/Regex.h"
+#include "llvm/Target/TargetMachine.h"
+#include "llvm/Transforms/AggressiveInstCombine/AggressiveInstCombine.h"
+#include "llvm/Transforms/Coroutines/CoroCleanup.h"
+#include "llvm/Transforms/Coroutines/CoroConditionalWrapper.h"
+#include "llvm/Transforms/Coroutines/CoroEarly.h"
+#include "llvm/Transforms/Coroutines/CoroElide.h"
+#include "llvm/Transforms/Coroutines/CoroSplit.h"
+#include "llvm/Transforms/IPO/AlwaysInliner.h"
+#include "llvm/Transforms/IPO/Annotation2Metadata.h"
+#include "llvm/Transforms/IPO/ArgumentPromotion.h"
+#include "llvm/Transforms/IPO/Attributor.h"
+#include "llvm/Transforms/IPO/BlockExtractor.h"
+#include "llvm/Transforms/IPO/CalledValuePropagation.h"
+#include "llvm/Transforms/IPO/ConstantMerge.h"
+#include "llvm/Transforms/IPO/CrossDSOCFI.h"
+#include "llvm/Transforms/IPO/DeadArgumentElimination.h"
+#include "llvm/Transforms/IPO/ElimAvailExtern.h"
+#include "llvm/Transforms/IPO/EmbedBitcodePass.h"
+#include "llvm/Transforms/IPO/ForceFunctionAttrs.h"
+#include "llvm/Transforms/IPO/FunctionAttrs.h"
+#include "llvm/Transforms/IPO/FunctionImport.h"
+#include "llvm/Transforms/IPO/GlobalDCE.h"
+#include "llvm/Transforms/IPO/GlobalOpt.h"
+#include "llvm/Transforms/IPO/GlobalSplit.h"
+#include "llvm/Transforms/IPO/HotColdSplitting.h"
+#include "llvm/Transforms/IPO/IROutliner.h"
+#include "llvm/Transforms/IPO/InferFunctionAttrs.h"
+#include "llvm/Transforms/IPO/Inliner.h"
+#include "llvm/Transforms/IPO/Internalize.h"
+#include "llvm/Transforms/IPO/LoopExtractor.h"
+#include "llvm/Transforms/IPO/LowerTypeTests.h"
+#include "llvm/Transforms/IPO/MemProfContextDisambiguation.h"
+#include "llvm/Transforms/IPO/MergeFunctions.h"
+#include "llvm/Transforms/IPO/ModuleInliner.h"
+#include "llvm/Transforms/IPO/OpenMPOpt.h"
+#include "llvm/Transforms/IPO/PartialInlining.h"
+#include "llvm/Transforms/IPO/SCCP.h"
+#include "llvm/Transforms/IPO/SampleProfile.h"
+#include "llvm/Transforms/IPO/SampleProfileProbe.h"
+#include "llvm/Transforms/IPO/StripDeadPrototypes.h"
+#include "llvm/Transforms/IPO/StripSymbols.h"
+#include "llvm/Transforms/IPO/SyntheticCountsPropagation.h"
+#include "llvm/Transforms/IPO/WholeProgramDevirt.h"
+#include "llvm/Transforms/InstCombine/InstCombine.h"
+#include "llvm/Transforms/Instrumentation.h"
+#include "llvm/Transforms/Instrumentation/AddressSanitizer.h"
+#include "llvm/Transforms/Instrumentation/BoundsChecking.h"
+#include "llvm/Transforms/Instrumentation/CGProfile.h"
+#include "llvm/Transforms/Instrumentation/ControlHeightReduction.h"
+#include "llvm/Transforms/Instrumentation/DataFlowSanitizer.h"
+#include "llvm/Transforms/Instrumentation/GCOVProfiler.h"
+#include "llvm/Transforms/Instrumentation/HWAddressSanitizer.h"
+#include "llvm/Transforms/Instrumentation/InstrOrderFile.h"
+#include "llvm/Transforms/Instrumentation/InstrProfiling.h"
+#include "llvm/Transforms/Instrumentation/KCFI.h"
+#include "llvm/Transforms/Instrumentation/MemProfiler.h"
+#include "llvm/Transforms/Instrumentation/MemorySanitizer.h"
+#include "llvm/Transforms/Instrumentation/PGOInstrumentation.h"
+#include "llvm/Transforms/Instrumentation/PoisonChecking.h"
+#include "llvm/Transforms/Instrumentation/SanitizerBinaryMetadata.h"
+#include "llvm/Transforms/Instrumentation/SanitizerCoverage.h"
+#include "llvm/Transforms/Instrumentation/ThreadSanitizer.h"
+#include "llvm/Transforms/ObjCARC.h"
+#include "llvm/Transforms/Scalar/ADCE.h"
+#include "llvm/Transforms/Scalar/AlignmentFromAssumptions.h"
+#include "llvm/Transforms/Scalar/AnnotationRemarks.h"
+#include "llvm/Transforms/Scalar/BDCE.h"
+#include "llvm/Transforms/Scalar/CallSiteSplitting.h"
+#include "llvm/Transforms/Scalar/ConstantHoisting.h"
+#include "llvm/Transforms/Scalar/ConstraintElimination.h"
+#include "llvm/Transforms/Scalar/CorrelatedValuePropagation.h"
+#include "llvm/Transforms/Scalar/DCE.h"
+#include "llvm/Transforms/Scalar/DFAJumpThreading.h"
+#include "llvm/Transforms/Scalar/DeadStoreElimination.h"
+#include "llvm/Transforms/Scalar/DivRemPairs.h"
+#include "llvm/Transforms/Scalar/EarlyCSE.h"
+#include "llvm/Transforms/Scalar/FlattenCFG.h"
+#include "llvm/Transforms/Scalar/Float2Int.h"
+#include "llvm/Transforms/Scalar/GVN.h"
+#include "llvm/Transforms/Scalar/GuardWidening.h"
+#include "llvm/Transforms/Scalar/IVUsersPrinter.h"
+#include "llvm/Transforms/Scalar/IndVarSimplify.h"
+#include "llvm/Transforms/Scalar/InductiveRangeCheckElimination.h"
+#include "llvm/Transforms/Scalar/InferAddressSpaces.h"
+#include "llvm/Transforms/Scalar/InstSimplifyPass.h"
+#include "llvm/Transforms/Scalar/JumpThreading.h"
+#include "llvm/Transforms/Scalar/LICM.h"
+#include "llvm/Transforms/Scalar/LoopAccessAnalysisPrinter.h"
+#include "llvm/Transforms/Scalar/LoopBoundSplit.h"
+#include "llvm/Transforms/Scalar/LoopDataPrefetch.h"
+#include "llvm/Transforms/Scalar/LoopDeletion.h"
+#include "llvm/Transforms/Scalar/LoopDistribute.h"
+#include "llvm/Transforms/Scalar/LoopFlatten.h"
+#include "llvm/Transforms/Scalar/LoopFuse.h"
+#include "llvm/Transforms/Scalar/LoopIdiomRecognize.h"
+#include "llvm/Transforms/Scalar/LoopInstSimplify.h"
+#include "llvm/Transforms/Scalar/LoopInterchange.h"
+#include "llvm/Transforms/Scalar/LoopLoadElimination.h"
+#include "llvm/Transforms/Scalar/LoopPassManager.h"
+#include "llvm/Transforms/Scalar/LoopPredication.h"
+#include "llvm/Transforms/Scalar/LoopReroll.h"
+#include "llvm/Transforms/Scalar/LoopRotation.h"
+#include "llvm/Transforms/Scalar/LoopSimplifyCFG.h"
+#include "llvm/Transforms/Scalar/LoopSink.h"
+#include "llvm/Transforms/Scalar/LoopStrengthReduce.h"
+#include "llvm/Transforms/Scalar/LoopUnrollAndJamPass.h"
+#include "llvm/Transforms/Scalar/LoopUnrollPass.h"
+#include "llvm/Transforms/Scalar/LoopVersioningLICM.h"
+#include "llvm/Transforms/Scalar/LowerAtomicPass.h"
+#include "llvm/Transforms/Scalar/LowerConstantIntrinsics.h"
+#include "llvm/Transforms/Scalar/LowerExpectIntrinsic.h"
+#include "llvm/Transforms/Scalar/LowerGuardIntrinsic.h"
+#include "llvm/Transforms/Scalar/LowerMatrixIntrinsics.h"
+#include "llvm/Transforms/Scalar/LowerWidenableCondition.h"
+#include "llvm/Transforms/Scalar/MakeGuardsExplicit.h"
+#include "llvm/Transforms/Scalar/MemCpyOptimizer.h"
+#include "llvm/Transforms/Scalar/MergeICmps.h"
+#include "llvm/Transforms/Scalar/MergedLoadStoreMotion.h"
+#include "llvm/Transforms/Scalar/NaryReassociate.h"
+#include "llvm/Transforms/Scalar/NewGVN.h"
+#include "llvm/Transforms/Scalar/PartiallyInlineLibCalls.h"
+#include "llvm/Transforms/Scalar/PlaceSafepoints.h"
+#include "llvm/Transforms/Scalar/Reassociate.h"
+#include "llvm/Transforms/Scalar/Reg2Mem.h"
+#include "llvm/Transforms/Scalar/RewriteStatepointsForGC.h"
+#include "llvm/Transforms/Scalar/SCCP.h"
+#include "llvm/Transforms/Scalar/SROA.h"
+#include "llvm/Transforms/Scalar/ScalarizeMaskedMemIntrin.h"
+#include "llvm/Transforms/Scalar/Scalarizer.h"
+#include "llvm/Transforms/Scalar/SeparateConstOffsetFromGEP.h"
+#include "llvm/Transforms/Scalar/SimpleLoopUnswitch.h"
+#include "llvm/Transforms/Scalar/SimplifyCFG.h"
+#include "llvm/Transforms/Scalar/Sink.h"
+#include "llvm/Transforms/Scalar/SpeculativeExecution.h"
+#include "llvm/Transforms/Scalar/StraightLineStrengthReduce.h"
+#include "llvm/Transforms/Scalar/StructurizeCFG.h"
+#include "llvm/Transforms/Scalar/TLSVariableHoist.h"
+#include "llvm/Transforms/Scalar/TailRecursionElimination.h"
+#include "llvm/Transforms/Scalar/WarnMissedTransforms.h"
+#include "llvm/Transforms/Utils/AddDiscriminators.h"
+#include "llvm/Transforms/Utils/AssumeBundleBuilder.h"
+#include "llvm/Transforms/Utils/BreakCriticalEdges.h"
+#include "llvm/Transforms/Utils/CanonicalizeAliases.h"
+#include "llvm/Transforms/Utils/CanonicalizeFreezeInLoops.h"
+#include "llvm/Transforms/Utils/CountVisits.h"
+#include "llvm/Transforms/Utils/Debugify.h"
+#include "llvm/Transforms/Utils/EntryExitInstrumenter.h"
+#include "llvm/Transforms/Utils/FixIrreducible.h"
+#include "llvm/Transforms/Utils/HelloWorld.h"
+#include "llvm/Transforms/Utils/InjectTLIMappings.h"
+#include "llvm/Transforms/Utils/InstructionNamer.h"
+#include "llvm/Transforms/Utils/LCSSA.h"
+#include "llvm/Transforms/Utils/LibCallsShrinkWrap.h"
+#include "llvm/Transforms/Utils/LoopSimplify.h"
+#include "llvm/Transforms/Utils/LoopVersioning.h"
+#include "llvm/Transforms/Utils/LowerGlobalDtors.h"
+#include "llvm/Transforms/Utils/LowerIFunc.h"
+#include "llvm/Transforms/Utils/LowerInvoke.h"
+#include "llvm/Transforms/Utils/LowerSwitch.h"
+#include "llvm/Transforms/Utils/Mem2Reg.h"
+#include "llvm/Transforms/Utils/MetaRenamer.h"
+#include "llvm/Transforms/Utils/MoveAutoInit.h"
+#include "llvm/Transforms/Utils/NameAnonGlobals.h"
+#include "llvm/Transforms/Utils/PredicateInfo.h"
+#include "llvm/Transforms/Utils/RelLookupTableConverter.h"
+#include "llvm/Transforms/Utils/StripGCRelocates.h"
+#include "llvm/Transforms/Utils/StripNonLineTableDebugInfo.h"
+#include "llvm/Transforms/Utils/SymbolRewriter.h"
+#include "llvm/Transforms/Utils/UnifyFunctionExitNodes.h"
+#include "llvm/Transforms/Utils/UnifyLoopExits.h"
+#include "llvm/Transforms/Vectorize/LoadStoreVectorizer.h"
+#include "llvm/Transforms/Vectorize/LoopVectorize.h"
+#include "llvm/Transforms/Vectorize/SLPVectorizer.h"
+#include "llvm/Transforms/Vectorize/VectorCombine.h"
+
 #include "llvm/IR/LLVMRemarkStreamer.h"
 #include "llvm/IR/LegacyPassManager.h"
 #include "llvm/Remarks/RemarkStreamer.h"
@@ -36,13 +279,28 @@
 #include <llvm/Analysis/Passes.h>
 #include <llvm/Analysis/ScalarEvolutionAliasAnalysis.h>
 #include <llvm/CodeGen/Passes.h>
+#include <llvm/Passes/PassBuilder.h>
 #include <llvm/Transforms/AggressiveInstCombine/AggressiveInstCombine.h>
 #include <llvm/Transforms/IPO.h>
 #include <llvm/Transforms/IPO/AlwaysInliner.h>
 #include <llvm/Transforms/Scalar/SimpleLoopUnswitch.h>
+#include <llvm/Transforms/IPO/ArgumentPromotion.h>
 #include <llvm/Transforms/Utils.h>
 #include <llvm/Transforms/Utils/UnifyFunctionExitNodes.h>
+
 using namespace llvm;
+
+typedef llvm::PassBuilder *LLVMPassBuilder;
+
+typedef llvm::ModulePassManager *LLVMModulePassManager;
+
+typedef llvm::FunctionAnalysisManager *LLVMFunctionAnalysisManager;
+
+typedef llvm::ModuleAnalysisManager *LLVMModuleAnalysisManager;
+
+typedef llvm::PassInstrumentationCallbacks *LLVMPassInstrumentationCallbacks;
+
+typedef llvm::TimePassesHandler *LLVMTimePassesHandler;
 
 /*
  * Exposed API
@@ -50,33 +308,70 @@ using namespace llvm;
 
 extern "C" {
 
-API_EXPORT(void)
-LLVMPY_SetTimePasses(bool enable) { TimePassesIsEnabled = enable; }
+API_EXPORT(LLVMTimePassesHandler)
+LLVMPY_CreateLLVMTimePassesHandler() { return new TimePassesHandler(true); }
 
 API_EXPORT(void)
-LLVMPY_ReportAndResetTimings(const char **outmsg) {
+LLVMPY_DisposeLLVMTimePassesHandler(LLVMTimePassesHandler TimePasses) {
+    delete TimePasses;
+}
+
+API_EXPORT(void)
+LLVMPY_SetTimePasses(LLVMTimePassesHandler TimePasses,
+                     LLVMPassInstrumentationCallbacks PIC) {
+    // if (TimePasses)
+    //   delete TimePasses;
+    // Reset any existing timing
+    TimePasses->print();
+    TimePasses->registerCallbacks(*PIC);
+}
+
+API_EXPORT(void)
+LLVMPY_ReportAndResetTimings(LLVMTimePassesHandler TimePasses,
+                             const char **outmsg) {
     std::string osbuf;
     raw_string_ostream os(osbuf);
-    reportAndResetTimings(&os);
+    TimePasses->setOutStream(os);
+    TimePasses->print();
     os.flush();
     *outmsg = LLVMPY_CreateString(os.str().c_str());
 }
 
-API_EXPORT(LLVMPassManagerRef)
-LLVMPY_CreatePassManager() { return LLVMCreatePassManager(); }
+API_EXPORT(LLVMModulePassManager)
+LLVMPY_CreatePassManager() { return nullptr; }
 
 API_EXPORT(void)
-LLVMPY_DisposePassManager(LLVMPassManagerRef PM) {
-    return LLVMDisposePassManager(PM);
+LLVMPY_DisposePassManager(ModulePassManager *MPM) { delete MPM; }
+
+API_EXPORT(void)
+LLVMPY_DisposeFunctionPassManager(FunctionPassManager *FPM) { delete FPM; }
+
+API_EXPORT(FunctionPassManager *)
+LLVMPY_CreateFunctionPassManager() { return new FunctionPassManager(); }
+
+API_EXPORT(LoopAnalysisManager *)
+LLVMPY_CreateLoopAnalysisManager(LLVMModuleRef M) {
+    return new LoopAnalysisManager();
 }
 
-API_EXPORT(LLVMPassManagerRef)
-LLVMPY_CreateFunctionPassManager(LLVMModuleRef M) {
-    return LLVMCreateFunctionPassManagerForModule(M);
+API_EXPORT(FunctionAnalysisManager *)
+LLVMPY_CreateFunctionAnalysisManager(LLVMModuleRef M) {
+    return new FunctionAnalysisManager();
+}
+
+API_EXPORT(CGSCCAnalysisManager *)
+LLVMPY_CreateCGSCCAnalysisManager(LLVMModuleRef M) {
+    return new CGSCCAnalysisManager();
+}
+
+API_EXPORT(ModuleAnalysisManager *)
+LLVMPY_CreateModuleAnalysisManager(LLVMModuleRef M) {
+    return new ModuleAnalysisManager();
 }
 
 API_EXPORT(int)
-LLVMPY_RunPassManagerWithRemarks(LLVMPassManagerRef PM, LLVMModuleRef M,
+LLVMPY_RunPassManagerWithRemarks(LLVMModulePassManager PM, LLVMModuleRef M,
+                                 LLVMModuleAnalysisManager MAM,
                                  const char *remarks_format,
                                  const char *remarks_filter,
                                  const char *record_filename) {
@@ -87,206 +382,265 @@ LLVMPY_RunPassManagerWithRemarks(LLVMPassManagerRef PM, LLVMModuleRef M,
         return -1;
     }
     auto optimisationFile = std::move(*setupResult);
-    auto r = LLVMRunPassManager(PM, M);
+    auto r = PM->run(*unwrap(M), *MAM);
 
     unwrap(M)->getContext().setMainRemarkStreamer(nullptr);
     unwrap(M)->getContext().setLLVMRemarkStreamer(nullptr);
 
     optimisationFile->keep();
     optimisationFile->os().flush();
-    return r;
+
+    // TODO: return void
+    return 1;
 }
 
 API_EXPORT(int)
-LLVMPY_RunPassManager(LLVMPassManagerRef PM, LLVMModuleRef M) {
-    return LLVMRunPassManager(PM, M);
+LLVMPY_RunPassManager(LLVMModulePassManager PM, LLVMModuleRef M,
+                      LLVMModuleAnalysisManager MAM) {
+    // PassBuilder PB;
+    // LoopAnalysisManager LAM;
+    // FunctionAnalysisManager FAM;
+    // CGSCCAnalysisManager CGAM;
+    // ModuleAnalysisManager MAM;
+
+    // // Register all the basic analyses with the managers.
+    // PB.registerModuleAnalyses(MAM);
+    // PB.registerCGSCCAnalyses(CGAM);
+    // PB.registerFunctionAnalyses(FAM);
+    // PB.registerLoopAnalyses(LAM);
+    // PB.crossRegisterProxies(LAM, FAM, CGAM, MAM);
+
+    // PM = new
+    // llvm::ModulePassManager(PB.buildPerModuleDefaultPipeline(OptimizationLevel::O2,
+    // false)); PM->printPipeline(outs(), [](StringRef ClassName) { return
+    // ClassName; });
+    PM->run(*unwrap(M), *MAM);
+
+    return 0;
 }
 
 API_EXPORT(int)
-LLVMPY_RunFunctionPassManagerWithRemarks(LLVMPassManagerRef PM, LLVMValueRef F,
+LLVMPY_RunFunctionPassManagerWithRemarks(FunctionPassManager *FPM, Function *F,
+                                         LLVMFunctionAnalysisManager FAM,
                                          const char *remarks_format,
                                          const char *remarks_filter,
                                          const char *record_filename) {
     auto setupResult = llvm::setupLLVMOptimizationRemarks(
-        unwrap(F)->getContext(), record_filename, remarks_filter,
-        remarks_format, true);
+        F->getContext(), record_filename, remarks_filter, remarks_format, true);
     if (!setupResult) {
         return -1;
     }
     auto optimisationFile = std::move(*setupResult);
 
-    auto r = LLVMRunFunctionPassManager(PM, F);
+    // F->print(outs());
+    // FPM->printPipeline(outs(), [](StringRef ClassName) {
+    //   return ClassName;
+    // });
+    FPM->run(*F, *FAM);
 
-    unwrap(F)->getContext().setMainRemarkStreamer(nullptr);
-    unwrap(F)->getContext().setLLVMRemarkStreamer(nullptr);
+    F->getContext().setMainRemarkStreamer(nullptr);
+    F->getContext().setLLVMRemarkStreamer(nullptr);
 
     optimisationFile->keep();
     optimisationFile->os().flush();
-    return r;
+    // TODO return void
+    return 1;
 }
 
 API_EXPORT(int)
-LLVMPY_RunFunctionPassManager(LLVMPassManagerRef PM, LLVMValueRef F) {
-    return LLVMRunFunctionPassManager(PM, F);
+LLVMPY_RunFunctionPassManager(FunctionPassManager *FPM, Function *F,
+                              LLVMFunctionAnalysisManager FAM) {
+    // PassBuilder PB;
+    // LoopAnalysisManager LAM;
+    // FunctionAnalysisManager FAM;
+    // CGSCCAnalysisManager CGAM;
+    // ModuleAnalysisManager MAM;
+
+    // // Register all the basic analyses with the managers.
+    // PB.registerModuleAnalyses(MAM);
+    // PB.registerCGSCCAnalyses(CGAM);
+    // PB.registerFunctionAnalyses(FAM);
+    // PB.registerLoopAnalyses(LAM);
+    // PB.crossRegisterProxies(LAM, FAM, CGAM, MAM);
+
+    // FPM = new
+    // llvm::FunctionPassManager(PB.buildFunctionSimplificationPipeline(OptimizationLevel::O2,
+    // llvm::ThinOrFullLTOPhase::None)); FPM->printPipeline(outs(), [](StringRef
+    // ClassName) { return ClassName; });
+    FPM->run(*F, *FAM);
+
+    return 0;
 }
 
+// Deprecated, unneeded
 API_EXPORT(int)
-LLVMPY_InitializeFunctionPassManager(LLVMPassManagerRef FPM) {
-    return LLVMInitializeFunctionPassManager(FPM);
-}
+LLVMPY_InitializeFunctionPassManager(FunctionPassManager *PB) { return 0; }
 
+// Deprecated, unneeded
 API_EXPORT(int)
-LLVMPY_FinalizeFunctionPassManager(LLVMPassManagerRef FPM) {
-    return LLVMFinalizeFunctionPassManager(FPM);
+LLVMPY_FinalizeFunctionPassManager(FunctionPassManager *PB) { return 0; }
+
+// TODO register AA passes correctly
+API_EXPORT(void)
+LLVMPY_AddAAEvalPass(FunctionAnalysisManager *FAM) {
+    AAManager AA;
+    FAM->registerPass([&] { return std::move(AA); });
 }
 
 API_EXPORT(void)
-LLVMPY_AddAAEvalPass(LLVMPassManagerRef PM) {
-    unwrap(PM)->add(llvm::createAAEvalPass());
+LLVMPY_AddBasicAAWrapperPass(FunctionAnalysisManager *FAM) {
+    AAManager AA;
+    FAM->registerPass([&] { return std::move(AA); });
 }
 
 API_EXPORT(void)
-LLVMPY_AddBasicAAWrapperPass(LLVMPassManagerRef PM) {
-    unwrap(PM)->add(llvm::createBasicAAWrapperPass());
+LLVMPY_AddDependenceAnalysisPass(FunctionAnalysisManager *FAM) {
+    FAM->registerPass([&] { return DependenceAnalysis(); });
 }
 
 API_EXPORT(void)
-LLVMPY_AddDependenceAnalysisPass(LLVMPassManagerRef PM) {
-    unwrap(PM)->add(llvm::createDependenceAnalysisWrapperPass());
+LLVMPY_AddCallGraphDOTPrinterPass(ModulePassManager *MAM) {
+    MAM->addPass(CallGraphDOTPrinterPass());
 }
 
-API_EXPORT(void)
-LLVMPY_AddCallGraphDOTPrinterPass(LLVMPassManagerRef PM) {
-    unwrap(PM)->add(llvm::createCallGraphDOTPrinterPass());
-}
-
+// Not ported over to NPM yet
 API_EXPORT(void)
 LLVMPY_AddDotDomPrinterPass(LLVMPassManagerRef PM, bool showBody) {
-#if LLVM_VERSION_MAJOR > 14
-    unwrap(PM)->add(showBody ? llvm::createDomPrinterWrapperPassPass()
-                             : llvm::createDomOnlyPrinterWrapperPassPass());
-#else
-    unwrap(PM)->add(showBody ? llvm::createDomPrinterPass()
-                             : llvm::createDomOnlyPrinterPass());
-#endif
+    // #if LLVM_VERSION_MAJOR < 15
+    //     unwrap(PM)->add(showBody ? llvm::createDomPrinterPass()
+    //                              : llvm::createDomOnlyViewerPass());
+    // #else
+    //     unwrap(PM)->add(showBody ? llvm::createDomPrinterWrapperPassPass()
+    //                              :
+    //                              llvm::createDomOnlyViewerWrapperPassPass());
+    // #endif
 }
 
 API_EXPORT(void)
-LLVMPY_AddGlobalsModRefAAPass(LLVMPassManagerRef PM) {
-    unwrap(PM)->add(llvm::createGlobalsAAWrapperPass());
+LLVMPY_AddGlobalsModRefAAPass(ModuleAnalysisManager *MAM) {
+    MAM->registerPass([&] { return GlobalsAA(); });
 }
 
+// Not ported over to NPM yet
 API_EXPORT(void)
 LLVMPY_AddDotPostDomPrinterPass(LLVMPassManagerRef PM, bool showBody) {
-#if LLVM_VERSION_MAJOR > 14
-    unwrap(PM)->add(showBody ? llvm::createPostDomPrinterWrapperPassPass()
-                             : llvm::createPostDomOnlyPrinterWrapperPassPass());
-#else
-    unwrap(PM)->add(showBody ? llvm::createPostDomPrinterPass()
-                             : llvm::createPostDomOnlyPrinterPass());
-#endif
+    // #if LLVM_VERSION_MAJOR < 15
+    //     unwrap(PM)->add(showBody ? llvm::createPostDomPrinterPass()
+    //                              : llvm::createPostDomOnlyViewerPass());
+    // #else
+    //     unwrap(PM)->add(showBody ?
+    //     llvm::createPostDomPrinterWrapperPassPass()
+    //                              :
+    //                              llvm::createPostDomOnlyViewerWrapperPassPass());
+    // #endif
 }
 
+// Not ported over to NPM yet
 API_EXPORT(void)
 LLVMPY_AddCFGPrinterPass(LLVMPassManagerRef PM) {
-    unwrap(PM)->add(llvm::createCFGPrinterLegacyPassPass());
+    // unwrap(PM)->add(llvm::createCFGPrinterLegacyPassPass());
 }
 
 API_EXPORT(void)
-LLVMPY_AddConstantMergePass(LLVMPassManagerRef PM) {
-    LLVMAddConstantMergePass(PM);
+LLVMPY_AddConstantMergePass(ModulePassManager *MPM) {
+    MPM->addPass(ConstantMergePass());
 }
 
 API_EXPORT(void)
-LLVMPY_AddDeadStoreEliminationPass(LLVMPassManagerRef PM) {
-    unwrap(PM)->add(llvm::createDeadStoreEliminationPass());
+LLVMPY_AddDeadStoreEliminationPass(FunctionPassManager *FPM) {
+    FPM->addPass(DSEPass());
 }
 
 API_EXPORT(void)
-LLVMPY_AddReversePostOrderFunctionAttrsPass(LLVMPassManagerRef PM) {
-    unwrap(PM)->add(llvm::createReversePostOrderFunctionAttrsPass());
+LLVMPY_AddReversePostOrderFunctionAttrsPass(ModulePassManager *MPM) {
+    MPM->addPass(ReversePostOrderFunctionAttrsPass());
 }
 
 API_EXPORT(void)
-LLVMPY_AddDeadArgEliminationPass(LLVMPassManagerRef PM) {
-    LLVMAddDeadArgEliminationPass(PM);
+LLVMPY_AddDeadArgEliminationPass(ModulePassManager *MPM) {
+    MPM->addPass(DeadArgumentEliminationPass());
 }
 
+// Not ported over to NPM yet
 API_EXPORT(void)
 LLVMPY_AddInstructionCountPass(LLVMPassManagerRef PM) {
-    unwrap(PM)->add(llvm::createInstCountPass());
+    // unwrap(PM)->add(llvm::createInstCountPass());
 }
 
 API_EXPORT(void)
-LLVMPY_AddIVUsersPass(LLVMPassManagerRef PM) {
-    unwrap(PM)->add(llvm::createIVUsersPass());
+LLVMPY_AddIVUsersPass(LoopAnalysisManager *LAM) {
+    LAM->registerPass([&] { return IVUsersAnalysis(); });
 }
 
 API_EXPORT(void)
-LLVMPY_AddLazyValueInfoPass(LLVMPassManagerRef PM) {
-    unwrap(PM)->add(llvm::createLazyValueInfoPass());
-}
-API_EXPORT(void)
-LLVMPY_AddLintPass(LLVMPassManagerRef PM) {
-    unwrap(PM)->add(llvm::createLintLegacyPassPass());
-}
-API_EXPORT(void)
-LLVMPY_AddModuleDebugInfoPrinterPass(LLVMPassManagerRef PM) {
-    unwrap(PM)->add(llvm::createModuleDebugInfoPrinterPass());
+LLVMPY_AddLazyValueInfoPass(FunctionAnalysisManager *FAM) {
+    FAM->registerPass([&] { return LazyValueAnalysis(); });
 }
 
 API_EXPORT(void)
-LLVMPY_AddRegionInfoPass(LLVMPassManagerRef PM) {
-    unwrap(PM)->add(llvm::createRegionInfoPass());
+LLVMPY_AddLintPass(FunctionPassManager *FPM) { FPM->addPass(LintPass()); }
+
+// TODO: does dbgs() work?
+API_EXPORT(void)
+LLVMPY_AddModuleDebugInfoPrinterPass(ModulePassManager *MPM) {
+    MPM->addPass(ModuleDebugInfoPrinterPass(dbgs()));
 }
 
 API_EXPORT(void)
-LLVMPY_AddScalarEvolutionAAPass(LLVMPassManagerRef PM) {
-    unwrap(PM)->add(llvm::createSCEVAAWrapperPass());
+LLVMPY_AddRegionInfoPass(FunctionAnalysisManager *FAM) {
+    FAM->registerPass([&] { return RegionInfoAnalysis(); });
 }
 
 API_EXPORT(void)
-LLVMPY_AddAggressiveDCEPass(LLVMPassManagerRef PM) {
-    unwrap(PM)->add(llvm::createAggressiveDCEPass());
+LLVMPY_AddScalarEvolutionAAPass(FunctionAnalysisManager *FAM) {
+    FAM->registerPass([&] { return SCEVAA(); });
 }
 
 API_EXPORT(void)
-LLVMPY_AddAlwaysInlinerPass(LLVMPassManagerRef PM, bool insertLifetime) {
-    unwrap(PM)->add(llvm::createAlwaysInlinerLegacyPass(insertLifetime));
+LLVMPY_AddAggressiveDCEPass(FunctionPassManager *FPM) {
+    FPM->addPass(ADCEPass());
 }
 
-#if LLVM_VERSION_MAJOR < 15
 API_EXPORT(void)
-LLVMPY_AddArgPromotionPass(LLVMPassManagerRef PM, unsigned int maxElements) {
-    unwrap(PM)->add(llvm::createArgumentPromotionPass(maxElements));
+LLVMPY_AddAlwaysInlinerPass(ModulePassManager *MPM, bool insertLifetime) {
+    MPM->addPass(AlwaysInlinerPass(insertLifetime));
 }
-#endif
 
 API_EXPORT(void)
-LLVMPY_AddBreakCriticalEdgesPass(LLVMPassManagerRef PM) {
-    unwrap(PM)->add(llvm::createBreakCriticalEdgesPass());
+LLVMPY_AddArgPromotionPass(ModulePassManager *MPM, unsigned int maxElements) {
+    MPM->addPass(
+        createModuleToPostOrderCGSCCPassAdaptor(ArgumentPromotionPass()));
+}
+
+API_EXPORT(void)
+LLVMPY_AddBreakCriticalEdgesPass(FunctionPassManager *FPM) {
+    FPM->addPass(BreakCriticalEdgesPass());
 }
 
 API_EXPORT(void)
 LLVMPY_AddFunctionAttrsPass(LLVMPassManagerRef PM) {
-    LLVMAddFunctionAttrsPass(PM);
+    assert(false && "FunctionAttrsPass is Legacy");
 }
 
 API_EXPORT(void)
-LLVMPY_AddFunctionInliningPass(LLVMPassManagerRef PM, int Threshold) {
-    unwrap(PM)->add(createFunctionInliningPass(Threshold));
+LLVMPY_AddFunctionInliningPass(LLVMModulePassManager MPM, int Threshold) {
+    MPM->addPass(ModuleInlinerWrapperPass(getInlineParams(Threshold)));
 }
 
 API_EXPORT(void)
 LLVMPY_AddGlobalOptimizerPass(LLVMPassManagerRef PM) {
-    LLVMAddGlobalOptimizerPass(PM);
+    assert(false && "GlobalOptimizerPass is Legacy");
 }
 
 API_EXPORT(void)
-LLVMPY_AddGlobalDCEPass(LLVMPassManagerRef PM) { LLVMAddGlobalDCEPass(PM); }
+LLVMPY_AddGlobalDCEPass(LLVMPassManagerRef PM) {
+    assert(false && "GlobalDCEPass is Legacy");
+}
 
 API_EXPORT(void)
-LLVMPY_AddIPSCCPPass(LLVMPassManagerRef PM) { LLVMAddIPSCCPPass(PM); }
+LLVMPY_AddIPSCCPPass(LLVMPassManagerRef PM) {
+    assert(false && "IPSCCPPass is Legacy");
+}
 
 API_EXPORT(void)
 LLVMPY_AddDeadCodeEliminationPass(LLVMPassManagerRef PM) {
@@ -295,17 +649,17 @@ LLVMPY_AddDeadCodeEliminationPass(LLVMPassManagerRef PM) {
 
 API_EXPORT(void)
 LLVMPY_AddAggressiveInstructionCombiningPass(LLVMPassManagerRef PM) {
-    unwrap(PM)->add(createAggressiveInstCombinerPass());
+    assert(false && "AggressiveInstructionCombiningPass is Legacy");
 }
 
 API_EXPORT(void)
 LLVMPY_AddInternalizePass(LLVMPassManagerRef PM) {
-    unwrap(PM)->add(createInternalizePass());
+    assert(false && "InternalizePass is Legacy");
 }
 
 API_EXPORT(void)
 LLVMPY_AddJumpThreadingPass(LLVMPassManagerRef PM, int threshold) {
-    unwrap(PM)->add(createJumpThreadingPass(threshold));
+    assert(false && "JumpThreadingPass is Legacy");
 }
 
 API_EXPORT(void)
@@ -315,7 +669,7 @@ LLVMPY_AddLCSSAPass(LLVMPassManagerRef PM) {
 
 API_EXPORT(void)
 LLVMPY_AddLoopDeletionPass(LLVMPassManagerRef PM) {
-    unwrap(PM)->add(createLoopDeletionPass());
+    assert(false && "LoopDeletionPass is Legacy");
 }
 
 API_EXPORT(void)
@@ -339,21 +693,23 @@ LLVMPY_AddLoopSimplificationPass(LLVMPassManagerRef PM) {
 }
 
 API_EXPORT(void)
-LLVMPY_AddLoopUnrollPass(LLVMPassManagerRef PM) { LLVMAddLoopUnrollPass(PM); }
+LLVMPY_AddLoopUnrollPass(LLVMPassManagerRef PM) {
+    assert(false && "LoopUnrollPass is Legacy");
+}
 
 API_EXPORT(void)
 LLVMPY_AddLoopUnrollAndJamPass(LLVMPassManagerRef PM) {
-    LLVMAddLoopUnrollAndJamPass(PM);
+    assert(false && "LoopUnrollAndJamPass is Legacy");
 }
 
 API_EXPORT(void)
 LLVMPY_AddLoopUnswitchPass(LLVMPassManagerRef PM, bool optimizeForSize,
                            bool hasBranchDivergence) {
-#if LLVM_VERSION_MAJOR > 14
-    unwrap(PM)->add(createSimpleLoopUnswitchLegacyPass(optimizeForSize));
-#else
+#if LLVM_VERSION_MAJOR < 15
     unwrap(PM)->add(
         createLoopUnswitchPass(optimizeForSize, hasBranchDivergence));
+#else
+    unwrap(PM)->add(createSimpleLoopUnswitchLegacyPass(optimizeForSize));
 #endif
 }
 
@@ -374,12 +730,12 @@ LLVMPY_AddLowerSwitchPass(LLVMPassManagerRef PM) {
 
 API_EXPORT(void)
 LLVMPY_AddMemCpyOptimizationPass(LLVMPassManagerRef PM) {
-    unwrap(PM)->add(createMemCpyOptPass());
+    assert(false && "MemCpyOptimizationPass is Legacy");
 }
 
 API_EXPORT(void)
 LLVMPY_AddMergeFunctionsPass(LLVMPassManagerRef PM) {
-    unwrap(PM)->add(createMergeFunctionsPass());
+    assert(false && "MergeFunctionsPass is Legacy");
 }
 
 API_EXPORT(void)
@@ -389,12 +745,12 @@ LLVMPY_AddMergeReturnsPass(LLVMPassManagerRef PM) {
 
 API_EXPORT(void)
 LLVMPY_AddPartialInliningPass(LLVMPassManagerRef PM) {
-    unwrap(PM)->add(createPartialInliningPass());
+    assert(false && "PartialInliningPass is Legacy");
 }
 
 API_EXPORT(void)
 LLVMPY_AddPruneExceptionHandlingPass(LLVMPassManagerRef PM) {
-    unwrap(PM)->add(createPruneEHPass());
+    assert(false && "PruneExceptionHandlingPass is Legacy");
 }
 
 API_EXPORT(void)
@@ -414,27 +770,27 @@ LLVMPY_AddSinkPass(LLVMPassManagerRef PM) {
 
 API_EXPORT(void)
 LLVMPY_AddStripSymbolsPass(LLVMPassManagerRef PM, bool onlyDebugInfo) {
-    unwrap(PM)->add(createStripSymbolsPass(onlyDebugInfo));
+    assert(false && "StripSymbolsPass is Legacy");
 }
 
 API_EXPORT(void)
 LLVMPY_AddStripDeadDebugInfoPass(LLVMPassManagerRef PM) {
-    unwrap(PM)->add(createStripDeadDebugInfoPass());
+    assert(false && "StripDeadDebugInfoPass( is Legacy");
 }
 
 API_EXPORT(void)
 LLVMPY_AddStripDeadPrototypesPass(LLVMPassManagerRef PM) {
-    unwrap(PM)->add(createStripDeadPrototypesPass());
+    assert(false && "StripDeadPrototypesPass is Legacy");
 }
 
 API_EXPORT(void)
 LLVMPY_AddStripDebugDeclarePrototypesPass(LLVMPassManagerRef PM) {
-    unwrap(PM)->add(createStripDebugDeclarePass());
+    assert(false && "StripDebugDeclarePrototypesPass is Legacy");
 }
 
 API_EXPORT(void)
 LLVMPY_AddStripNondebugSymbolsPass(LLVMPassManagerRef PM) {
-    unwrap(PM)->add(createStripNonDebugSymbolsPass());
+    assert(false && "StripNondebugSymbolsPass is Legacy");
 }
 
 API_EXPORT(void)
@@ -444,44 +800,55 @@ LLVMPY_AddTailCallEliminationPass(LLVMPassManagerRef PM) {
 
 API_EXPORT(void)
 LLVMPY_AddCFGSimplificationPass(LLVMPassManagerRef PM) {
-    LLVMAddCFGSimplificationPass(PM);
+    assert(false && "CFGSimplificationPass is Legacy");
 }
 
 API_EXPORT(void)
-LLVMPY_AddGVNPass(LLVMPassManagerRef PM) { LLVMAddGVNPass(PM); }
-
-API_EXPORT(void)
-LLVMPY_AddInstructionCombiningPass(LLVMPassManagerRef PM) {
-    LLVMAddInstructionCombiningPass(PM);
+LLVMPY_AddGVNPass(LLVMPassManagerRef PM) {
+    assert(false && "GVNPass is Legacy");
 }
 
 API_EXPORT(void)
-LLVMPY_AddLICMPass(LLVMPassManagerRef PM) { LLVMAddLICMPass(PM); }
+LLVMPY_AddInstructionCombiningPass(ModulePassManager *PM) {
+    PM->addPass(createModuleToFunctionPassAdaptor(InstCombinePass()));
+}
 
 API_EXPORT(void)
-LLVMPY_AddSCCPPass(LLVMPassManagerRef PM) { LLVMAddSCCPPass(PM); }
+LLVMPY_AddLICMPass(FunctionPassManager *PM) {
+    PM->addPass(createFunctionToLoopPassAdaptor(
+        LICMPass(/*PTO.LicmMssaOptCap=*/SetLicmMssaOptCap,
+                 /*PTO.LicmMssaNoAccForPromotionCap=*/
+                 SetLicmMssaNoAccForPromotionCap,
+                 /*AllowSpeculation=*/true),
+        /*UseMemorySSA=*/true, /*UseBlockFrequencyInfo=*/true));
+}
+
+API_EXPORT(void)
+LLVMPY_AddSCCPPass(LLVMPassManagerRef PM) {
+    assert(false && "SCCPPass is Legacy");
+}
 
 API_EXPORT(void)
 LLVMPY_AddSROAPass(LLVMPassManagerRef PM) { unwrap(PM)->add(createSROAPass()); }
 
 API_EXPORT(void)
 LLVMPY_AddTypeBasedAliasAnalysisPass(LLVMPassManagerRef PM) {
-    LLVMAddTypeBasedAliasAnalysisPass(PM);
+    assert(false && "TypeBasedAliasAnalysisPass is Legacy");
 }
 
 API_EXPORT(void)
 LLVMPY_AddBasicAliasAnalysisPass(LLVMPassManagerRef PM) {
-    LLVMAddBasicAliasAnalysisPass(PM);
+    assert(false && "BasicAliasAnalysisPass is Legacy");
 }
 
 API_EXPORT(void)
 LLVMPY_LLVMAddLoopRotatePass(LLVMPassManagerRef PM) {
-    LLVMAddLoopRotatePass(PM);
+    assert(false && "AddLoopRotatePass is Legacy");
 }
 
 API_EXPORT(void)
-LLVMPY_AddInstructionNamerPass(LLVMPassManagerRef PM) {
-    unwrap(PM)->add(createInstructionNamerPass());
+LLVMPY_AddInstructionNamerPass(LLVMModulePassManager PM) {
+    PM->addPass(createModuleToFunctionPassAdaptor(InstructionNamerPass()));
 }
 
 } // end extern "C"

--- a/ffi/passmanagers.cpp
+++ b/ffi/passmanagers.cpp
@@ -283,8 +283,8 @@
 #include <llvm/Transforms/AggressiveInstCombine/AggressiveInstCombine.h>
 #include <llvm/Transforms/IPO.h>
 #include <llvm/Transforms/IPO/AlwaysInliner.h>
-#include <llvm/Transforms/Scalar/SimpleLoopUnswitch.h>
 #include <llvm/Transforms/IPO/ArgumentPromotion.h>
+#include <llvm/Transforms/Scalar/SimpleLoopUnswitch.h>
 #include <llvm/Transforms/Utils.h>
 #include <llvm/Transforms/Utils/UnifyFunctionExitNodes.h>
 
@@ -319,9 +319,6 @@ LLVMPY_DisposeLLVMTimePassesHandler(LLVMTimePassesHandler TimePasses) {
 API_EXPORT(void)
 LLVMPY_SetTimePasses(LLVMTimePassesHandler TimePasses,
                      LLVMPassInstrumentationCallbacks PIC) {
-    // if (TimePasses)
-    //   delete TimePasses;
-    // Reset any existing timing
     TimePasses->print();
     TimePasses->registerCallbacks(*PIC);
 }
@@ -397,25 +394,7 @@ LLVMPY_RunPassManagerWithRemarks(LLVMModulePassManager PM, LLVMModuleRef M,
 API_EXPORT(int)
 LLVMPY_RunPassManager(LLVMModulePassManager PM, LLVMModuleRef M,
                       LLVMModuleAnalysisManager MAM) {
-    // PassBuilder PB;
-    // LoopAnalysisManager LAM;
-    // FunctionAnalysisManager FAM;
-    // CGSCCAnalysisManager CGAM;
-    // ModuleAnalysisManager MAM;
-
-    // // Register all the basic analyses with the managers.
-    // PB.registerModuleAnalyses(MAM);
-    // PB.registerCGSCCAnalyses(CGAM);
-    // PB.registerFunctionAnalyses(FAM);
-    // PB.registerLoopAnalyses(LAM);
-    // PB.crossRegisterProxies(LAM, FAM, CGAM, MAM);
-
-    // PM = new
-    // llvm::ModulePassManager(PB.buildPerModuleDefaultPipeline(OptimizationLevel::O2,
-    // false)); PM->printPipeline(outs(), [](StringRef ClassName) { return
-    // ClassName; });
     PM->run(*unwrap(M), *MAM);
-
     return 0;
 }
 
@@ -432,10 +411,6 @@ LLVMPY_RunFunctionPassManagerWithRemarks(FunctionPassManager *FPM, Function *F,
     }
     auto optimisationFile = std::move(*setupResult);
 
-    // F->print(outs());
-    // FPM->printPipeline(outs(), [](StringRef ClassName) {
-    //   return ClassName;
-    // });
     FPM->run(*F, *FAM);
 
     F->getContext().setMainRemarkStreamer(nullptr);
@@ -450,25 +425,7 @@ LLVMPY_RunFunctionPassManagerWithRemarks(FunctionPassManager *FPM, Function *F,
 API_EXPORT(int)
 LLVMPY_RunFunctionPassManager(FunctionPassManager *FPM, Function *F,
                               LLVMFunctionAnalysisManager FAM) {
-    // PassBuilder PB;
-    // LoopAnalysisManager LAM;
-    // FunctionAnalysisManager FAM;
-    // CGSCCAnalysisManager CGAM;
-    // ModuleAnalysisManager MAM;
-
-    // // Register all the basic analyses with the managers.
-    // PB.registerModuleAnalyses(MAM);
-    // PB.registerCGSCCAnalyses(CGAM);
-    // PB.registerFunctionAnalyses(FAM);
-    // PB.registerLoopAnalyses(LAM);
-    // PB.crossRegisterProxies(LAM, FAM, CGAM, MAM);
-
-    // FPM = new
-    // llvm::FunctionPassManager(PB.buildFunctionSimplificationPipeline(OptimizationLevel::O2,
-    // llvm::ThinOrFullLTOPhase::None)); FPM->printPipeline(outs(), [](StringRef
-    // ClassName) { return ClassName; });
     FPM->run(*F, *FAM);
-
     return 0;
 }
 

--- a/ffi/passmanagers.cpp
+++ b/ffi/passmanagers.cpp
@@ -1,16 +1,20 @@
 #include <sstream>
 
-#include "core.h"
+#include "ffi_types.h"
 
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/IR/DiagnosticInfo.h"
 #include "llvm/IR/DiagnosticPrinter.h"
-#include "llvm/IR/LegacyPassManager.h"
 #include "llvm/IR/Module.h"
 #include "llvm/Support/FileSystem.h"
 #include "llvm/Support/ToolOutputFile.h"
 #include "llvm/Support/YAMLTraits.h"
 #include "llvm/Support/raw_ostream.h"
+
+#include "llvm/IR/LLVMRemarkStreamer.h"
+#include "llvm/Remarks/RemarkStreamer.h"
+#include "llvm/Transforms/IPO.h"
+#include "llvm/Transforms/Scalar.h"
 
 // From PassBuilder.cpp
 #include "llvm/Analysis/AliasAnalysisEvaluator.h"
@@ -72,7 +76,7 @@
 #include "llvm/CodeGen/TypePromotion.h"
 #include "llvm/IR/DebugInfo.h"
 #include "llvm/IR/Dominators.h"
-#include "llvm/IR/PassManager.h"
+
 #include "llvm/IR/PrintPasses.h"
 #include "llvm/IR/SafepointIRVerifier.h"
 #include "llvm/IR/Verifier.h"
@@ -259,48 +263,7 @@
 #include "llvm/Transforms/Vectorize/SLPVectorizer.h"
 #include "llvm/Transforms/Vectorize/VectorCombine.h"
 
-#include "llvm/IR/LLVMRemarkStreamer.h"
-#include "llvm/IR/LegacyPassManager.h"
-#include "llvm/Remarks/RemarkStreamer.h"
-#include "llvm/Transforms/IPO.h"
-#include "llvm/Transforms/Scalar.h"
-
-#include <llvm/IR/PassTimingInfo.h>
-
-#include <llvm/Analysis/AliasAnalysisEvaluator.h>
-#include <llvm/Analysis/BasicAliasAnalysis.h>
-#include <llvm/Analysis/CFGPrinter.h>
-#include <llvm/Analysis/CallPrinter.h>
-#include <llvm/Analysis/DependenceAnalysis.h>
-#include <llvm/Analysis/DomPrinter.h>
-#include <llvm/Analysis/GlobalsModRef.h>
-#include <llvm/Analysis/IVUsers.h>
-#include <llvm/Analysis/Lint.h>
-#include <llvm/Analysis/Passes.h>
-#include <llvm/Analysis/ScalarEvolutionAliasAnalysis.h>
-#include <llvm/CodeGen/Passes.h>
-#include <llvm/Passes/PassBuilder.h>
-#include <llvm/Transforms/AggressiveInstCombine/AggressiveInstCombine.h>
-#include <llvm/Transforms/IPO.h>
-#include <llvm/Transforms/IPO/AlwaysInliner.h>
-#include <llvm/Transforms/IPO/ArgumentPromotion.h>
-#include <llvm/Transforms/Scalar/SimpleLoopUnswitch.h>
-#include <llvm/Transforms/Utils.h>
-#include <llvm/Transforms/Utils/UnifyFunctionExitNodes.h>
-
 using namespace llvm;
-
-typedef llvm::PassBuilder *LLVMPassBuilder;
-
-typedef llvm::ModulePassManager *LLVMModulePassManager;
-
-typedef llvm::FunctionAnalysisManager *LLVMFunctionAnalysisManager;
-
-typedef llvm::ModuleAnalysisManager *LLVMModuleAnalysisManager;
-
-typedef llvm::PassInstrumentationCallbacks *LLVMPassInstrumentationCallbacks;
-
-typedef llvm::TimePassesHandler *LLVMTimePassesHandler;
 
 /*
  * Exposed API
@@ -621,7 +584,7 @@ LLVMPY_AddJumpThreadingPass(LLVMPassManagerRef PM, int threshold) {
 
 API_EXPORT(void)
 LLVMPY_AddLCSSAPass(LLVMPassManagerRef PM) {
-    unwrap(PM)->add(createLCSSAPass());
+    assert(false && "createLCSSAPass is Legacy");
 }
 
 API_EXPORT(void)
@@ -646,7 +609,7 @@ LLVMPY_AddLoopStrengthReducePass(LLVMPassManagerRef PM) {
 
 API_EXPORT(void)
 LLVMPY_AddLoopSimplificationPass(LLVMPassManagerRef PM) {
-    unwrap(PM)->add(createLoopSimplifyPass());
+    assert(false && "LoopSimplifyPass is Legacy");
 }
 
 API_EXPORT(void)
@@ -677,12 +640,12 @@ LLVMPY_AddLowerAtomicPass(LLVMPassManagerRef PM) {
 
 API_EXPORT(void)
 LLVMPY_AddLowerInvokePass(LLVMPassManagerRef PM) {
-    unwrap(PM)->add(createLowerInvokePass());
+    assert(false && "LowerInvokePass is Legacy");
 }
 
 API_EXPORT(void)
 LLVMPY_AddLowerSwitchPass(LLVMPassManagerRef PM) {
-    unwrap(PM)->add(createLowerSwitchPass());
+    assert(false && "LowerSwitchPass is Legacy");
 }
 
 API_EXPORT(void)

--- a/ffi/targets.cpp
+++ b/ffi/targets.cpp
@@ -5,8 +5,8 @@
 #include "llvm/IR/LegacyPassManager.h"
 #include "llvm/IR/Type.h"
 #include "llvm/MC/TargetRegistry.h"
-#include "llvm/TargetParser/Host.h"
 #include "llvm/Target/TargetMachine.h"
+#include "llvm/TargetParser/Host.h"
 #include "llvm/TargetParser/Triple.h"
 
 #include <cstdio>
@@ -126,7 +126,6 @@ API_EXPORT(LLVMTargetRef)
 LLVMPY_GetTargetFromTriple(const char *Triple, const char **ErrOut) {
     char *ErrorMessage;
     LLVMTargetRef T;
-    printf("GetTargetFromTriple %s\n", Triple);
     if (LLVMGetTargetFromTriple(Triple, &T, &ErrorMessage)) {
         *ErrOut = LLVMPY_CreateString(ErrorMessage);
         LLVMDisposeMessage(ErrorMessage);

--- a/ffi/targets.cpp
+++ b/ffi/targets.cpp
@@ -1,4 +1,4 @@
-#include "core.h"
+#include "ffi_types.h"
 #include "llvm-c/Target.h"
 #include "llvm-c/TargetMachine.h"
 #include "llvm/Analysis/TargetLibraryInfo.h"
@@ -26,9 +26,6 @@ inline LLVMTargetMachineRef wrap(TargetMachine *TM) {
 }
 
 } // namespace llvm
-
-typedef llvm::ModulePassManager *LLVMModulePassManager;
-typedef llvm::FunctionAnalysisManager *LLVMFunctionAnalysisManager;
 
 extern "C" {
 
@@ -248,8 +245,7 @@ LLVMPY_CreateTargetMachineData(LLVMTargetMachineRef TM) {
 
 API_EXPORT(void)
 LLVMPY_AddAnalysisPasses(LLVMTargetMachineRef TM, LLVMPassManagerRef PM) {
-    assert(0 && "Not implemented");
-    LLVMAddAnalysisPasses(TM, PM);
+    assert(0 && "Legacy Pass Manager only");
 }
 
 API_EXPORT(const void *)

--- a/ffi/transforms.cpp
+++ b/ffi/transforms.cpp
@@ -122,9 +122,9 @@ LLVMPY_LLVMPassInstrumentationCallbacksDispose(
 API_EXPORT(void)
 LLVMPY_PassManagerBuilderDispose(LLVMPassBuilder PB,
                                  LLVMPassBuilderOptionsRef Options) {
-    // TODO figure out proper deletion
-    // delete(PB);
-    // LLVMDisposePassBuilderOptions(Options);
+    if (PB)
+        delete(PB);
+    LLVMDisposePassBuilderOptions(Options);
 }
 
 // Deprecated: no longer exists in LLVM

--- a/ffi/transforms.cpp
+++ b/ffi/transforms.cpp
@@ -122,12 +122,13 @@ LLVMPY_LLVMPassInstrumentationCallbacksDispose(
 API_EXPORT(void)
 LLVMPY_PassManagerBuilderDispose(LLVMPassBuilder PB,
                                  LLVMPassBuilderOptionsRef Options) {
-    if (PB)
+    if (PB) {
         delete (PB);
+        PB = nullptr;
+    }
     LLVMDisposePassBuilderOptions(Options);
 }
 
-// Deprecated: no longer exists in LLVM
 API_EXPORT(LLVMModulePassManager)
 LLVMPY_PassManagerBuilderPopulateModulePassManager(
     LLVMPassBuilder PB, LLVMPassBuilderOptionsRef Options,
@@ -136,8 +137,10 @@ LLVMPY_PassManagerBuilderPopulateModulePassManager(
     LLVMFunctionAnalysisManager FAM, LLVMCGSCCAnalysisManager CGAM,
     LLVMPassInstrumentationCallbacks PIC) {
     // TODO handle PB memory better
-    if (PB)
+    if (PB) {
         delete (PB);
+        PB = nullptr;
+    }
 
     PB = new llvm::PassBuilder(nullptr, unwrap(Options)->PTO,
                                /*Optional<PGOOptions> PGOOpt =*/{}, PIC);
@@ -197,8 +200,10 @@ LLVMPY_PassManagerBuilderPopulateFunctionPassManager(
     LLVMFunctionAnalysisManager FAM, LLVMCGSCCAnalysisManager CGAM,
     LLVMPassInstrumentationCallbacks PIC) {
     // TODO handle PB memory better
-    if (PB)
+    if (PB) {
         delete (PB);
+        PB = nullptr;
+    }
 
     PB = new llvm::PassBuilder(nullptr, unwrap(Options)->PTO,
                                /*Optional<PGOOptions> PGOOpt =*/{}, PIC);

--- a/ffi/transforms.cpp
+++ b/ffi/transforms.cpp
@@ -1,13 +1,8 @@
-#include "core.h"
+#include "ffi_types.h"
 #include "llvm-c/Target.h"
 #include "llvm-c/Transforms/PassBuilder.h"
-#include "llvm/IR/PassManager.h"
-#include "llvm/Passes/OptimizationLevel.h"
-#include "llvm/Passes/PassBuilder.h"
 
-#include "llvm-c/Transforms/PassBuilder.h"
 #include "llvm/IR/Verifier.h"
-#include "llvm/Passes/PassBuilder.h"
 #include "llvm/Passes/StandardInstrumentations.h"
 #include "llvm/Support/CBindingWrapping.h"
 
@@ -32,24 +27,6 @@ static llvm::TargetMachine *unwrap(LLVMTargetMachineRef P) {
 
 DEFINE_SIMPLE_CONVERSION_FUNCTIONS(LLVMPassBuilderOptions,
                                    LLVMPassBuilderOptionsRef)
-
-typedef llvm::FunctionPassManager *LLVMFunctionPassManager;
-
-typedef llvm::ModulePassManager *LLVMModulePassManager;
-
-typedef llvm::OptimizationLevel const *LLVMOptimizationLevel;
-
-typedef llvm::PassBuilder *LLVMPassBuilder;
-
-typedef llvm::ModuleAnalysisManager *LLVMModuleAnalysisManager;
-
-typedef llvm::CGSCCAnalysisManager *LLVMCGSCCAnalysisManager;
-
-typedef llvm::FunctionAnalysisManager *LLVMFunctionAnalysisManager;
-
-typedef llvm::LoopAnalysisManager *LLVMLoopAnalysisManager;
-
-typedef llvm::PassInstrumentationCallbacks *LLVMPassInstrumentationCallbacks;
 
 static const LLVMOptimizationLevel mapToLevel(unsigned OptLevel,
                                               unsigned SizeLevel) {

--- a/ffi/transforms.cpp
+++ b/ffi/transforms.cpp
@@ -123,7 +123,7 @@ API_EXPORT(void)
 LLVMPY_PassManagerBuilderDispose(LLVMPassBuilder PB,
                                  LLVMPassBuilderOptionsRef Options) {
     if (PB)
-        delete(PB);
+        delete (PB);
     LLVMDisposePassBuilderOptions(Options);
 }
 

--- a/ffi/transforms.cpp
+++ b/ffi/transforms.cpp
@@ -1,96 +1,295 @@
 #include "core.h"
 #include "llvm-c/Target.h"
-#include "llvm-c/Transforms/PassManagerBuilder.h"
-#include "llvm/Transforms/IPO/PassManagerBuilder.h"
+#include "llvm-c/Transforms/PassBuilder.h"
+#include "llvm/IR/PassManager.h"
+#include "llvm/Passes/OptimizationLevel.h"
+#include "llvm/Passes/PassBuilder.h"
+
+#include "llvm-c/Transforms/PassBuilder.h"
+#include "llvm/IR/Verifier.h"
+#include "llvm/Passes/PassBuilder.h"
+#include "llvm/Passes/StandardInstrumentations.h"
+#include "llvm/Support/CBindingWrapping.h"
+
+/// Helper struct for holding a set of builder options for LLVMRunPasses. This
+/// structure is used to keep LLVMRunPasses backwards compatible with future
+/// versions in case we modify the options the new Pass Manager utilizes.
+class LLVMPassBuilderOptions {
+  public:
+    explicit LLVMPassBuilderOptions(
+        bool DebugLogging = false, bool VerifyEach = false,
+        llvm::PipelineTuningOptions PTO = llvm::PipelineTuningOptions())
+        : DebugLogging(DebugLogging), VerifyEach(VerifyEach), PTO(PTO) {}
+
+    bool DebugLogging;
+    bool VerifyEach;
+    llvm::PipelineTuningOptions PTO;
+};
+
+static llvm::TargetMachine *unwrap(LLVMTargetMachineRef P) {
+    return reinterpret_cast<llvm::TargetMachine *>(P);
+}
+
+DEFINE_SIMPLE_CONVERSION_FUNCTIONS(LLVMPassBuilderOptions,
+                                   LLVMPassBuilderOptionsRef)
+
+typedef llvm::FunctionPassManager *LLVMFunctionPassManager;
+
+typedef llvm::ModulePassManager *LLVMModulePassManager;
+
+typedef llvm::OptimizationLevel const *LLVMOptimizationLevel;
+
+typedef llvm::PassBuilder *LLVMPassBuilder;
+
+typedef llvm::ModuleAnalysisManager *LLVMModuleAnalysisManager;
+
+typedef llvm::CGSCCAnalysisManager *LLVMCGSCCAnalysisManager;
+
+typedef llvm::FunctionAnalysisManager *LLVMFunctionAnalysisManager;
+
+typedef llvm::LoopAnalysisManager *LLVMLoopAnalysisManager;
+
+typedef llvm::PassInstrumentationCallbacks *LLVMPassInstrumentationCallbacks;
+
+static const LLVMOptimizationLevel mapToLevel(unsigned OptLevel,
+                                              unsigned SizeLevel) {
+    switch (OptLevel) {
+    default:
+        llvm_unreachable("Invalid optimization level!");
+
+    case 0:
+        return &llvm::OptimizationLevel::O0;
+
+    case 1:
+        return &llvm::OptimizationLevel::O1;
+
+    case 2:
+        switch (SizeLevel) {
+        default:
+            llvm_unreachable("Invalid optimization level for size!");
+
+        case 0:
+            return &llvm::OptimizationLevel::O2;
+
+        case 1:
+            return &llvm::OptimizationLevel::Os;
+
+        case 2:
+            return &llvm::OptimizationLevel::Oz;
+        }
+
+    case 3:
+        return &llvm::OptimizationLevel::O3;
+    }
+}
 
 extern "C" {
 
-API_EXPORT(LLVMPassManagerBuilderRef)
-LLVMPY_PassManagerBuilderCreate() { return LLVMPassManagerBuilderCreate(); }
+API_EXPORT(LLVMPassBuilder)
+LLVMPY_PassManagerBuilderCreate() { return new llvm::PassBuilder(); }
 
-API_EXPORT(void)
-LLVMPY_PassManagerBuilderDispose(LLVMPassManagerBuilderRef PMB) {
-    LLVMPassManagerBuilderDispose(PMB);
+API_EXPORT(LLVMPassBuilderOptionsRef)
+LLVMPY_PassManagerBuilderOptionsCreate() {
+    return LLVMCreatePassBuilderOptions();
+}
+
+API_EXPORT(LLVMModuleAnalysisManager)
+LLVMPY_LLVMModuleAnalysisManagerCreate() {
+    return new llvm::ModuleAnalysisManager;
 }
 
 API_EXPORT(void)
+LLVMPY_LLVMModuleAnalysisManagerDispose(LLVMModuleAnalysisManager MAM) {
+    delete (MAM);
+}
+
+API_EXPORT(LLVMLoopAnalysisManager)
+LLVMPY_LLVMLoopAnalysisManagerCreate() { return new llvm::LoopAnalysisManager; }
+
+API_EXPORT(void)
+LLVMPY_LLVMLoopAnalysisManagerDispose(LLVMLoopAnalysisManager LAM) {
+    delete (LAM);
+}
+
+API_EXPORT(LLVMFunctionAnalysisManager)
+LLVMPY_LLVMFunctionAnalysisManagerCreate() {
+    return new llvm::FunctionAnalysisManager;
+}
+
+API_EXPORT(void)
+LLVMPY_LLVMFunctionAnalysisManagerDispose(LLVMFunctionAnalysisManager FAM) {
+    delete (FAM);
+}
+
+API_EXPORT(LLVMCGSCCAnalysisManager)
+LLVMPY_LLVMCGSCCAnalysisManagerCreate() {
+    return new llvm::CGSCCAnalysisManager;
+}
+
+API_EXPORT(void)
+LLVMPY_LLVMCGSCCAnalysisManagerDispose(LLVMCGSCCAnalysisManager CGAM) {
+    delete (CGAM);
+}
+
+API_EXPORT(LLVMPassInstrumentationCallbacks)
+LLVMPY_LLVMPassInstrumentationCallbacksCreate() {
+    return new llvm::PassInstrumentationCallbacks;
+}
+
+API_EXPORT(void)
+LLVMPY_LLVMPassInstrumentationCallbacksDispose(
+    LLVMPassInstrumentationCallbacks PIC) {
+    delete (PIC);
+}
+
+API_EXPORT(void)
+LLVMPY_PassManagerBuilderDispose(LLVMPassBuilder PB,
+                                 LLVMPassBuilderOptionsRef Options) {
+    // TODO figure out proper deletion
+    // delete(PB);
+    // LLVMDisposePassBuilderOptions(Options);
+}
+
+// Deprecated: no longer exists in LLVM
+API_EXPORT(LLVMModulePassManager)
 LLVMPY_PassManagerBuilderPopulateModulePassManager(
-    LLVMPassManagerBuilderRef PMB, LLVMPassManagerRef PM) {
-    LLVMPassManagerBuilderPopulateModulePassManager(PMB, PM);
+    LLVMPassBuilder PB, LLVMPassBuilderOptionsRef Options,
+    LLVMOptimizationLevel Level, LLVMModulePassManager MPM,
+    LLVMModuleAnalysisManager MAM, LLVMLoopAnalysisManager LAM,
+    LLVMFunctionAnalysisManager FAM, LLVMCGSCCAnalysisManager CGAM,
+    LLVMPassInstrumentationCallbacks PIC) {
+    // TODO handle PB memory better
+    if (PB)
+        delete (PB);
+
+    PB = new llvm::PassBuilder(nullptr, unwrap(Options)->PTO,
+                               /*Optional<PGOOptions> PGOOpt =*/{}, PIC);
+
+    // Register all the basic analyses with the managers.
+    PB->registerModuleAnalyses(*MAM);
+    PB->registerCGSCCAnalyses(*CGAM);
+    PB->registerFunctionAnalyses(*FAM);
+    PB->registerLoopAnalyses(*LAM);
+    PB->crossRegisterProxies(*LAM, *FAM, *CGAM, *MAM);
+
+    MPM = new llvm::ModulePassManager(
+        PB->buildPerModuleDefaultPipeline(*Level, false));
+
+    return MPM;
+}
+
+API_EXPORT(LLVMOptimizationLevel)
+LLVMPY_PassManagerCreateOptimizationLevel(unsigned OptLevel,
+                                          unsigned SizeLevel) {
+    return mapToLevel(OptLevel, SizeLevel);
 }
 
 API_EXPORT(unsigned)
-LLVMPY_PassManagerBuilderGetOptLevel(LLVMPassManagerBuilderRef PMB) {
-    llvm::PassManagerBuilder *pmb = llvm::unwrap(PMB);
-    return pmb->OptLevel;
-}
-
-API_EXPORT(void)
-LLVMPY_PassManagerBuilderSetOptLevel(LLVMPassManagerBuilderRef PMB,
-                                     unsigned OptLevel) {
-    LLVMPassManagerBuilderSetOptLevel(PMB, OptLevel);
+LLVMPY_PassManagerBuilderGetOptLevel(LLVMOptimizationLevel Level) {
+    return Level->getSpeedupLevel();
 }
 
 API_EXPORT(unsigned)
-LLVMPY_PassManagerBuilderGetSizeLevel(LLVMPassManagerBuilderRef PMB) {
-    llvm::PassManagerBuilder *pmb = llvm::unwrap(PMB);
-    return pmb->SizeLevel;
-}
-
-API_EXPORT(void)
-LLVMPY_PassManagerBuilderSetSizeLevel(LLVMPassManagerBuilderRef PMB,
-                                      unsigned SizeLevel) {
-    LLVMPassManagerBuilderSetSizeLevel(PMB, SizeLevel);
+LLVMPY_PassManagerBuilderGetSizeLevel(LLVMOptimizationLevel Level) {
+    return Level->getSizeLevel();
 }
 
 API_EXPORT(int)
-LLVMPY_PassManagerBuilderGetDisableUnrollLoops(LLVMPassManagerBuilderRef PMB) {
-    llvm::PassManagerBuilder *pmb = llvm::unwrap(PMB);
-    return pmb->DisableUnrollLoops;
+LLVMPY_PassManagerBuilderGetDisableUnrollLoops(
+    LLVMPassBuilderOptionsRef Options) {
+    return unwrap(Options)->PTO.LoopUnrolling;
 }
 
 API_EXPORT(void)
-LLVMPY_PassManagerBuilderSetDisableUnrollLoops(LLVMPassManagerBuilderRef PMB,
-                                               LLVMBool Value) {
-    LLVMPassManagerBuilderSetDisableUnrollLoops(PMB, Value);
+LLVMPY_PassManagerBuilderSetDisableUnrollLoops(
+    LLVMPassBuilderOptionsRef Options, LLVMBool Value) {
+    LLVMPassBuilderOptionsSetLoopUnrolling(Options, Value);
 }
 
 API_EXPORT(void)
-LLVMPY_PassManagerBuilderUseInlinerWithThreshold(LLVMPassManagerBuilderRef PMB,
-                                                 unsigned Threshold) {
-    LLVMPassManagerBuilderUseInlinerWithThreshold(PMB, Threshold);
+LLVMPY_PassManagerBuilderUseInlinerWithThreshold(
+    LLVMPassBuilderOptionsRef Options, unsigned Threshold) {
+    LLVMPassBuilderOptionsSetInlinerThreshold(Options, Threshold);
 }
 
-API_EXPORT(void)
+API_EXPORT(LLVMFunctionPassManager)
 LLVMPY_PassManagerBuilderPopulateFunctionPassManager(
-    LLVMPassManagerBuilderRef PMB, LLVMPassManagerRef PM) {
-    LLVMPassManagerBuilderPopulateFunctionPassManager(PMB, PM);
+    LLVMPassBuilder PB, LLVMPassBuilderOptionsRef Options,
+    LLVMOptimizationLevel Level, LLVMFunctionPassManager FPM,
+    LLVMModuleAnalysisManager MAM, LLVMLoopAnalysisManager LAM,
+    LLVMFunctionAnalysisManager FAM, LLVMCGSCCAnalysisManager CGAM,
+    LLVMPassInstrumentationCallbacks PIC) {
+    // TODO handle PB memory better
+    if (PB)
+        delete (PB);
+
+    PB = new llvm::PassBuilder(nullptr, unwrap(Options)->PTO,
+                               /*Optional<PGOOptions> PGOOpt =*/{}, PIC);
+
+    // Register all the basic analyses with the managers.
+    PB->registerModuleAnalyses(*MAM);
+    PB->registerCGSCCAnalyses(*CGAM);
+    PB->registerFunctionAnalyses(*FAM);
+    PB->registerLoopAnalyses(*LAM);
+    PB->crossRegisterProxies(*LAM, *FAM, *CGAM, *MAM);
+
+    // O0 maps to now passes
+    if (*Level != llvm::OptimizationLevel::O0)
+        FPM->addPass(PB->buildFunctionSimplificationPipeline(
+            *Level, llvm::ThinOrFullLTOPhase::None));
+
+    return FPM;
 }
 
 API_EXPORT(void)
-LLVMPY_PassManagerBuilderSetLoopVectorize(LLVMPassManagerBuilderRef PMB,
+LLVMPY_PassManagerBuilderSetLoopVectorize(LLVMPassBuilderOptionsRef Options,
                                           int Value) {
-    llvm::PassManagerBuilder *pmb = llvm::unwrap(PMB);
-    pmb->LoopVectorize = Value;
+    LLVMPassBuilderOptionsSetLoopVectorization(Options, Value);
 }
 
 API_EXPORT(int)
-LLVMPY_PassManagerBuilderGetLoopVectorize(LLVMPassManagerBuilderRef PMB) {
-    llvm::PassManagerBuilder *pmb = llvm::unwrap(PMB);
-    return pmb->LoopVectorize;
+LLVMPY_PassManagerBuilderGetLoopVectorize(LLVMPassBuilderOptionsRef Options) {
+    return unwrap(Options)->PTO.LoopVectorization;
 }
 
 API_EXPORT(void)
-LLVMPY_PassManagerBuilderSetSLPVectorize(LLVMPassManagerBuilderRef PMB,
+LLVMPY_PassManagerBuilderSetSLPVectorize(LLVMPassBuilderOptionsRef Options,
                                          int Value) {
-    llvm::PassManagerBuilder *pmb = llvm::unwrap(PMB);
-    pmb->SLPVectorize = Value;
+    LLVMPassBuilderOptionsSetSLPVectorization(Options, Value);
 }
 
 API_EXPORT(int)
-LLVMPY_PassManagerBuilderGetSLPVectorize(LLVMPassManagerBuilderRef PMB) {
-    llvm::PassManagerBuilder *pmb = llvm::unwrap(PMB);
-    return pmb->SLPVectorize;
+LLVMPY_PassManagerBuilderGetSLPVectorize(LLVMPassBuilderOptionsRef Options) {
+    return unwrap(Options)->PTO.SLPVectorization;
 }
+
+// TODO: Expose additional new options?
+// llvm-project/llvm/include/llvm-c/Transforms/PassBuilder.h
+/*
+void LLVMPassBuilderOptionsSetVerifyEach(LLVMPassBuilderOptionsRef Options,
+                                         LLVMBool VerifyEach);
+
+void LLVMPassBuilderOptionsSetDebugLogging(LLVMPassBuilderOptionsRef Options,
+                                           LLVMBool DebugLogging);
+
+void LLVMPassBuilderOptionsSetLoopInterleaving(
+    LLVMPassBuilderOptionsRef Options, LLVMBool LoopInterleaving);
+
+void LLVMPassBuilderOptionsSetForgetAllSCEVInLoopUnroll(
+    LLVMPassBuilderOptionsRef Options, LLVMBool ForgetAllSCEVInLoopUnroll);
+
+void LLVMPassBuilderOptionsSetLicmMssaOptCap(LLVMPassBuilderOptionsRef Options,
+                                             unsigned LicmMssaOptCap);
+
+void LLVMPassBuilderOptionsSetLicmMssaNoAccForPromotionCap(
+    LLVMPassBuilderOptionsRef Options, unsigned LicmMssaNoAccForPromotionCap);
+
+void LLVMPassBuilderOptionsSetCallGraphProfile(
+    LLVMPassBuilderOptionsRef Options, LLVMBool CallGraphProfile);
+
+void LLVMPassBuilderOptionsSetMergeFunctions(LLVMPassBuilderOptionsRef Options,
+                                             LLVMBool MergeFunctions);
+
+*/
 
 } // end extern "C"

--- a/ffi/type.cpp
+++ b/ffi/type.cpp
@@ -156,7 +156,7 @@ LLVMPY_GetElementType(LLVMTypeRef type) {
 #else
 API_EXPORT(LLVMTypeRef)
 LLVMPY_GetElementType(LLVMTypeRef type) {
-    assert(false & "No element types with opaque pointers");
+    assert(false && "No element types with opaque pointers");
 }
 #endif
 

--- a/ffi/type.cpp
+++ b/ffi/type.cpp
@@ -155,7 +155,9 @@ LLVMPY_GetElementType(LLVMTypeRef type) {
 }
 #else
 API_EXPORT(LLVMTypeRef)
-LLVMPY_GetElementType(LLVMTypeRef type) { assert(false & "No element types with opaque pointers"); }
+LLVMPY_GetElementType(LLVMTypeRef type) {
+    assert(false & "No element types with opaque pointers");
+}
 #endif
 
 } // end extern "C"

--- a/ffi/type.cpp
+++ b/ffi/type.cpp
@@ -155,7 +155,7 @@ LLVMPY_GetElementType(LLVMTypeRef type) {
 }
 #else
 API_EXPORT(LLVMTypeRef)
-LLVMPY_GetElementType(LLVMTypeRef type) { return nullptr; }
+LLVMPY_GetElementType(LLVMTypeRef type) { assert(false & "No element types with opaque pointers"); }
 #endif
 
 } // end extern "C"

--- a/ffi/type.cpp
+++ b/ffi/type.cpp
@@ -157,6 +157,7 @@ LLVMPY_GetElementType(LLVMTypeRef type) {
 API_EXPORT(LLVMTypeRef)
 LLVMPY_GetElementType(LLVMTypeRef type) {
     assert(false && "No element types with opaque pointers");
+    return nullptr;
 }
 #endif
 

--- a/ffi/value.cpp
+++ b/ffi/value.cpp
@@ -471,4 +471,14 @@ LLVMPY_GetOpcodeName(LLVMValueRef Val) {
     return LLVMPY_CreateString("");
 }
 
+API_EXPORT(bool)
+LLVMPY_IsFunctionVararg(LLVMValueRef F) {
+    using namespace llvm;
+    Function *func = unwrap<Function>(F);
+    if (func != nullptr) {
+        return func->isVarArg();
+    }
+    return false;
+}
+
 } // end extern "C"

--- a/llvmlite/binding/ffi.py
+++ b/llvmlite/binding/ffi.py
@@ -51,9 +51,10 @@ LLVMCGSCCAnalysisManager = _make_opaque_ref("LLVMCGSCCAnalysisManager")
 LLVMFunctionAnalysisManager = _make_opaque_ref("LLVMFunctionAnalysisManager")
 LLVMLoopAnalysisManager = _make_opaque_ref("LLVMLoopAnalysisManager")
 LLVMLoopAnalysisManager = _make_opaque_ref("LLVMLoopAnalysisManager")
-LLVMPassInstrumentationCallbacks = _make_opaque_ref("LLVMPassInstrumentationCallbacks")
+LLVMPassInstrumentationCallbacks = _make_opaque_ref(
+    "LLVMPassInstrumentationCallbacks"
+)
 LLVMTimePassesHandler = _make_opaque_ref("LLVMTimePassesHandler")
- 
 
 
 class _LLVMLock:

--- a/llvmlite/binding/ffi.py
+++ b/llvmlite/binding/ffi.py
@@ -40,6 +40,20 @@ LLVMObjectFileRef = _make_opaque_ref("LLVMObjectFile")
 LLVMSectionIteratorRef = _make_opaque_ref("LLVMSectionIterator")
 LLVMOrcLLJITRef = _make_opaque_ref("LLVMOrcLLJITRef")
 LLVMOrcDylibTrackerRef = _make_opaque_ref("LLVMOrcDylibTrackerRef")
+LLVMPassBuilderOptionsRef = _make_opaque_ref("LLVMPassBuilderOptions")
+LLVMOptimizationLevel = _make_opaque_ref("LLVMOptimizationLevel")
+LLVMFunctionPassManager = _make_opaque_ref("LLVMFunctionPassManager")
+LLVMPassBuilder = _make_opaque_ref("LLVMPassBuilder")
+LLVMModulePassManager = _make_opaque_ref("LLVMModulePassManager")
+
+LLVMModuleAnalysisManager = _make_opaque_ref("LLVMModuleAnalysisManager")
+LLVMCGSCCAnalysisManager = _make_opaque_ref("LLVMCGSCCAnalysisManager")
+LLVMFunctionAnalysisManager = _make_opaque_ref("LLVMFunctionAnalysisManager")
+LLVMLoopAnalysisManager = _make_opaque_ref("LLVMLoopAnalysisManager")
+LLVMLoopAnalysisManager = _make_opaque_ref("LLVMLoopAnalysisManager")
+LLVMPassInstrumentationCallbacks = _make_opaque_ref("LLVMPassInstrumentationCallbacks")
+LLVMTimePassesHandler = _make_opaque_ref("LLVMTimePassesHandler")
+ 
 
 
 class _LLVMLock:
@@ -189,6 +203,10 @@ class _lib_fn_wrapper(object):
 
     def __call__(self, *args, **kwargs):
         with self._lock:
+            print(self._cfn.__name__)
+            print("calling")
+            for arg in args:
+              print(type(arg))
             return self._cfn(*args, **kwargs)
 
 

--- a/llvmlite/binding/ffi.py
+++ b/llvmlite/binding/ffi.py
@@ -203,10 +203,6 @@ class _lib_fn_wrapper(object):
 
     def __call__(self, *args, **kwargs):
         with self._lock:
-            print(self._cfn.__name__)
-            print("calling")
-            for arg in args:
-              print(type(arg))
             return self._cfn(*args, **kwargs)
 
 

--- a/llvmlite/binding/initfini.py
+++ b/llvmlite/binding/initfini.py
@@ -7,7 +7,8 @@ def initialize():
     """
     Initialize the LLVM core.
     """
-    ffi.lib.LLVMPY_InitializeCore()
+    # No longer necessary with NPM
+    # ffi.lib.LLVMPY_InitializeCore()
 
 
 def initialize_all_targets():

--- a/llvmlite/binding/passmanagers.py
+++ b/llvmlite/binding/passmanagers.py
@@ -816,7 +816,9 @@ class FunctionPassManager(PassManager):
             The filter that should be applied to the remarks output.
         """
         if remarks_file is None:
-            return ffi.lib.LLVMPY_RunFunctionPassManager(self, function, self.__FAM__)
+            return ffi.lib.LLVMPY_RunFunctionPassManager(
+                self, function, self.__FAM__
+            )
         else:
             r = ffi.lib.LLVMPY_RunFunctionPassManagerWithRemarks(
                 self, function, self.__FAM__, _encode_string(remarks_format),
@@ -858,15 +860,21 @@ class FunctionPassManager(PassManager):
             os.unlink(remarkfile)
 
     def add_target_library_info(self, triple):
-        ffi.lib.LLVMPY_AddTargetLibraryInfoPass(self.__FAM__, _encode_string(triple))
+        ffi.lib.LLVMPY_AddTargetLibraryInfoPass(
+            self.__FAM__, _encode_string(triple)
+        )
 
 
 # ============================================================================
 # FFI
 
-ffi.lib.LLVMPY_LLVMFunctionAnalysisManagerCreate.restype = ffi.LLVMFunctionAnalysisManager
+ffi.lib.LLVMPY_LLVMFunctionAnalysisManagerCreate.restype = (
+    ffi.LLVMFunctionAnalysisManager
+)
 
-ffi.lib.LLVMPY_LLVMModuleAnalysisManagerCreate.restype = ffi.LLVMModuleAnalysisManager
+ffi.lib.LLVMPY_LLVMModuleAnalysisManagerCreate.restype = (
+    ffi.LLVMModuleAnalysisManager
+)
 
 ffi.lib.LLVMPY_CreateLLVMTimePassesHandler.restype = ffi.LLVMTimePassesHandler
 
@@ -877,35 +885,54 @@ ffi.lib.LLVMPY_CreateFunctionPassManager.restype = ffi.LLVMFunctionPassManager
 
 ffi.lib.LLVMPY_DisposePassManager.argtypes = [ffi.LLVMModulePassManager]
 
-ffi.lib.LLVMPY_DisposeFunctionPassManager.argtypes = [ffi.LLVMFunctionPassManager]
+ffi.lib.LLVMPY_DisposeFunctionPassManager.argtypes = [
+    ffi.LLVMFunctionPassManager
+]
 
-ffi.lib.LLVMPY_DisposeLLVMTimePassesHandler.argtypes = [ffi.LLVMTimePassesHandler]
+ffi.lib.LLVMPY_DisposeLLVMTimePassesHandler.argtypes = [
+    ffi.LLVMTimePassesHandler
+]
 
-ffi.lib.LLVMPY_RunPassManager.argtypes = [ffi.LLVMModulePassManager,
-                                          ffi.LLVMModuleRef,
-                                          ffi.LLVMModuleAnalysisManager]
+ffi.lib.LLVMPY_RunPassManager.argtypes = [
+    ffi.LLVMModulePassManager,
+    ffi.LLVMModuleRef,
+    ffi.LLVMModuleAnalysisManager,
+]
 ffi.lib.LLVMPY_RunPassManager.restype = c_bool
 
-ffi.lib.LLVMPY_RunPassManagerWithRemarks.argtypes = [ffi.LLVMModulePassManager,
-                                                     ffi.LLVMModuleRef,
-                                                     ffi.LLVMModuleAnalysisManager,
-                                                     c_char_p,
-                                                     c_char_p,
-                                                     c_char_p]
+ffi.lib.LLVMPY_RunPassManagerWithRemarks.argtypes = [
+    ffi.LLVMModulePassManager,
+    ffi.LLVMModuleRef,
+    ffi.LLVMModuleAnalysisManager,
+    c_char_p,
+    c_char_p,
+    c_char_p,
+]
 ffi.lib.LLVMPY_RunPassManagerWithRemarks.restype = c_int
 
-ffi.lib.LLVMPY_InitializeFunctionPassManager.argtypes = [ffi.LLVMFunctionPassManager]
+ffi.lib.LLVMPY_InitializeFunctionPassManager.argtypes = [
+    ffi.LLVMFunctionPassManager
+]
 ffi.lib.LLVMPY_InitializeFunctionPassManager.restype = c_bool
 
-ffi.lib.LLVMPY_FinalizeFunctionPassManager.argtypes = [ffi.LLVMFunctionPassManager]
+ffi.lib.LLVMPY_FinalizeFunctionPassManager.argtypes = [
+    ffi.LLVMFunctionPassManager
+]
 ffi.lib.LLVMPY_FinalizeFunctionPassManager.restype = c_bool
 
-ffi.lib.LLVMPY_RunFunctionPassManager.argtypes = [ffi.LLVMFunctionPassManager,
-                                                  ffi.LLVMValueRef]
+ffi.lib.LLVMPY_RunFunctionPassManager.argtypes = [
+    ffi.LLVMFunctionPassManager,
+    ffi.LLVMValueRef,
+]
 ffi.lib.LLVMPY_RunFunctionPassManager.restype = c_bool
 
 ffi.lib.LLVMPY_RunFunctionPassManagerWithRemarks.argtypes = [
-    ffi.LLVMFunctionPassManager, ffi.LLVMValueRef, ffi.LLVMFunctionAnalysisManager, c_char_p, c_char_p, c_char_p
+    ffi.LLVMFunctionPassManager,
+    ffi.LLVMValueRef,
+    ffi.LLVMFunctionAnalysisManager,
+    c_char_p,
+    c_char_p,
+    c_char_p,
 ]
 ffi.lib.LLVMPY_RunFunctionPassManagerWithRemarks.restype = c_int
 
@@ -919,7 +946,8 @@ ffi.lib.LLVMPY_AddCFGPrinterPass.argtypes = [ffi.LLVMPassManagerRef]
 ffi.lib.LLVMPY_AddDotDomPrinterPass.argtypes = [ffi.LLVMPassManagerRef, c_bool]
 ffi.lib.LLVMPY_AddDotPostDomPrinterPass.argtypes = [
     ffi.LLVMPassManagerRef,
-    c_bool]
+    c_bool,
+]
 ffi.lib.LLVMPY_AddGlobalsModRefAAPass.argtypes = [ffi.LLVMPassManagerRef]
 ffi.lib.LLVMPY_AddInstructionCountPass.argtypes = [ffi.LLVMPassManagerRef]
 ffi.lib.LLVMPY_AddIVUsersPass.argtypes = [ffi.LLVMPassManagerRef]
@@ -933,15 +961,18 @@ ffi.lib.LLVMPY_AddAlwaysInlinerPass.argtypes = [ffi.LLVMPassManagerRef, c_bool]
 
 if llvm_version_major < 15:
     ffi.lib.LLVMPY_AddArgPromotionPass.argtypes = [
-        ffi.LLVMPassManagerRef, c_uint]
+        ffi.LLVMPassManagerRef,
+        c_uint,
+    ]
 
 ffi.lib.LLVMPY_AddBreakCriticalEdgesPass.argtypes = [ffi.LLVMPassManagerRef]
-ffi.lib.LLVMPY_AddDeadStoreEliminationPass.argtypes = [
-    ffi.LLVMPassManagerRef]
+ffi.lib.LLVMPY_AddDeadStoreEliminationPass.argtypes = [ffi.LLVMPassManagerRef]
 ffi.lib.LLVMPY_AddReversePostOrderFunctionAttrsPass.argtypes = [
-    ffi.LLVMPassManagerRef]
+    ffi.LLVMPassManagerRef
+]
 ffi.lib.LLVMPY_AddAggressiveInstructionCombiningPass.argtypes = [
-    ffi.LLVMPassManagerRef]
+    ffi.LLVMPassManagerRef
+]
 ffi.lib.LLVMPY_AddInternalizePass.argtypes = [ffi.LLVMPassManagerRef]
 ffi.lib.LLVMPY_AddLCSSAPass.argtypes = [ffi.LLVMPassManagerRef]
 ffi.lib.LLVMPY_AddLoopDeletionPass.argtypes = [ffi.LLVMPassManagerRef]
@@ -951,8 +982,11 @@ ffi.lib.LLVMPY_AddLoopStrengthReducePass.argtypes = [ffi.LLVMPassManagerRef]
 ffi.lib.LLVMPY_AddLoopSimplificationPass.argtypes = [ffi.LLVMPassManagerRef]
 ffi.lib.LLVMPY_AddLoopUnrollPass.argtypes = [ffi.LLVMPassManagerRef]
 ffi.lib.LLVMPY_AddLoopUnrollAndJamPass.argtypes = [ffi.LLVMPassManagerRef]
-ffi.lib.LLVMPY_AddLoopUnswitchPass.argtypes = [ffi.LLVMPassManagerRef, c_bool,
-                                               c_bool]
+ffi.lib.LLVMPY_AddLoopUnswitchPass.argtypes = [
+    ffi.LLVMPassManagerRef,
+    c_bool,
+    c_bool,
+]
 ffi.lib.LLVMPY_AddLowerAtomicPass.argtypes = [ffi.LLVMPassManagerRef]
 ffi.lib.LLVMPY_AddLowerInvokePass.argtypes = [ffi.LLVMPassManagerRef]
 ffi.lib.LLVMPY_AddLowerSwitchPass.argtypes = [ffi.LLVMPassManagerRef]
@@ -968,13 +1002,16 @@ ffi.lib.LLVMPY_AddStripSymbolsPass.argtypes = [ffi.LLVMPassManagerRef, c_bool]
 ffi.lib.LLVMPY_AddStripDeadDebugInfoPass.argtypes = [ffi.LLVMPassManagerRef]
 ffi.lib.LLVMPY_AddStripDeadPrototypesPass.argtypes = [ffi.LLVMPassManagerRef]
 ffi.lib.LLVMPY_AddStripDebugDeclarePrototypesPass.argtypes = [
-    ffi.LLVMPassManagerRef]
+    ffi.LLVMPassManagerRef
+]
 ffi.lib.LLVMPY_AddStripNondebugSymbolsPass.argtypes = [ffi.LLVMPassManagerRef]
 ffi.lib.LLVMPY_AddTailCallEliminationPass.argtypes = [ffi.LLVMPassManagerRef]
 ffi.lib.LLVMPY_AddJumpThreadingPass.argtypes = [ffi.LLVMPassManagerRef, c_int]
 ffi.lib.LLVMPY_AddFunctionAttrsPass.argtypes = [ffi.LLVMPassManagerRef]
 ffi.lib.LLVMPY_AddFunctionInliningPass.argtypes = [
-    ffi.LLVMModulePassManager, c_int]
+    ffi.LLVMModulePassManager,
+    c_int,
+]
 ffi.lib.LLVMPY_AddGlobalDCEPass.argtypes = [ffi.LLVMPassManagerRef]
 ffi.lib.LLVMPY_AddGlobalOptimizerPass.argtypes = [ffi.LLVMPassManagerRef]
 ffi.lib.LLVMPY_AddIPSCCPPass.argtypes = [ffi.LLVMPassManagerRef]
@@ -982,17 +1019,24 @@ ffi.lib.LLVMPY_AddIPSCCPPass.argtypes = [ffi.LLVMPassManagerRef]
 ffi.lib.LLVMPY_AddDeadCodeEliminationPass.argtypes = [ffi.LLVMPassManagerRef]
 ffi.lib.LLVMPY_AddCFGSimplificationPass.argtypes = [ffi.LLVMPassManagerRef]
 ffi.lib.LLVMPY_AddGVNPass.argtypes = [ffi.LLVMPassManagerRef]
-ffi.lib.LLVMPY_AddInstructionCombiningPass.argtypes = [ffi.LLVMModulePassManager]
+ffi.lib.LLVMPY_AddInstructionCombiningPass.argtypes = [
+    ffi.LLVMModulePassManager
+]
 ffi.lib.LLVMPY_AddLICMPass.argtypes = [ffi.LLVMFunctionPassManager]
 ffi.lib.LLVMPY_AddSCCPPass.argtypes = [ffi.LLVMPassManagerRef]
 ffi.lib.LLVMPY_AddSROAPass.argtypes = [ffi.LLVMPassManagerRef]
 ffi.lib.LLVMPY_AddTypeBasedAliasAnalysisPass.argtypes = [ffi.LLVMPassManagerRef]
 ffi.lib.LLVMPY_AddBasicAliasAnalysisPass.argtypes = [ffi.LLVMPassManagerRef]
-ffi.lib.LLVMPY_AddTargetLibraryInfoPass.argtypes = [ffi.LLVMFunctionAnalysisManager,
-                                                    c_char_p]
+ffi.lib.LLVMPY_AddTargetLibraryInfoPass.argtypes = [
+    ffi.LLVMFunctionAnalysisManager,
+    c_char_p,
+]
 ffi.lib.LLVMPY_AddInstructionNamerPass.argtypes = [ffi.LLVMModulePassManager]
 
-ffi.lib.LLVMPY_AddRefPrunePass.argtypes = [ffi.LLVMModulePassManager, c_int,
-                                           c_size_t]
+ffi.lib.LLVMPY_AddRefPrunePass.argtypes = [
+    ffi.LLVMModulePassManager,
+    c_int,
+    c_size_t,
+]
 
 ffi.lib.LLVMPY_DumpRefPruneStats.argtypes = [POINTER(_c_PruneStats), c_bool]

--- a/llvmlite/binding/passmanagers.py
+++ b/llvmlite/binding/passmanagers.py
@@ -636,7 +636,6 @@ class ModulePassManager(PassManager):
             ptr = ffi.lib.LLVMPY_CreatePassManager()
         PassManager.__init__(self, ptr)
         self.__MAM__ = ffi.lib.LLVMPY_LLVMModuleAnalysisManagerCreate()
-        print(self.__MAM__)
         self.__TimePasses__ = ffi.lib.LLVMPY_CreateLLVMTimePassesHandler()
 
     def update(self, ptr):

--- a/llvmlite/binding/passmanagers.py
+++ b/llvmlite/binding/passmanagers.py
@@ -613,7 +613,6 @@ class PassManager(ffi.ObjectRef):
         ffi.lib.LLVMPY_LLVMAddLoopRotatePass(self)
 
     def add_target_library_info(self, triple):
-        raise RuntimeError('Should not be called directly.')
         ffi.lib.LLVMPY_AddTargetLibraryInfoPass(self, _encode_string(triple))
 
     def add_instruction_namer_pass(self):

--- a/llvmlite/binding/targets.py
+++ b/llvmlite/binding/targets.py
@@ -151,7 +151,8 @@ class TargetData(ffi.ObjectRef):
         """
         Get ABI size of pointee type of LLVM pointer type *ty*.
         """
-        raise RuntimeError("Opaque pointers means pointee information cannot be queried")
+        raise RuntimeError("Opaque pointers means pointee "
+                           "information cannot be queried")
         size = ffi.lib.LLVMPY_ABISizeOfElementType(self, ty)
         if size == -1:
             raise RuntimeError("Not a pointer type: %s" % (ty,))
@@ -161,7 +162,8 @@ class TargetData(ffi.ObjectRef):
         """
         Get minimum ABI alignment of pointee type of LLVM pointer type *ty*.
         """
-        raise RuntimeError("Opaque pointers means pointee information cannot be queried")
+        raise RuntimeError("Opaque pointers means pointee "
+                           "information cannot be queried")
         size = ffi.lib.LLVMPY_ABIAlignmentOfElementType(self, ty)
         if size == -1:
             raise RuntimeError("Not a pointer type: %s" % (ty,))
@@ -389,7 +391,7 @@ ffi.lib.LLVMPY_ABIAlignmentOfElementType.argtypes = [ffi.LLVMTargetDataRef,
 ffi.lib.LLVMPY_ABIAlignmentOfElementType.restype = c_longlong
 
 ffi.lib.LLVMPY_ABIAlignmentOfType.argtypes = [ffi.LLVMTargetDataRef,
-                                                     ffi.LLVMTypeRef]
+                                              ffi.LLVMTypeRef]
 ffi.lib.LLVMPY_ABIAlignmentOfType.restype = c_longlong
 
 ffi.lib.LLVMPY_GetTargetFromTriple.argtypes = [c_char_p, POINTER(c_char_p)]

--- a/llvmlite/binding/targets.py
+++ b/llvmlite/binding/targets.py
@@ -151,6 +151,7 @@ class TargetData(ffi.ObjectRef):
         """
         Get ABI size of pointee type of LLVM pointer type *ty*.
         """
+        raise RuntimeError("Opaque pointers means pointee information cannot be queried")
         size = ffi.lib.LLVMPY_ABISizeOfElementType(self, ty)
         if size == -1:
             raise RuntimeError("Not a pointer type: %s" % (ty,))
@@ -160,10 +161,17 @@ class TargetData(ffi.ObjectRef):
         """
         Get minimum ABI alignment of pointee type of LLVM pointer type *ty*.
         """
+        raise RuntimeError("Opaque pointers means pointee information cannot be queried")
         size = ffi.lib.LLVMPY_ABIAlignmentOfElementType(self, ty)
         if size == -1:
             raise RuntimeError("Not a pointer type: %s" % (ty,))
         return size
+
+    def get_abi_alignment(self, ty):
+        """
+        Get minimum ABI alignment of pointee type of LLVM pointer type *ty*.
+        """
+        return ffi.lib.LLVMPY_ABIAlignmentOfType(self, ty)
 
 
 RELOC = frozenset(['default', 'static', 'pic', 'dynamicnopic'])
@@ -380,6 +388,10 @@ ffi.lib.LLVMPY_ABIAlignmentOfElementType.argtypes = [ffi.LLVMTargetDataRef,
                                                      ffi.LLVMTypeRef]
 ffi.lib.LLVMPY_ABIAlignmentOfElementType.restype = c_longlong
 
+ffi.lib.LLVMPY_ABIAlignmentOfType.argtypes = [ffi.LLVMTargetDataRef,
+                                                     ffi.LLVMTypeRef]
+ffi.lib.LLVMPY_ABIAlignmentOfType.restype = c_longlong
+
 ffi.lib.LLVMPY_GetTargetFromTriple.argtypes = [c_char_p, POINTER(c_char_p)]
 ffi.lib.LLVMPY_GetTargetFromTriple.restype = ffi.LLVMTargetRef
 
@@ -422,7 +434,7 @@ ffi.lib.LLVMPY_SetTargetMachineAsmVerbosity.argtypes = [
 
 ffi.lib.LLVMPY_AddAnalysisPasses.argtypes = [
     ffi.LLVMTargetMachineRef,
-    ffi.LLVMPassManagerRef,
+    ffi.LLVMModulePassManager,
 ]
 
 ffi.lib.LLVMPY_TargetMachineEmitToMemory.argtypes = [

--- a/llvmlite/binding/transforms.py
+++ b/llvmlite/binding/transforms.py
@@ -1,4 +1,4 @@
-from ctypes import c_uint, c_bool
+from ctypes import c_uint, c_bool, POINTER, c_char_p
 from llvmlite.binding import ffi
 from llvmlite.binding import passmanagers
 
@@ -6,36 +6,56 @@ from llvmlite.binding import passmanagers
 def create_pass_manager_builder():
     return PassManagerBuilder()
 
+class OptimizationLevel(ffi.ObjectRef):
+    def __init__(self, ptr=None):
+        if ptr is None:
+            ptr = ffi.lib.LLVMPY_PassManagerCreateOptimizationLevel(0, 0)
+        ffi.ObjectRef.__init__(self, ptr)
 
 class PassManagerBuilder(ffi.ObjectRef):
-    __slots__ = ()
+    __opt_level__ = 0
+    __size_level__ = 0
+    __MAM__ = ffi.LLVMModuleAnalysisManager
+    __LAM__ = ffi.LLVMLoopAnalysisManager
+    __FAM__ = ffi.LLVMFunctionAnalysisManager
+    __CGAM__ = ffi.LLVMCGSCCAnalysisManager
+    __PIC__ = ffi.LLVMPassInstrumentationCallbacks
+    __pipeline_options__ = ffi.LLVMPassBuilderOptionsRef
 
     def __init__(self, ptr=None):
         if ptr is None:
             ptr = ffi.lib.LLVMPY_PassManagerBuilderCreate()
         ffi.ObjectRef.__init__(self, ptr)
 
+        self.__MAM__ = ffi.lib.LLVMPY_LLVMModuleAnalysisManagerCreate()
+        self.__LAM__ = ffi.lib.LLVMPY_LLVMLoopAnalysisManagerCreate()
+        self.__FAM__ = ffi.lib.LLVMPY_LLVMFunctionAnalysisManagerCreate()
+        self.__CGAM__ = ffi.lib.LLVMPY_LLVMCGSCCAnalysisManagerCreate()
+        self.__PIC__ = ffi.lib.LLVMPY_LLVMPassInstrumentationCallbacksCreate()
+        self.__pipeline_options__ = ffi.lib.LLVMPY_PassManagerBuilderOptionsCreate()
+
     @property
     def opt_level(self):
         """
         The general optimization level as an integer between 0 and 3.
+        Whether and how much to optimize for size.  An integer between 0 and 2.
         """
-        return ffi.lib.LLVMPY_PassManagerBuilderGetOptLevel(self)
+        return self.__opt_level__
 
     @opt_level.setter
     def opt_level(self, level):
-        ffi.lib.LLVMPY_PassManagerBuilderSetOptLevel(self, level)
+        self.__opt_level__ = level
 
     @property
     def size_level(self):
         """
         Whether and how much to optimize for size.  An integer between 0 and 2.
         """
-        return ffi.lib.LLVMPY_PassManagerBuilderGetSizeLevel(self)
+        return self.__size_level__
 
     @size_level.setter
     def size_level(self, size):
-        ffi.lib.LLVMPY_PassManagerBuilderSetSizeLevel(self, size)
+        self.__size_level__ = size
 
     @property
     def inlining_threshold(self):
@@ -48,29 +68,29 @@ class PassManagerBuilder(ffi.ObjectRef):
     @inlining_threshold.setter
     def inlining_threshold(self, threshold):
         ffi.lib.LLVMPY_PassManagerBuilderUseInlinerWithThreshold(
-            self, threshold)
+            self.__pipeline_options__, threshold)
 
     @property
     def disable_unroll_loops(self):
         """
         If true, disable loop unrolling.
         """
-        return ffi.lib.LLVMPY_PassManagerBuilderGetDisableUnrollLoops(self)
+        return ffi.lib.LLVMPY_PassManagerBuilderGetDisableUnrollLoops(self.__pipeline_options__)
 
     @disable_unroll_loops.setter
     def disable_unroll_loops(self, disable=True):
-        ffi.lib.LLVMPY_PassManagerBuilderSetDisableUnrollLoops(self, disable)
+        ffi.lib.LLVMPY_PassManagerBuilderSetDisableUnrollLoops(self.__pipeline_options__, disable)
 
     @property
     def loop_vectorize(self):
         """
         If true, allow vectorizing loops.
         """
-        return ffi.lib.LLVMPY_PassManagerBuilderGetLoopVectorize(self)
+        return ffi.lib.LLVMPY_PassManagerBuilderGetLoopVectorize(self.__pipeline_options__)
 
     @loop_vectorize.setter
     def loop_vectorize(self, enable=True):
-        return ffi.lib.LLVMPY_PassManagerBuilderSetLoopVectorize(self, enable)
+        return ffi.lib.LLVMPY_PassManagerBuilderSetLoopVectorize(self.__pipeline_options__, enable)
 
     @property
     def slp_vectorize(self):
@@ -78,17 +98,19 @@ class PassManagerBuilder(ffi.ObjectRef):
         If true, enable the "SLP vectorizer", which uses a different algorithm
         from the loop vectorizer.  Both may be enabled at the same time.
         """
-        return ffi.lib.LLVMPY_PassManagerBuilderGetSLPVectorize(self)
+        return ffi.lib.LLVMPY_PassManagerBuilderGetSLPVectorize(self.__pipeline_options__)
 
     @slp_vectorize.setter
     def slp_vectorize(self, enable=True):
-        return ffi.lib.LLVMPY_PassManagerBuilderSetSLPVectorize(self, enable)
+        return ffi.lib.LLVMPY_PassManagerBuilderSetSLPVectorize(self.__pipeline_options__, enable)
 
     def _populate_module_pm(self, pm):
-        ffi.lib.LLVMPY_PassManagerBuilderPopulateModulePassManager(self, pm)
+        pm.update(ffi.lib.LLVMPY_PassManagerBuilderPopulateModulePassManager(self, self.__pipeline_options__, OptimizationLevel(ffi.lib.LLVMPY_PassManagerCreateOptimizationLevel(c_uint(self.__opt_level__), c_uint(self.__size_level__))), pm, pm.__MAM__, self.__LAM__, self.__FAM__, self.__CGAM__, self.__PIC__))
+        pm.__PIC__ = self.__PIC__
 
     def _populate_function_pm(self, pm):
-        ffi.lib.LLVMPY_PassManagerBuilderPopulateFunctionPassManager(self, pm)
+        pm.update(ffi.lib.LLVMPY_PassManagerBuilderPopulateFunctionPassManager(self, self.__pipeline_options__, OptimizationLevel(ffi.lib.LLVMPY_PassManagerCreateOptimizationLevel(c_uint(self.__opt_level__), c_uint(self.__size_level__))), pm, self.__MAM__, self.__LAM__, pm.__FAM__, self.__CGAM__, self.__PIC__))
+        pm.__PIC__ = self.__PIC__
 
     def populate(self, pm):
         if isinstance(pm, passmanagers.ModulePassManager):
@@ -99,40 +121,70 @@ class PassManagerBuilder(ffi.ObjectRef):
             raise TypeError(pm)
 
     def _dispose(self):
-        self._capi.LLVMPY_PassManagerBuilderDispose(self)
+        self._capi.LLVMPY_PassManagerBuilderDispose(self, self.__pipeline_options__)
 
 
 # ============================================================================
 # FFI
 
-ffi.lib.LLVMPY_PassManagerBuilderCreate.restype = ffi.LLVMPassManagerBuilderRef
+ffi.lib.LLVMPY_PassManagerBuilderCreate.restype = ffi.LLVMPassBuilder
+
+ffi.lib.LLVMPY_LLVMModuleAnalysisManagerCreate.restype = ffi.LLVMModuleAnalysisManager
+ffi.lib.LLVMPY_LLVMLoopAnalysisManagerCreate.restype = ffi.LLVMLoopAnalysisManager
+ffi.lib.LLVMPY_LLVMFunctionAnalysisManagerCreate.restype = ffi.LLVMFunctionAnalysisManager
+ffi.lib.LLVMPY_LLVMCGSCCAnalysisManagerCreate.restype = ffi.LLVMCGSCCAnalysisManager
+ffi.lib.LLVMPY_LLVMPassInstrumentationCallbacksCreate.restype = ffi.LLVMPassInstrumentationCallbacks
+
+
+ffi.lib.LLVMPY_PassManagerBuilderOptionsCreate.restype = ffi.LLVMPassBuilderOptionsRef
 
 ffi.lib.LLVMPY_PassManagerBuilderDispose.argtypes = [
-    ffi.LLVMPassManagerBuilderRef,
+    ffi.LLVMPassBuilder,
+    ffi.LLVMPassBuilderOptionsRef,
 ]
 
 ffi.lib.LLVMPY_PassManagerBuilderPopulateModulePassManager.argtypes = [
-    ffi.LLVMPassManagerBuilderRef,
-    ffi.LLVMPassManagerRef,
+    ffi.LLVMPassBuilder,
+    ffi.LLVMPassBuilderOptionsRef,
+    ffi.LLVMOptimizationLevel,
+    ffi.LLVMModulePassManager,
+    ffi.LLVMModuleAnalysisManager,
+    ffi.LLVMLoopAnalysisManager,
+    ffi.LLVMFunctionAnalysisManager,
+    ffi.LLVMCGSCCAnalysisManager,
+    ffi.LLVMPassInstrumentationCallbacks,
 ]
 
+ffi.lib.LLVMPY_PassManagerBuilderPopulateModulePassManager.restype = ffi.LLVMModulePassManager
+
 ffi.lib.LLVMPY_PassManagerBuilderPopulateFunctionPassManager.argtypes = [
-    ffi.LLVMPassManagerBuilderRef,
-    ffi.LLVMPassManagerRef,
+    ffi.LLVMPassBuilder,
+    ffi.LLVMPassBuilderOptionsRef,
+    ffi.LLVMOptimizationLevel,
+    ffi.LLVMFunctionPassManager,
+    ffi.LLVMModuleAnalysisManager,
+    ffi.LLVMLoopAnalysisManager,
+    ffi.LLVMFunctionAnalysisManager,
+    ffi.LLVMCGSCCAnalysisManager,
+    ffi.LLVMPassInstrumentationCallbacks,
 ]
+
+ffi.lib.LLVMPY_PassManagerBuilderPopulateFunctionPassManager.restype = ffi.LLVMFunctionPassManager
+
+ffi.lib.LLVMPY_PassManagerCreateOptimizationLevel.restype = ffi.LLVMOptimizationLevel
+ffi.lib.LLVMPY_PassManagerCreateOptimizationLevel.argtypes = [c_uint, c_uint]
 
 # Unsigned int PassManagerBuilder properties
 
-for _func in (ffi.lib.LLVMPY_PassManagerBuilderSetOptLevel,
-              ffi.lib.LLVMPY_PassManagerBuilderSetSizeLevel,
-              ffi.lib.LLVMPY_PassManagerBuilderUseInlinerWithThreshold,
+for _func in (ffi.lib.LLVMPY_PassManagerBuilderUseInlinerWithThreshold,
               ):
-    _func.argtypes = [ffi.LLVMPassManagerBuilderRef, c_uint]
+    _func.argtypes = [ffi.LLVMPassBuilderOptionsRef, c_uint]
+    
 
 for _func in (ffi.lib.LLVMPY_PassManagerBuilderGetOptLevel,
               ffi.lib.LLVMPY_PassManagerBuilderGetSizeLevel,
               ):
-    _func.argtypes = [ffi.LLVMPassManagerBuilderRef]
+    _func.argtypes = [ffi.LLVMOptimizationLevel]
     _func.restype = c_uint
 
 # Boolean PassManagerBuilder properties
@@ -141,11 +193,11 @@ for _func in (ffi.lib.LLVMPY_PassManagerBuilderSetDisableUnrollLoops,
               ffi.lib.LLVMPY_PassManagerBuilderSetLoopVectorize,
               ffi.lib.LLVMPY_PassManagerBuilderSetSLPVectorize,
               ):
-    _func.argtypes = [ffi.LLVMPassManagerBuilderRef, c_bool]
+    _func.argtypes = [ffi.LLVMPassBuilderOptionsRef, c_bool]
 
 for _func in (ffi.lib.LLVMPY_PassManagerBuilderGetDisableUnrollLoops,
               ffi.lib.LLVMPY_PassManagerBuilderGetLoopVectorize,
               ffi.lib.LLVMPY_PassManagerBuilderGetSLPVectorize,
               ):
-    _func.argtypes = [ffi.LLVMPassManagerBuilderRef]
+    _func.argtypes = [ffi.LLVMPassBuilderOptionsRef]
     _func.restype = c_bool

--- a/llvmlite/binding/transforms.py
+++ b/llvmlite/binding/transforms.py
@@ -38,7 +38,6 @@ class PassManagerBuilder(ffi.ObjectRef):
     def opt_level(self):
         """
         The general optimization level as an integer between 0 and 3.
-        Whether and how much to optimize for size.  An integer between 0 and 2.
         """
         return self.__opt_level__
 
@@ -105,11 +104,13 @@ class PassManagerBuilder(ffi.ObjectRef):
         return ffi.lib.LLVMPY_PassManagerBuilderSetSLPVectorize(self.__pipeline_options__, enable)
 
     def _populate_module_pm(self, pm):
-        pm.update(ffi.lib.LLVMPY_PassManagerBuilderPopulateModulePassManager(self, self.__pipeline_options__, OptimizationLevel(ffi.lib.LLVMPY_PassManagerCreateOptimizationLevel(c_uint(self.__opt_level__), c_uint(self.__size_level__))), pm, pm.__MAM__, self.__LAM__, self.__FAM__, self.__CGAM__, self.__PIC__))
+        opt_level = OptimizationLevel(ffi.lib.LLVMPY_PassManagerCreateOptimizationLevel(c_uint(self.__opt_level__), c_uint(self.__size_level__)))
+        pm.update(ffi.lib.LLVMPY_PassManagerBuilderPopulateModulePassManager(self, self.__pipeline_options__, opt_level, pm, pm.__MAM__, self.__LAM__, self.__FAM__, self.__CGAM__, self.__PIC__))
         pm.__PIC__ = self.__PIC__
 
     def _populate_function_pm(self, pm):
-        pm.update(ffi.lib.LLVMPY_PassManagerBuilderPopulateFunctionPassManager(self, self.__pipeline_options__, OptimizationLevel(ffi.lib.LLVMPY_PassManagerCreateOptimizationLevel(c_uint(self.__opt_level__), c_uint(self.__size_level__))), pm, self.__MAM__, self.__LAM__, pm.__FAM__, self.__CGAM__, self.__PIC__))
+        opt_level = OptimizationLevel(ffi.lib.LLVMPY_PassManagerCreateOptimizationLevel(c_uint(self.__opt_level__), c_uint(self.__size_level__)))
+        pm.update(ffi.lib.LLVMPY_PassManagerBuilderPopulateFunctionPassManager(self, self.__pipeline_options__, opt_level, pm, self.__MAM__, self.__LAM__, pm.__FAM__, self.__CGAM__, self.__PIC__))
         pm.__PIC__ = self.__PIC__
 
     def populate(self, pm):

--- a/llvmlite/binding/transforms.py
+++ b/llvmlite/binding/transforms.py
@@ -1,4 +1,4 @@
-from ctypes import c_uint, c_bool, POINTER, c_char_p
+from ctypes import c_uint, c_bool
 from llvmlite.binding import ffi
 from llvmlite.binding import passmanagers
 
@@ -6,11 +6,13 @@ from llvmlite.binding import passmanagers
 def create_pass_manager_builder():
     return PassManagerBuilder()
 
+
 class OptimizationLevel(ffi.ObjectRef):
     def __init__(self, ptr=None):
         if ptr is None:
             ptr = ffi.lib.LLVMPY_PassManagerCreateOptimizationLevel(0, 0)
         ffi.ObjectRef.__init__(self, ptr)
+
 
 class PassManagerBuilder(ffi.ObjectRef):
     __opt_level__ = 0
@@ -32,7 +34,9 @@ class PassManagerBuilder(ffi.ObjectRef):
         self.__FAM__ = ffi.lib.LLVMPY_LLVMFunctionAnalysisManagerCreate()
         self.__CGAM__ = ffi.lib.LLVMPY_LLVMCGSCCAnalysisManagerCreate()
         self.__PIC__ = ffi.lib.LLVMPY_LLVMPassInstrumentationCallbacksCreate()
-        self.__pipeline_options__ = ffi.lib.LLVMPY_PassManagerBuilderOptionsCreate()
+        self.__pipeline_options__ = (
+            ffi.lib.LLVMPY_PassManagerBuilderOptionsCreate()
+        )
 
     @property
     def opt_level(self):
@@ -67,29 +71,38 @@ class PassManagerBuilder(ffi.ObjectRef):
     @inlining_threshold.setter
     def inlining_threshold(self, threshold):
         ffi.lib.LLVMPY_PassManagerBuilderUseInlinerWithThreshold(
-            self.__pipeline_options__, threshold)
+            self.__pipeline_options__, threshold
+        )
 
     @property
     def disable_unroll_loops(self):
         """
         If true, disable loop unrolling.
         """
-        return ffi.lib.LLVMPY_PassManagerBuilderGetDisableUnrollLoops(self.__pipeline_options__)
+        return ffi.lib.LLVMPY_PassManagerBuilderGetDisableUnrollLoops(
+            self.__pipeline_options__
+        )
 
     @disable_unroll_loops.setter
     def disable_unroll_loops(self, disable=True):
-        ffi.lib.LLVMPY_PassManagerBuilderSetDisableUnrollLoops(self.__pipeline_options__, disable)
+        ffi.lib.LLVMPY_PassManagerBuilderSetDisableUnrollLoops(
+            self.__pipeline_options__, disable
+        )
 
     @property
     def loop_vectorize(self):
         """
         If true, allow vectorizing loops.
         """
-        return ffi.lib.LLVMPY_PassManagerBuilderGetLoopVectorize(self.__pipeline_options__)
+        return ffi.lib.LLVMPY_PassManagerBuilderGetLoopVectorize(
+            self.__pipeline_options__
+        )
 
     @loop_vectorize.setter
     def loop_vectorize(self, enable=True):
-        return ffi.lib.LLVMPY_PassManagerBuilderSetLoopVectorize(self.__pipeline_options__, enable)
+        return ffi.lib.LLVMPY_PassManagerBuilderSetLoopVectorize(
+            self.__pipeline_options__, enable
+        )
 
     @property
     def slp_vectorize(self):
@@ -97,20 +110,56 @@ class PassManagerBuilder(ffi.ObjectRef):
         If true, enable the "SLP vectorizer", which uses a different algorithm
         from the loop vectorizer.  Both may be enabled at the same time.
         """
-        return ffi.lib.LLVMPY_PassManagerBuilderGetSLPVectorize(self.__pipeline_options__)
+        return ffi.lib.LLVMPY_PassManagerBuilderGetSLPVectorize(
+            self.__pipeline_options__
+        )
 
     @slp_vectorize.setter
     def slp_vectorize(self, enable=True):
-        return ffi.lib.LLVMPY_PassManagerBuilderSetSLPVectorize(self.__pipeline_options__, enable)
+        return ffi.lib.LLVMPY_PassManagerBuilderSetSLPVectorize(
+            self.__pipeline_options__, enable
+        )
 
     def _populate_module_pm(self, pm):
-        opt_level = OptimizationLevel(ffi.lib.LLVMPY_PassManagerCreateOptimizationLevel(c_uint(self.__opt_level__), c_uint(self.__size_level__)))
-        pm.update(ffi.lib.LLVMPY_PassManagerBuilderPopulateModulePassManager(self, self.__pipeline_options__, opt_level, pm, pm.__MAM__, self.__LAM__, self.__FAM__, self.__CGAM__, self.__PIC__))
+        opt_level = OptimizationLevel(
+            ffi.lib.LLVMPY_PassManagerCreateOptimizationLevel(
+                c_uint(self.__opt_level__), c_uint(self.__size_level__)
+            )
+        )
+        pm.update(
+            ffi.lib.LLVMPY_PassManagerBuilderPopulateModulePassManager(
+                self,
+                self.__pipeline_options__,
+                opt_level,
+                pm,
+                pm.__MAM__,
+                self.__LAM__,
+                self.__FAM__,
+                self.__CGAM__,
+                self.__PIC__,
+            )
+        )
         pm.__PIC__ = self.__PIC__
 
     def _populate_function_pm(self, pm):
-        opt_level = OptimizationLevel(ffi.lib.LLVMPY_PassManagerCreateOptimizationLevel(c_uint(self.__opt_level__), c_uint(self.__size_level__)))
-        pm.update(ffi.lib.LLVMPY_PassManagerBuilderPopulateFunctionPassManager(self, self.__pipeline_options__, opt_level, pm, self.__MAM__, self.__LAM__, pm.__FAM__, self.__CGAM__, self.__PIC__))
+        opt_level = OptimizationLevel(
+            ffi.lib.LLVMPY_PassManagerCreateOptimizationLevel(
+                c_uint(self.__opt_level__), c_uint(self.__size_level__)
+            )
+        )
+        pm.update(
+            ffi.lib.LLVMPY_PassManagerBuilderPopulateFunctionPassManager(
+                self,
+                self.__pipeline_options__,
+                opt_level,
+                pm,
+                self.__MAM__,
+                self.__LAM__,
+                pm.__FAM__,
+                self.__CGAM__,
+                self.__PIC__,
+            )
+        )
         pm.__PIC__ = self.__PIC__
 
     def populate(self, pm):
@@ -122,7 +171,9 @@ class PassManagerBuilder(ffi.ObjectRef):
             raise TypeError(pm)
 
     def _dispose(self):
-        self._capi.LLVMPY_PassManagerBuilderDispose(self, self.__pipeline_options__)
+        self._capi.LLVMPY_PassManagerBuilderDispose(
+            self, self.__pipeline_options__
+        )
 
 
 # ============================================================================
@@ -130,14 +181,26 @@ class PassManagerBuilder(ffi.ObjectRef):
 
 ffi.lib.LLVMPY_PassManagerBuilderCreate.restype = ffi.LLVMPassBuilder
 
-ffi.lib.LLVMPY_LLVMModuleAnalysisManagerCreate.restype = ffi.LLVMModuleAnalysisManager
-ffi.lib.LLVMPY_LLVMLoopAnalysisManagerCreate.restype = ffi.LLVMLoopAnalysisManager
-ffi.lib.LLVMPY_LLVMFunctionAnalysisManagerCreate.restype = ffi.LLVMFunctionAnalysisManager
-ffi.lib.LLVMPY_LLVMCGSCCAnalysisManagerCreate.restype = ffi.LLVMCGSCCAnalysisManager
-ffi.lib.LLVMPY_LLVMPassInstrumentationCallbacksCreate.restype = ffi.LLVMPassInstrumentationCallbacks
+ffi.lib.LLVMPY_LLVMModuleAnalysisManagerCreate.restype = (
+    ffi.LLVMModuleAnalysisManager
+)
+ffi.lib.LLVMPY_LLVMLoopAnalysisManagerCreate.restype = (
+    ffi.LLVMLoopAnalysisManager
+)
+ffi.lib.LLVMPY_LLVMFunctionAnalysisManagerCreate.restype = (
+    ffi.LLVMFunctionAnalysisManager
+)
+ffi.lib.LLVMPY_LLVMCGSCCAnalysisManagerCreate.restype = (
+    ffi.LLVMCGSCCAnalysisManager
+)
+ffi.lib.LLVMPY_LLVMPassInstrumentationCallbacksCreate.restype = (
+    ffi.LLVMPassInstrumentationCallbacks
+)
 
 
-ffi.lib.LLVMPY_PassManagerBuilderOptionsCreate.restype = ffi.LLVMPassBuilderOptionsRef
+ffi.lib.LLVMPY_PassManagerBuilderOptionsCreate.restype = (
+    ffi.LLVMPassBuilderOptionsRef
+)
 
 ffi.lib.LLVMPY_PassManagerBuilderDispose.argtypes = [
     ffi.LLVMPassBuilder,
@@ -156,7 +219,9 @@ ffi.lib.LLVMPY_PassManagerBuilderPopulateModulePassManager.argtypes = [
     ffi.LLVMPassInstrumentationCallbacks,
 ]
 
-ffi.lib.LLVMPY_PassManagerBuilderPopulateModulePassManager.restype = ffi.LLVMModulePassManager
+ffi.lib.LLVMPY_PassManagerBuilderPopulateModulePassManager.restype = (
+    ffi.LLVMModulePassManager
+)
 
 ffi.lib.LLVMPY_PassManagerBuilderPopulateFunctionPassManager.argtypes = [
     ffi.LLVMPassBuilder,
@@ -170,35 +235,41 @@ ffi.lib.LLVMPY_PassManagerBuilderPopulateFunctionPassManager.argtypes = [
     ffi.LLVMPassInstrumentationCallbacks,
 ]
 
-ffi.lib.LLVMPY_PassManagerBuilderPopulateFunctionPassManager.restype = ffi.LLVMFunctionPassManager
+ffi.lib.LLVMPY_PassManagerBuilderPopulateFunctionPassManager.restype = (
+    ffi.LLVMFunctionPassManager
+)
 
-ffi.lib.LLVMPY_PassManagerCreateOptimizationLevel.restype = ffi.LLVMOptimizationLevel
+ffi.lib.LLVMPY_PassManagerCreateOptimizationLevel.restype = (
+    ffi.LLVMOptimizationLevel
+)
 ffi.lib.LLVMPY_PassManagerCreateOptimizationLevel.argtypes = [c_uint, c_uint]
 
 # Unsigned int PassManagerBuilder properties
 
-for _func in (ffi.lib.LLVMPY_PassManagerBuilderUseInlinerWithThreshold,
-              ):
+for _func in (ffi.lib.LLVMPY_PassManagerBuilderUseInlinerWithThreshold,):
     _func.argtypes = [ffi.LLVMPassBuilderOptionsRef, c_uint]
-    
 
-for _func in (ffi.lib.LLVMPY_PassManagerBuilderGetOptLevel,
-              ffi.lib.LLVMPY_PassManagerBuilderGetSizeLevel,
-              ):
+
+for _func in (
+    ffi.lib.LLVMPY_PassManagerBuilderGetOptLevel,
+    ffi.lib.LLVMPY_PassManagerBuilderGetSizeLevel,
+):
     _func.argtypes = [ffi.LLVMOptimizationLevel]
     _func.restype = c_uint
 
 # Boolean PassManagerBuilder properties
 
-for _func in (ffi.lib.LLVMPY_PassManagerBuilderSetDisableUnrollLoops,
-              ffi.lib.LLVMPY_PassManagerBuilderSetLoopVectorize,
-              ffi.lib.LLVMPY_PassManagerBuilderSetSLPVectorize,
-              ):
+for _func in (
+    ffi.lib.LLVMPY_PassManagerBuilderSetDisableUnrollLoops,
+    ffi.lib.LLVMPY_PassManagerBuilderSetLoopVectorize,
+    ffi.lib.LLVMPY_PassManagerBuilderSetSLPVectorize,
+):
     _func.argtypes = [ffi.LLVMPassBuilderOptionsRef, c_bool]
 
-for _func in (ffi.lib.LLVMPY_PassManagerBuilderGetDisableUnrollLoops,
-              ffi.lib.LLVMPY_PassManagerBuilderGetLoopVectorize,
-              ffi.lib.LLVMPY_PassManagerBuilderGetSLPVectorize,
-              ):
+for _func in (
+    ffi.lib.LLVMPY_PassManagerBuilderGetDisableUnrollLoops,
+    ffi.lib.LLVMPY_PassManagerBuilderGetLoopVectorize,
+    ffi.lib.LLVMPY_PassManagerBuilderGetSLPVectorize,
+):
     _func.argtypes = [ffi.LLVMPassBuilderOptionsRef]
     _func.restype = c_bool

--- a/llvmlite/binding/typeref.py
+++ b/llvmlite/binding/typeref.py
@@ -68,16 +68,6 @@ class TypeRef(ffi.ObjectRef):
         return ffi.lib.LLVMPY_TypeIsVector(self)
 
     @property
-    def is_function_vararg(self):
-        """
-        Returns true if a function type accepts a variable number of arguments.
-        When the type is not a function, raises exception.
-        """
-        if self.type_kind != TypeKind.function:
-            raise ValueError("Type {} is not a function".format(self))
-        return ffi.lib.LLVMPY_IsFunctionVararg(self)
-
-    @property
     def elements(self):
         """
         Returns iterator over enclosing types
@@ -92,7 +82,7 @@ class TypeRef(ffi.ObjectRef):
         """
         if not self.is_pointer:
             raise ValueError("Type {} is not a pointer".format(self))
-        return TypeRef(ffi.lib.LLVMPY_GetElementType(self))
+        raise ValueError("LLVM uses opaque pointers, so this operation is no longer supported")
 
     @property
     def element_count(self):
@@ -176,9 +166,6 @@ ffi.lib.LLVMPY_TypeIsVector.restype = c_bool
 
 ffi.lib.LLVMPY_TypeIsStruct.argtypes = [ffi.LLVMTypeRef]
 ffi.lib.LLVMPY_TypeIsStruct.restype = c_bool
-
-ffi.lib.LLVMPY_IsFunctionVararg.argtypes = [ffi.LLVMTypeRef]
-ffi.lib.LLVMPY_IsFunctionVararg.restype = c_bool
 
 ffi.lib.LLVMPY_GetTypeKind.argtypes = [ffi.LLVMTypeRef]
 ffi.lib.LLVMPY_GetTypeKind.restype = c_int

--- a/llvmlite/binding/typeref.py
+++ b/llvmlite/binding/typeref.py
@@ -82,7 +82,8 @@ class TypeRef(ffi.ObjectRef):
         """
         if not self.is_pointer:
             raise ValueError("Type {} is not a pointer".format(self))
-        raise ValueError("LLVM uses opaque pointers, so this operation is no longer supported")
+        raise ValueError("LLVM uses opaque pointers, "
+                         "so this operation is no longer supported")
 
     @property
     def element_count(self):

--- a/llvmlite/binding/value.py
+++ b/llvmlite/binding/value.py
@@ -218,6 +218,14 @@ class ValueRef(ffi.ObjectRef):
         return TypeRef(ffi.lib.LLVMPY_TypeOf(self))
 
     @property
+    def global_value_type(self):
+        """
+        This value's LLVM type.
+        """
+        # XXX what does this return?
+        return TypeRef(ffi.lib.LLVMPY_GlobalGetValueType(self))
+
+    @property
     def is_declaration(self):
         """
         Whether this value (presumably global) is defined in the current
@@ -312,6 +320,17 @@ class ValueRef(ffi.ObjectRef):
             raise ValueError('expected instruction value, got %s'
                              % (self._kind,))
         return ffi.ret_string(ffi.lib.LLVMPY_GetOpcodeName(self))
+
+    @property
+    def is_function_vararg(self):
+        """
+        Returns true if a function type accepts a variable number of arguments.
+        When the type is not a function, raises exception.
+        """
+        if not self.is_function:
+            raise ValueError('expected function value, got %s'
+                             % (self._kind,))
+        return ffi.lib.LLVMPY_IsFunctionVararg(self)
 
     @property
     def incoming_blocks(self):
@@ -505,6 +524,9 @@ ffi.lib.LLVMPY_SetValueName.argtypes = [ffi.LLVMValueRef, c_char_p]
 ffi.lib.LLVMPY_TypeOf.argtypes = [ffi.LLVMValueRef]
 ffi.lib.LLVMPY_TypeOf.restype = ffi.LLVMTypeRef
 
+ffi.lib.LLVMPY_GlobalGetValueType.argtypes = [ffi.LLVMValueRef]
+ffi.lib.LLVMPY_GlobalGetValueType.restype = ffi.LLVMTypeRef
+
 ffi.lib.LLVMPY_GetTypeName.argtypes = [ffi.LLVMTypeRef]
 ffi.lib.LLVMPY_GetTypeName.restype = c_void_p
 
@@ -616,3 +638,6 @@ ffi.lib.LLVMPY_GetConstantIntNumWords.restype = c_uint
 ffi.lib.LLVMPY_GetConstantFPValue.argtypes = [ffi.LLVMValueRef,
                                               POINTER(c_bool)]
 ffi.lib.LLVMPY_GetConstantFPValue.restype = c_double
+
+ffi.lib.LLVMPY_IsFunctionVararg.argtypes = [ffi.LLVMValueRef]
+ffi.lib.LLVMPY_IsFunctionVararg.restype = c_bool

--- a/llvmlite/ir/types.py
+++ b/llvmlite/ir/types.py
@@ -43,14 +43,14 @@ class Type(_StrCaching):
             m = Module(context=context)
         foo = GlobalVariable(m, self, name="foo")
         with parse_assembly(str(m)) as llmod:
-            return llmod.get_global_variable(foo.name).type
+            return llmod.get_global_variable(foo.name).global_value_type
 
     def get_abi_size(self, target_data, context=None):
         """
         Get the ABI size of this type according to data layout *target_data*.
         """
         llty = self._get_ll_pointer_type(target_data, context)
-        return target_data.get_pointee_abi_size(llty)
+        return target_data.get_abi_size(llty)
 
     def get_abi_alignment(self, target_data, context=None):
         """
@@ -58,7 +58,7 @@ class Type(_StrCaching):
         *target_data*.
         """
         llty = self._get_ll_pointer_type(target_data, context)
-        return target_data.get_pointee_abi_alignment(llty)
+        return target_data.get_abi_alignment(llty)
 
     def format_constant(self, value):
         """

--- a/llvmlite/tests/test_binding.py
+++ b/llvmlite/tests/test_binding.py
@@ -600,6 +600,7 @@ class TestDependencies(BaseTest):
             if not dep.startswith('ld-linux-') and dep not in allowed:
                 self.fail("unexpected dependency %r in %r" % (dep, deps))
 
+
 class TestRISCVABI(BaseTest):
     """
     Test calling convention of floating point arguments of RISC-V
@@ -671,6 +672,7 @@ class TestRISCVABI(BaseTest):
         target = self.riscv_target_machine(features="+f,+d", abiname="ilp32d")
         self.assertEqual(self.break_up_asm(target.emit_assembly(llmod)),
                          riscv_asm_ilp32d)
+
 
 class TestMisc(BaseTest):
     """
@@ -810,6 +812,7 @@ class TestMisc(BaseTest):
         flags = "-Werror"
         cmdargs = [sys.executable, flags, "-c", code]
         subprocess.check_call(cmdargs)
+
 
 class TestModuleRef(BaseTest):
 
@@ -1008,6 +1011,7 @@ class TestModuleRef(BaseTest):
         cloned = m.clone()
         self.assertIsNot(cloned, m)
         self.assertEqual(cloned.as_bitcode(), m.as_bitcode())
+
 
 class JITTestMixin(object):
     """
@@ -2225,7 +2229,8 @@ class TestPasses(BaseTest, PassManagerTestMixin):
         """Test a specific situation that demonstrate TLI is affecting
         optimization. See https://github.com/numba/numba/issues/8898.
         """
-        # TLI now correctly enabled without requiring any additional LLVM API calls
+        # TLI now correctly enabled without
+        # requiring any additional LLVM API calls
         def run(use_tli):
             mod = llvm.parse_assembly(asm_tli_exp2)
             pm = llvm.ModulePassManager()
@@ -2576,6 +2581,7 @@ class TestLLVMLockCallbacks(BaseTest):
         # Check: removing non-existent callbacks will trigger a ValueError
         with self.assertRaises(ValueError):
             llvm.ffi.unregister_lock_callback(acq, rel)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/llvmlite/tests/test_binding.py
+++ b/llvmlite/tests/test_binding.py
@@ -405,11 +405,11 @@ riscv_asm_ilp32 = [
     'addi\tsp, sp, -16',
     'sw\ta1, 8(sp)',
     'sw\ta2, 12(sp)',
-    'fld\tft0, 8(sp)',
-    'fmv.w.x\tft1, a0',
-    'fcvt.d.s\tft1, ft1',
-    'fadd.d\tft0, ft1, ft0',
-    'fsd\tft0, 8(sp)',
+    'fld\tfa5, 8(sp)',
+    'fmv.w.x\tfa4, a0',
+    'fcvt.d.s\tfa4, fa4',
+    'fadd.d\tfa5, fa4, fa5',
+    'fsd\tfa5, 8(sp)',
     'lw\ta0, 8(sp)',
     'lw\ta1, 12(sp)',
     'addi\tsp, sp, 16',
@@ -421,10 +421,10 @@ riscv_asm_ilp32f = [
     'addi\tsp, sp, -16',
     'sw\ta0, 8(sp)',
     'sw\ta1, 12(sp)',
-    'fld\tft0, 8(sp)',
-    'fcvt.d.s\tft1, fa0',
-    'fadd.d\tft0, ft1, ft0',
-    'fsd\tft0, 8(sp)',
+    'fld\tfa5, 8(sp)',
+    'fcvt.d.s\tfa4, fa0',
+    'fadd.d\tfa5, fa4, fa5',
+    'fsd\tfa5, 8(sp)',
     'lw\ta0, 8(sp)',
     'lw\ta1, 12(sp)',
     'addi\tsp, sp, 16',
@@ -433,8 +433,8 @@ riscv_asm_ilp32f = [
 
 
 riscv_asm_ilp32d = [
-    'fcvt.d.s\tft0, fa0',
-    'fadd.d\tfa0, ft0, fa1',
+    'fcvt.d.s\tfa5, fa0',
+    'fadd.d\tfa0, fa5, fa1',
     'ret'
 ]
 

--- a/llvmlite/tests/test_binding.py
+++ b/llvmlite/tests/test_binding.py
@@ -654,7 +654,7 @@ class TestRISCVABI(BaseTest):
     def test_rv32d_ilp32(self):
         self.check_riscv_target()
         llmod = self.fpadd_ll_module()
-        target = self.riscv_target_machine(features="+f,+d")
+        target = self.riscv_target_machine(features="+f,+d", abiname="ilp32")
         self.assertEqual(self.break_up_asm(target.emit_assembly(llmod)),
                          riscv_asm_ilp32)
 
@@ -2517,6 +2517,8 @@ class TestObjectFile(BaseTest):
 
 
 class TestTimePasses(BaseTest):
+    # Existing bug with LLVM where running the same pass manager multiple times
+    # leads to a crash
     @unittest.skip("https://github.com/llvm/llvm-project/issues/58939")
     def test_reporting(self):
         mp = llvm.create_module_pass_manager()

--- a/llvmlite/tests/test_binding.py
+++ b/llvmlite/tests/test_binding.py
@@ -1364,13 +1364,12 @@ class TestOrcLLJIT(BaseTest):
         del rt
         self.assertNotEqual(shared_value.value, 20)
 
+    # LLVM-17 orcjit now loads process by default
     def test_lookup_current_process_symbol_fails(self):
         # An attempt to lookup a symbol in the current process (Py_GetVersion,
         # in this case) should fail with an appropriate error if we have not
         # enabled searching the current process for symbols.
-        msg = 'Failed to materialize symbols:.*getversion'
-        with self.assertRaisesRegex(RuntimeError, msg):
-            self.jit(asm_getversion, "getversion", suppress_errors=True)
+        self.jit(asm_getversion, "getversion", suppress_errors=True)
 
     def test_lookup_current_process_symbol(self):
         self.jit(asm_getversion, "getversion", None, True)

--- a/llvmlite/tests/test_refprune.py
+++ b/llvmlite/tests/test_refprune.py
@@ -557,6 +557,5 @@ bb_F:
         self.assertEqual(stats.fanout_raise, 7)
 
 
-
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
```
~/llvm-project# git log
commit 6009708b4367171ccdbf4b5905cb6a803753fe18 (HEAD -> release/17.x, tag: llvmorg-17.0.6, upstream/release/17.x)
~/llvm-project/build-rel-static# cmake \
   -G Ninja \
   -DCMAKE_CXX_COMPILER=clang++ \
   -DCMAKE_C_COMPILER=clang \
   -DCMAKE_ASM_COMPILER=clang \
   -DCMAKE_ASM_COMPILER_ID=Clang \
   -DLLVM_TARGETS_TO_BUILD="X86" \
   -DLLVM_ENABLE_LLD=ON\
   -DLLVM_ENABLE_PROJECTS="clang;lld" \
   -DCMAKE_BUILD_TYPE=RelWithDebInfo \
   -DCMAKE_EXPORT_COMPILE_COMMANDS=1 \
   -DCMAKE_INSTALL_PREFIX=$1 \
   -DBUILD_SHARED_LIBS=false \
   -DLLVM_ENABLE_ASSERTIONS=ON \
   -DLLVM_OPTIMIZED_TABLEGEN=true \
    ../llvm
~/llvm-project/build-rel-static# ninja
...
~/migration/llvmlite# git log
commit 4907a4eee128ae5d95eddbd0ce4aeaa83bab4787 (HEAD -> modiking/llvm17, origin/modiking/llvm17)
~/migration/llvmlite# LLVM_CONFIG=/home/modimo/llvm-project/build-rel-static/bin/llvm-config python3.9 setup.py build
~/migration/llvmlite# LD_LIBRARY_PATH=/home/modimo/llvm-project/build-rel-static/lib python3.9 runtests.py 
..s................................................................s.............................................................x.sss...........s.....................................................................................................................................................................................................................................
----------------------------------------------------------------------
Ran 375 tests in 9.153s

OK (skipped=6, expected failures=1)
```

TODO:
1. I haven't hooked up all the boilerplate for every pass. With New Pass Manager (NPM) certain passes become specific to Module/Function/Loop and need adaptors to pass to the FunctionPassManager/ModulePassManager. We can do this with Macros in the code or I can generate separate methods for FPM/MPM. Alternatively, MPM is a superset of FPM so if there's interest we can consolidate everything into just MPM for simplicity.
2. I haven't tested with SVML patches in LLVM nor with SVML in general. I don't expect too much work beyond rebasing the LLVM patch however. Would appreciate any guidance on how to do this
3. Currently I don't have a conda package for LLVM. Would appreciate any help on getting that set up

High-level details:
1. The llvm-c APIs have not been updated from NPM. AFAICT the "c" APIs are ad-hoc maintained by whoever uses them. We can definitely bring up that boilerplate but currently the setup is using the C++ APIs
2. NPM has additional state for analysis managers it needs to carry. It also **must** be initialized by the pass builder before using. I've kept the high level python APIs as close as before but we can certainly re-evaluate how we want to expose these to keep things simpler
3. Opaque pointers means types can no longer be queried on pointers. Instead I've updated the general type query to use `global_value_type` which looks at the value rather than the pointer