### PR TITLE
Use RTD for all docs CI / testing (was: Try and get CI to use a newer Sphinx)

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -67,11 +67,6 @@ jobs:
         CONDA_ENV: cienv
         WHEEL: 'yes'
 
-      py39_docs:
-        PYTHON: '3.9'
-        CONDA_ENV: cienv
-        BUILD_DOCS: 'yes'
-
       llvm15:
         PYTHON: '3.12'
         CONDA_ENV: cienv

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -67,8 +67,8 @@ jobs:
         CONDA_ENV: cienv
         WHEEL: 'yes'
 
-      py39_docs:
-        PYTHON: '3.9'
+      py311_docs:
+        PYTHON: '3.11'
         CONDA_ENV: cienv
         BUILD_DOCS: 'yes'
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -67,8 +67,8 @@ jobs:
         CONDA_ENV: cienv
         WHEEL: 'yes'
 
-      py311_docs:
-        PYTHON: '3.11'
+      py39_docs:
+        PYTHON: '3.9'
         CONDA_ENV: cienv
         BUILD_DOCS: 'yes'
 

--- a/buildscripts/azure/azure-linux-macos.yml
+++ b/buildscripts/azure/azure-linux-macos.yml
@@ -42,17 +42,6 @@ jobs:
     - script: |
         set -e
         export PATH=$HOME/miniconda3/bin:$PATH
-        conda install -y -c conda-forge sphinx sphinx_rtd_theme pygments
-        echo "Building docs"
-        cd docs
-        make SPHINXOPTS=-Wn clean html
-        cd ..
-      displayName: 'Build Docs'
-      condition: eq(variables['BUILD_DOCS'], 'yes')
-
-    - script: |
-        set -e
-        export PATH=$HOME/miniconda3/bin:$PATH
         buildscripts/incremental/test.sh
       displayName: 'Test'
 # This is last because we need to install a bunch of LLVM stuff that will pollute the build environment

--- a/buildscripts/azure/azure-linux-macos.yml
+++ b/buildscripts/azure/azure-linux-macos.yml
@@ -42,7 +42,7 @@ jobs:
     - script: |
         set -e
         export PATH=$HOME/miniconda3/bin:$PATH
-        conda install -y sphinx sphinx_rtd_theme pygments
+        conda install -y -c conda-forge sphinx sphinx_rtd_theme pygments
         echo "Building docs"
         cd docs
         make SPHINXOPTS=-Wn clean html

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -304,3 +304,5 @@ intersphinx_mapping = {
     'python': ('https://docs.python.org/3', None),
     'llvm': ('http://llvm.org/releases/14.0.0/docs', None),
     }
+
+nitpicky = True

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -88,7 +88,7 @@ the llvmlite API at each release, for the following reasons:
 
    admin-guide/install
    user-guide/index
-   faq
+   faqs
    contributing
    release-notes
    glossary

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -88,7 +88,7 @@ the llvmlite API at each release, for the following reasons:
 
    admin-guide/install
    user-guide/index
-   faqs
+   faq
    contributing
    release-notes
    glossary


### PR DESCRIPTION
~Some PRs (e.g. #1046)  have problems with the docs because of the old Sphinx version CI is using, the latest available in the defaults channel being 5.0.2. This PR switches to using conda-forge to get later versions, so that features such as `:no-index:` can be used.~

~From the CI logs:~

```
    sphinx-7.3.7               |     pyhd8ed1ab_0         1.3 MB  conda-forge
    sphinx_rtd_theme-2.0.0     |     pyha770c72_0         2.5 MB  conda-forge
```

**Update**: The new approach in this PR is to remove the docs testing on Azure and enable nitpicky mode in the Sphinx config. Now:

- The RTD build is checking the same things as the Azure docs build was
- There is no inconsistency between Sphinx versions in docs testing (since RTD is only running one version of Sphinx)

I purposely broke a reference in adf79ff, and then the RTD build failed with nitpicky mode was enabled, demonstrating that this is testing for broken references. I have subsequently reverted / fixed the broken reference in a later commit, and removed the Azure docs testing.