### PR TITLE
remove all refops if a basic block is a raising block

### DIFF
--- a/ffi/custom_passes.cpp
+++ b/ffi/custom_passes.cpp
@@ -610,6 +610,7 @@ struct RefPrunePass : public FunctionPass {
 
     bool runRefInRaise(Function &F) {
         bool mutated = false;
+        SmallVector<CallInst *, 10> ref_list;
 
         // walk the basic blocks in Function F.
         for (BasicBlock &bb : F) {
@@ -621,12 +622,17 @@ struct RefPrunePass : public FunctionPass {
                 CallInst *ci;
                 if ((ci = GetRefOpCall(&ii))) {
                     if (IsIncRef(ci) || IsDecRef(ci)) {
-                        ci->eraseFromParent();
-                        mutated = true;
+                        ref_list.push_back(ci);
                     }
                 }
             }
         }
+
+        for (CallInst *ci : ref_list) {
+            ci->eraseFromParent();
+            mutated = true;
+        }
+
         return mutated;
     }
 

--- a/ffi/custom_passes.cpp
+++ b/ffi/custom_passes.cpp
@@ -818,16 +818,6 @@ struct RefPrunePass : public FunctionPass {
             return true;
         }
 
-        // If raising_blocks is non-NULL, see if the current node is a block
-        // which raises, if so add to the raising_blocks list, this path is now
-        // finished.
-        // It has to check isRaising first before checking hasDecref,
-        // since we allow raise basic block leak memory.
-        if (raising_blocks && isRaising(cur_node)) {
-            raising_blocks->insert(cur_node);
-            return true; // done for this path
-        }
-
         // Does the current block have a related decref?
         if (hasDecrefInNode(incref, cur_node)) {
             // Add to the list of decref_blocks
@@ -842,6 +832,14 @@ struct RefPrunePass : public FunctionPass {
             // mark head-node as always fail.
             bad_blocks.insert(incref->getParent());
             return false;
+        }
+
+        // If raising_blocks is non-NULL, see if the current node is a block
+        // which raises, if so add to the raising_blocks list, this path is now
+        // finished.
+        if (raising_blocks && isRaising(cur_node)) {
+            raising_blocks->insert(cur_node);
+            return true; // done for this path
         }
 
         // Continue searching by recursing into successors of the current

--- a/ffi/custom_passes.cpp
+++ b/ffi/custom_passes.cpp
@@ -273,7 +273,21 @@ struct RefPrunePass : public FunctionPass {
                 }
             }
 
-            // First: Remove refops on NULL
+            // 1st: Remove all refops if this is a raising block
+            if (isRaising(&bb)) {
+                for (CallInst *ci : incref_list) {
+                    ci->eraseFromParent();
+                    mutated = true;
+                }
+                for (CallInst *ci : decref_list) {
+                    ci->eraseFromParent();
+                    mutated = true;
+                }
+                incref_list.clear();
+                decref_list.clear();
+            }
+
+            // 2nd: Remove refops on NULL
             for (CallInst *ci : null_list) {
                 ci->eraseFromParent();
                 mutated = true;
@@ -283,7 +297,7 @@ struct RefPrunePass : public FunctionPass {
                 stats_per_bb += 1;
             }
 
-            // Second: Find matching pairs of incref decref
+            // 3rd: Find matching pairs of incref decref
             while (incref_list.size() > 0) {
                 // get an incref
                 CallInst *incref = incref_list.pop_back_val();

--- a/ffi/custom_passes.cpp
+++ b/ffi/custom_passes.cpp
@@ -804,6 +804,16 @@ struct RefPrunePass : public FunctionPass {
             return true;
         }
 
+        // If raising_blocks is non-NULL, see if the current node is a block
+        // which raises, if so add to the raising_blocks list, this path is now
+        // finished.
+        // It has to check isRaising first before checking hasDecref,
+        // since we allow raise basic block leak memory.
+        if (raising_blocks && isRaising(cur_node)) {
+            raising_blocks->insert(cur_node);
+            return true; // done for this path
+        }
+
         // Does the current block have a related decref?
         if (hasDecrefInNode(incref, cur_node)) {
             // Add to the list of decref_blocks
@@ -818,14 +828,6 @@ struct RefPrunePass : public FunctionPass {
             // mark head-node as always fail.
             bad_blocks.insert(incref->getParent());
             return false;
-        }
-
-        // If raising_blocks is non-NULL, see if the current node is a block
-        // which raises, if so add to the raising_blocks list, this path is now
-        // finished.
-        if (raising_blocks && isRaising(cur_node)) {
-            raising_blocks->insert(cur_node);
-            return true; // done for this path
         }
 
         // Continue searching by recursing into successors of the current

--- a/llvmlite/binding/passmanagers.py
+++ b/llvmlite/binding/passmanagers.py
@@ -9,7 +9,7 @@ from tempfile import mkstemp
 from llvmlite.binding.common import _encode_string
 
 _prunestats = namedtuple('PruneStats',
-                         ('basicblock diamond fanout fanout_raise ref_inraise'))
+                         ('basicblock diamond fanout fanout_raise'))
 
 llvm_version_major = llvm_version_info[0]
 
@@ -25,8 +25,7 @@ class PruneStats(_prunestats):
         return PruneStats(self.basicblock + other.basicblock,
                           self.diamond + other.diamond,
                           self.fanout + other.fanout,
-                          self.fanout_raise + other.fanout_raise,
-                          self.ref_inraise + other.ref_inraise)
+                          self.fanout_raise + other.fanout_raise)
 
     def __sub__(self, other):
         if not isinstance(other, PruneStats):
@@ -36,8 +35,7 @@ class PruneStats(_prunestats):
         return PruneStats(self.basicblock - other.basicblock,
                           self.diamond - other.diamond,
                           self.fanout - other.fanout,
-                          self.fanout_raise - other.fanout_raise,
-                          self.ref_inraise - other.ref_inraise)
+                          self.fanout_raise - other.fanout_raise)
 
 
 class _c_PruneStats(Structure):
@@ -45,8 +43,7 @@ class _c_PruneStats(Structure):
         ('basicblock', c_size_t),
         ('diamond', c_size_t),
         ('fanout', c_size_t),
-        ('fanout_raise', c_size_t),
-        ('ref_inraise', c_size_t)]
+        ('fanout_raise', c_size_t)]
 
 
 def dump_refprune_stats(printout=False):
