### PR TITLE
Added llvm based process triple partitioning

### DIFF
--- a/ffi/targets.cpp
+++ b/ffi/targets.cpp
@@ -39,14 +39,22 @@ LLVMPY_GetTripleParts(const char *triple_str, const char **arch_out,
                       const char **subarch_out, const char **vendor_out,
                       const char **os_out, const char **environment_out,
                       const char **object_fmt_out) {
-    auto triple = llvm::Triple(triple_str);
-    *arch_out = LLVMPY_CreateString(triple.getArchName().data());
+    // Normalize the triple string
+    auto triple_str_norm = llvm::Triple::normalize(triple_str);
+    auto triple = llvm::Triple(triple_str_norm);
+
+    *arch_out = LLVMPY_CreateString(
+        llvm::Triple::getArchTypeName(triple.getArch()).data());
+
     // TODO: Change this to something that actually gets the subarch
     // Using temporary value to prevent non empty string issues
     *subarch_out = LLVMPY_CreateString(triple.getArchName().data());
-    *vendor_out = LLVMPY_CreateString(triple.getVendorName().data());
-    *os_out = LLVMPY_CreateString(triple.getOSName().data());
-    *environment_out = LLVMPY_CreateString(triple.getEnvironmentName().data());
+    *vendor_out = LLVMPY_CreateString(
+        llvm::Triple::getVendorTypeName(triple.getVendor()).data());
+    *os_out =
+        LLVMPY_CreateString(llvm::Triple::getOSTypeName(triple.getOS()).data());
+    *environment_out = LLVMPY_CreateString(
+        llvm::Triple::getEnvironmentTypeName(triple.getEnvironment()).data());
     // TODO: Change this to something that actually gets the subarch
     // Using temporary value to prevent non empty string issues
     *object_fmt_out = LLVMPY_CreateString(triple.getEnvironmentName().data());

--- a/ffi/targets.cpp
+++ b/ffi/targets.cpp
@@ -34,6 +34,24 @@ LLVMPY_GetProcessTriple(const char **Out) {
     *Out = LLVMPY_CreateString(llvm::sys::getProcessTriple().c_str());
 }
 
+API_EXPORT(void)
+LLVMPY_GetTripleParts(const char *triple_str, const char **arch_out,
+                      const char **subarch_out, const char **vendor_out,
+                      const char **os_out, const char **environment_out,
+                      const char **object_fmt_out) {
+    auto triple = llvm::Triple(triple_str);
+    *arch_out = LLVMPY_CreateString(triple.getArchName().data());
+    // TODO: Change this to something that actually gets the subarch
+    // Using temporary value to prevent non empty string issues
+    *subarch_out = LLVMPY_CreateString(triple.getArchName().data());
+    *vendor_out = LLVMPY_CreateString(triple.getVendorName().data());
+    *os_out = LLVMPY_CreateString(triple.getOSName().data());
+    *environment_out = LLVMPY_CreateString(triple.getEnvironmentName().data());
+    // TODO: Change this to something that actually gets the subarch
+    // Using temporary value to prevent non empty string issues
+    *object_fmt_out = LLVMPY_CreateString(triple.getEnvironmentName().data());
+}
+
 /**
  * Output the feature string to the output argument.
  * Features are prefixed with '+' or '-' for enabled or disabled, respectively.

--- a/ffi/targets.cpp
+++ b/ffi/targets.cpp
@@ -36,28 +36,20 @@ LLVMPY_GetProcessTriple(const char **Out) {
 
 API_EXPORT(void)
 LLVMPY_GetTripleParts(const char *triple_str, const char **arch_out,
-                      const char **subarch_out, const char **vendor_out,
-                      const char **os_out, const char **environment_out,
-                      const char **object_fmt_out) {
+                      const char **vendor_out, const char **os_out,
+                      const char **environment_out) {
     // Normalize the triple string
     auto triple_str_norm = llvm::Triple::normalize(triple_str);
     auto triple = llvm::Triple(triple_str_norm);
 
     *arch_out = LLVMPY_CreateString(
         llvm::Triple::getArchTypeName(triple.getArch()).data());
-
-    // TODO: Change this to something that actually gets the subarch
-    // Using temporary value to prevent non empty string issues
-    *subarch_out = LLVMPY_CreateString(triple.getArchName().data());
     *vendor_out = LLVMPY_CreateString(
         llvm::Triple::getVendorTypeName(triple.getVendor()).data());
     *os_out =
         LLVMPY_CreateString(llvm::Triple::getOSTypeName(triple.getOS()).data());
     *environment_out = LLVMPY_CreateString(
         llvm::Triple::getEnvironmentTypeName(triple.getEnvironment()).data());
-    // TODO: Change this to something that actually gets the subarch
-    // Using temporary value to prevent non empty string issues
-    *object_fmt_out = LLVMPY_CreateString(triple.getEnvironmentName().data());
 }
 
 /**

--- a/llvmlite/binding/targets.py
+++ b/llvmlite/binding/targets.py
@@ -6,10 +6,10 @@ from llvmlite.binding import ffi
 from llvmlite.binding.common import _decode_string, _encode_string
 from collections import namedtuple
 
-from collections import namedtuple
-
 # Define the named tuple 'Point' with fields 'x' and 'y'
-Triple = namedtuple('Triple', ['Arch', 'SubArch', 'Vendor', 'OS', 'Env', 'ObjectFormat'])
+Triple = namedtuple('Triple', ['Arch', 'SubArch', 'Vendor',
+                               'OS', 'Env', 'ObjectFormat'])
+
 
 def get_process_triple():
     """
@@ -21,6 +21,7 @@ def get_process_triple():
     with ffi.OutputString() as out:
         ffi.lib.LLVMPY_GetProcessTriple(out)
         return str(out)
+
 
 def get_triple_parts(triple: str):
     """
@@ -37,7 +38,8 @@ def get_triple_parts(triple: str):
             if _str.startswith(arch):
                 subarch = _str[len(arch):]
                 break
-        return Triple(arch, subarch, str(vendor), str(os), str(env), get_object_format(triple))
+        return Triple(arch, subarch, str(vendor), str(os),
+                      str(env), get_object_format(triple))
 
 
 class FeatureMap(dict):

--- a/llvmlite/binding/targets.py
+++ b/llvmlite/binding/targets.py
@@ -3,6 +3,7 @@ from ctypes import (POINTER, c_char_p, c_longlong, c_int, c_size_t,
                     c_void_p, string_at)
 
 from llvmlite.binding import ffi
+from llvmlite.binding.initfini import llvm_version_info
 from llvmlite.binding.common import _decode_string, _encode_string
 from collections import namedtuple
 
@@ -111,11 +112,32 @@ def get_host_cpu_name():
         return str(out)
 
 
-_object_formats = {
-    1: "COFF",
-    2: "ELF",
-    3: "MachO",
-}
+# Adapted from https://github.com/llvm/llvm-project/blob/release/15.x/llvm/include/llvm/ADT/Triple.h#L269 # noqa
+llvm_version_major = llvm_version_info[0]
+
+
+if llvm_version_major >= 15:
+    _object_formats = {
+        0: "Unknown",
+        1: "COFF",
+        2: "DXContainer",
+        3: "ELF",
+        4: "GOFF",
+        5: "MachO",
+        6: "SPIRV",
+        7: "Wasm",
+        8: "XCOFF",
+    }
+else:
+    _object_formats = {
+        0: "Unknown",
+        1: "COFF",
+        2: "ELF",
+        3: "GOFF",
+        4: "MachO",
+        5: "Wasm",
+        6: "XCOFF",
+    }
 
 
 def get_object_format(triple=None):

--- a/llvmlite/binding/targets.py
+++ b/llvmlite/binding/targets.py
@@ -7,7 +7,6 @@ from llvmlite.binding.initfini import llvm_version_info
 from llvmlite.binding.common import _decode_string, _encode_string
 from collections import namedtuple
 
-# Define the named tuple 'Point' with fields 'x' and 'y'
 Triple = namedtuple('Triple', ['Arch', 'SubArch', 'Vendor',
                                'OS', 'Env', 'ObjectFormat'])
 

--- a/llvmlite/binding/targets.py
+++ b/llvmlite/binding/targets.py
@@ -17,6 +17,18 @@ def get_process_triple():
         ffi.lib.LLVMPY_GetProcessTriple(out)
         return str(out)
 
+def get_triple_parts(triple):
+    """
+    Return a tuple of the parts of the given triple.
+    """
+    with ffi.OutputString() as arch, ffi.OutputString() as subarch, \
+            ffi.OutputString() as vendor, \
+            ffi.OutputString() as os, ffi.OutputString() as env, \
+            ffi.OutputString() as objfmt:
+        ffi.lib.LLVMPY_GetTripleParts(triple.encode('utf8'),
+                                      arch, subarch, vendor, os, env, objfmt)
+        return (str(arch), str(subarch), str(vendor), str(os), str(env), str(objfmt))
+
 
 class FeatureMap(dict):
     """
@@ -340,6 +352,10 @@ def has_svml():
 # FFI
 
 ffi.lib.LLVMPY_GetProcessTriple.argtypes = [POINTER(c_char_p)]
+ffi.lib.LLVMPY_GetTripleParts.argtypes = [c_char_p, POINTER(c_char_p),
+                                          POINTER(c_char_p), POINTER(c_char_p),
+                                          POINTER(c_char_p), POINTER(c_char_p),
+                                          POINTER(c_char_p)]
 
 ffi.lib.LLVMPY_GetHostCPUFeatures.argtypes = [POINTER(c_char_p)]
 ffi.lib.LLVMPY_GetHostCPUFeatures.restype = c_int

--- a/llvmlite/tests/test_binding.py
+++ b/llvmlite/tests/test_binding.py
@@ -2118,6 +2118,37 @@ class TestTarget(BaseTest):
         self.assertIn(target.name, s)
         self.assertIn(target.description, s)
 
+    def test_get_parts_from_triple(self):
+        # Tests adapted from llvm-14::llvm/unittests/ADT/TripleTest.cpp
+        cases = [
+            ("x86_64-scei-ps4",
+             llvm.targets.Triple(Arch="x86_64", SubArch='',
+                                 Vendor="scei", OS="ps4",
+                                 Env="unknown", ObjectFormat="ELF")),
+            ("x86_64-sie-ps4",
+             llvm.targets.Triple(Arch="x86_64", SubArch='',
+                                 Vendor="scei", OS="ps4",
+                                 Env="unknown", ObjectFormat="ELF")),
+            ("powerpc-dunno-notsure",
+             llvm.targets.Triple(Arch="powerpc", SubArch='',
+                                 Vendor="unknown", OS="unknown",
+                                 Env="unknown", ObjectFormat="ELF")),
+            ("powerpcspe-unknown-freebsd",
+             llvm.targets.Triple(Arch="powerpc", SubArch='spe',
+                                 Vendor="unknown", OS="freebsd",
+                                 Env="unknown", ObjectFormat="ELF")),
+            ("armv6hl-none-linux-gnueabi",
+             llvm.targets.Triple(Arch="arm", SubArch='v6hl',
+                                 Vendor="unknown", OS="linux",
+                                 Env="gnueabi", ObjectFormat="ELF"))
+        ]
+
+        for case in cases:
+            triple_str, triple_obj = case
+            res = llvm.get_triple_parts(triple_str)
+
+            self.assertEqual(res, triple_obj)
+
 
 class TestTargetData(BaseTest):
 

--- a/llvmlite/tests/test_binding.py
+++ b/llvmlite/tests/test_binding.py
@@ -2140,7 +2140,27 @@ class TestTarget(BaseTest):
             ("armv6hl-none-linux-gnueabi",
              llvm.targets.Triple(Arch="arm", SubArch='v6hl',
                                  Vendor="unknown", OS="linux",
-                                 Env="gnueabi", ObjectFormat="ELF"))
+                                 Env="gnueabi", ObjectFormat="ELF")),
+            ("i686-unknown-linux-gnu",
+             llvm.targets.Triple(Arch="i386", SubArch='',
+                                 Vendor="unknown", OS="linux",
+                                 Env="gnu", ObjectFormat="ELF")),
+            ("i686-apple-macosx",
+             llvm.targets.Triple(Arch="i386", SubArch='',
+                                 Vendor="apple", OS="macosx",
+                                 Env="unknown", ObjectFormat="MachO")),
+            ("i686-dunno-win32",
+             llvm.targets.Triple(Arch="i386", SubArch='',
+                                 Vendor="unknown", OS="windows",
+                                 Env="msvc", ObjectFormat="COFF")),
+            ("s390x-ibm-zos",
+             llvm.targets.Triple(Arch="s390x", SubArch='',
+                                 Vendor="ibm", OS="zos",
+                                 Env="unknown", ObjectFormat="GOFF")),
+            ("wasm64-wasi",
+             llvm.targets.Triple(Arch="wasm64", SubArch='',
+                                 Vendor="unknown", OS="wasi",
+                                 Env="unknown", ObjectFormat="Wasm")),
         ]
 
         for case in cases:


### PR DESCRIPTION
As titiled,

This PR aims to add a `llvm` based binding that uses the internal `Triple` object to partition the process triple string into it's respective parts.

Example:

```python
from llvmlite import binding

triple_string = binding.get_default_triple()
triple_string = "armv6hl-none-linux-gnueabi"

triple_parts = binding.get_triple_parts(triple_string)

print("Triple String:", triple_string)
print("Triple Parts:", triple_parts)
# Triple String: armv6hl-none-linux-gnueabi
# Triple Parts: ('arm', 'v6hl', 'unknown', 'linux', 'gnueabi', 'ELF')

```