@@ -60,7 +57,7 @@ def dump_refprune_stats(printout=False):
 
     ffi.lib.LLVMPY_DumpRefPruneStats(byref(stats), do_print)
     return PruneStats(stats.basicblock, stats.diamond, stats.fanout,
-                      stats.fanout_raise, stats.ref_inraise)
+                      stats.fanout_raise)
 
 
 def set_time_passes(enable):
@@ -104,8 +101,7 @@ class RefPruneSubpasses(IntFlag):
     DIAMOND      = 0b0010    # noqa: E221
     FANOUT       = 0b0100    # noqa: E221
     FANOUT_RAISE = 0b1000
-    REF_INRAISE  = 0b10000   # noqa: E221
-    ALL = PER_BB | DIAMOND | FANOUT | FANOUT_RAISE | REF_INRAISE
+    ALL = PER_BB | DIAMOND | FANOUT | FANOUT_RAISE
 
 
 class PassManager(ffi.ObjectRef):

--- a/llvmlite/binding/passmanagers.py
+++ b/llvmlite/binding/passmanagers.py
@@ -104,7 +104,7 @@ class RefPruneSubpasses(IntFlag):
     DIAMOND      = 0b0010    # noqa: E221
     FANOUT       = 0b0100    # noqa: E221
     FANOUT_RAISE = 0b1000
-    REF_INRAISE  = 0b10000
+    REF_INRAISE  = 0b10000   # noqa: E221
     ALL = PER_BB | DIAMOND | FANOUT | FANOUT_RAISE | REF_INRAISE
 
 

--- a/llvmlite/binding/passmanagers.py
+++ b/llvmlite/binding/passmanagers.py
@@ -9,7 +9,7 @@ from tempfile import mkstemp
 from llvmlite.binding.common import _encode_string
 
 _prunestats = namedtuple('PruneStats',
-                         ('basicblock diamond fanout fanout_raise'))
+                         ('basicblock diamond fanout fanout_raise ref_inraise'))
 
 llvm_version_major = llvm_version_info[0]
 
@@ -25,7 +25,8 @@ class PruneStats(_prunestats):
         return PruneStats(self.basicblock + other.basicblock,
                           self.diamond + other.diamond,
                           self.fanout + other.fanout,
-                          self.fanout_raise + other.fanout_raise)
+                          self.fanout_raise + other.fanout_raise,
+                          self.ref_inraise + other.ref_inraise)
 
     def __sub__(self, other):
         if not isinstance(other, PruneStats):
@@ -35,7 +36,8 @@ class PruneStats(_prunestats):
         return PruneStats(self.basicblock - other.basicblock,
                           self.diamond - other.diamond,
                           self.fanout - other.fanout,
-                          self.fanout_raise - other.fanout_raise)
+                          self.fanout_raise - other.fanout_raise,
+                          self.ref_inraise - other.ref_inraise)
 
 
 class _c_PruneStats(Structure):
@@ -43,7 +45,8 @@ class _c_PruneStats(Structure):
         ('basicblock', c_size_t),
         ('diamond', c_size_t),
         ('fanout', c_size_t),
-        ('fanout_raise', c_size_t)]
+        ('fanout_raise', c_size_t),
+        ('ref_inraise', c_size_t)]
 
 
 def dump_refprune_stats(printout=False):
@@ -57,7 +60,7 @@ def dump_refprune_stats(printout=False):
 
     ffi.lib.LLVMPY_DumpRefPruneStats(byref(stats), do_print)
     return PruneStats(stats.basicblock, stats.diamond, stats.fanout,
-                      stats.fanout_raise)
+                      stats.fanout_raise, stats.ref_inraise)
 
 
 def set_time_passes(enable):
@@ -101,7 +104,8 @@ class RefPruneSubpasses(IntFlag):
     DIAMOND      = 0b0010    # noqa: E221
     FANOUT       = 0b0100    # noqa: E221
     FANOUT_RAISE = 0b1000
-    ALL = PER_BB | DIAMOND | FANOUT | FANOUT_RAISE
+    REF_INRAISE  = 0b10000
+    ALL = PER_BB | DIAMOND | FANOUT | FANOUT_RAISE | REF_INRAISE
 
 
 class PassManager(ffi.ObjectRef):

--- a/llvmlite/tests/test_refprune.py
+++ b/llvmlite/tests/test_refprune.py
@@ -256,7 +256,7 @@ bb_B:
 bb_C:
   %sroa = phi i8* [ %ptr, %bb_A ], [ null, %bb_B ]
   tail call void @NRT_decref(i8* %ptr)
-  tail call void @NRT_decref(i8* %l.sroa.0.0.i)
+  tail call void @NRT_decref(i8* %sroa)
   store i8* null, i8** %excinfo, !numba_exception_output !0
   br label %common.ret
 bb_D:

--- a/llvmlite/tests/test_refprune.py
+++ b/llvmlite/tests/test_refprune.py
@@ -557,14 +557,14 @@ bb_F:
 define i32 @main(i8* %ptr, i1 %cond1, i1 %cond2, i8** %excinfo) {
 bb_A:
   tail call void @NRT_incref(i8* %ptr)
-  tail call void @NRT_incref(i8* %ptr), !noalias !22
+  tail call void @NRT_incref(i8* %ptr)
   br i1 %cond1, label %bb_C, label %bb_B
 bb_B:
-  tail call void @NRT_decref(i8* %ptr), !noalias !22
+  tail call void @NRT_decref(i8* %ptr)
   br i1 %cond2, label %bb_D, label %bb_C
 bb_C:
   %sroa = phi i8* [ %ptr, %bb_A ], [ null, %bb_B ]
-  tail call void @NRT_decref(i8* %sroa), !noalias !22
+  tail call void @NRT_decref(i8* %sroa)
   store i8* null, i8** %excinfo, !numba_exception_output !0
   br label %common.ret
 bb_D:
@@ -573,6 +573,8 @@ bb_D:
 common.ret:
   %common.ret.op = phi i32 [ 0, %bb_D ], [ 1, %bb_C ]
   ret i32 %common.ret.op
+}
+!0 = !{i1 1}
 """
 
     def test_fanout_raise_7(self):

--- a/llvmlite/tests/test_refprune.py
+++ b/llvmlite/tests/test_refprune.py
@@ -579,7 +579,8 @@ common.ret:
 
     def test_fanout_raise_7(self):
         mod, stats = self.check(self.fanout_raise_7)
-        self.assertEqual(stats.fanout_raise, 5)
+        # why 4? Since one removal in bb_C doesn't count into fanout_raise
+        self.assertEqual(stats.fanout_raise, 4)
 
 if __name__ == '__main__':
     unittest.main()

--- a/llvmlite/tests/test_refprune.py
+++ b/llvmlite/tests/test_refprune.py
@@ -255,6 +255,8 @@ bb_B:
   br i1 %cond2, label %bb_D, label %bb_C
 bb_C:
   %sroa = phi i8* [ %ptr, %bb_A ], [ null, %bb_B ]
+  tail call void @NRT_decref(i8* %ptr)
+  tail call void @NRT_decref(i8* %l.sroa.0.0.i)
   store i8* null, i8** %excinfo, !numba_exception_output !0
   br label %common.ret
 bb_D:
@@ -268,7 +270,7 @@ common.ret:
 
     def test_per_bb_5(self):
         mod, stats = self.check(self.per_bb_ir_5)
-        self.assertEqual(stats.basicblock, 1)
+        self.assertEqual(stats.basicblock, 2)
 
 
 class TestDiamond(BaseTestByIR):
@@ -575,34 +577,6 @@ bb_F:
     def test_fanout_raise_6(self):
         mod, stats = self.check(self.fanout_raise_6)
         self.assertEqual(stats.fanout_raise, 7)
-
-    # test case 7 is from https://github.com/numba/llvmlite/issues/1044 [part1]
-    fanout_raise_7 = r"""
-define i32 @main(i8* %ptr, i1 %cond1, i1 %cond2, i8** %excinfo) {
-bb_A:
-  tail call void @NRT_incref(i8* %ptr)
-  tail call void @NRT_incref(i8* %ptr)
-  br i1 %cond1, label %bb_C, label %bb_B
-bb_B:
-  tail call void @NRT_decref(i8* %ptr)
-  br i1 %cond2, label %bb_D, label %bb_C
-bb_C:
-  %sroa = phi i8* [ %ptr, %bb_A ], [ null, %bb_B ]
-  store i8* null, i8** %excinfo, !numba_exception_output !0
-  br label %common.ret
-bb_D:
-  tail call void @NRT_decref(i8* %ptr)
-  br label %common.ret
-common.ret:
-  %common.ret.op = phi i32 [ 0, %bb_D ], [ 1, %bb_C ]
-  ret i32 %common.ret.op
-}
-!0 = !{i1 1}
-"""
-
-    def test_fanout_raise_7(self):
-        mod, stats = self.check(self.fanout_raise_7)
-        self.assertEqual(stats.fanout_raise, 4)
 
 
 if __name__ == '__main__':

--- a/llvmlite/tests/test_refprune.py
+++ b/llvmlite/tests/test_refprune.py
@@ -589,8 +589,11 @@ class TestRefInRaise(BaseTestByIR):
     ref_inraise_1 = r"""
 define i32 @main(i8* %ptr, i1 %cond1, i1 %cond2, i8** %excinfo) {
 bb_A:
+  tail call void @NRT_incref(i8* %ptr)
+  tail call void @NRT_incref(i8* %ptr)
   br i1 %cond1, label %bb_C, label %bb_B
 bb_B:
+  tail call void @NRT_decref(i8* %ptr)
   br i1 %cond2, label %bb_D, label %bb_C
 bb_C:
   %sroa = phi i8* [ %ptr, %bb_A ], [ null, %bb_B ]
@@ -598,6 +601,7 @@ bb_C:
   store i8* null, i8** %excinfo, !numba_exception_output !0
   br label %common.ret
 bb_D:
+  tail call void @NRT_decref(i8* %ptr)
   br label %common.ret
 common.ret:
   %common.ret.op = phi i32 [ 0, %bb_D ], [ 1, %bb_C ]


### PR DESCRIPTION
A possible way to 
fix #1044 

Notes for reviewers:
- remove all refops if a basic block is a raising block, since we allow memory leak in a raising block
- put this pruning operation in the per_bb pattern
- after per_bb pattern removes this case, fanout_raise pattern can do the rest as before