### PR TITLE
Add instrumentation callback hook for new pass managers

### DIFF
--- a/ffi/newpassmanagers.cpp
+++ b/ffi/newpassmanagers.cpp
@@ -80,11 +80,12 @@ LLVMPY_RunNewModulePassManager(LLVMModulePassManagerRef MPMRef,
     StandardInstrumentations SI(DebugLogging, VerifyEach, PrintPassOpts);
     SI.registerCallbacks(PIC, &FAM);
     PassBuilder PB(TM, *PTO, None, &PIC);
-# else
-    StandardInstrumentations SI(M->getContext(), DebugLogging, VerifyEach, PrintPassOpts);
+#else
+    StandardInstrumentations SI(M->getContext(), DebugLogging, VerifyEach,
+                                PrintPassOpts);
     SI.registerCallbacks(PIC, &FAM);
     PassBuilder PB(TM, *PTO, std::nullopt, &PIC);
-# endif
+#endif
 
     PB.registerLoopAnalyses(LAM);
     PB.registerFunctionAnalyses(FAM);
@@ -178,8 +179,9 @@ LLVMPY_RunNewFunctionPassManager(LLVMFunctionPassManagerRef FPMRef,
     StandardInstrumentations SI(DebugLogging, VerifyEach, PrintPassOpts);
     SI.registerCallbacks(PIC, &FAM);
     PassBuilder PB(TM, *PTO, None, &PIC);
-# else
-    StandardInstrumentations SI(F->getContext(), DebugLogging, VerifyEach, PrintPassOpts);
+#else
+    StandardInstrumentations SI(F->getContext(), DebugLogging, VerifyEach,
+                                PrintPassOpts);
     SI.registerCallbacks(PIC, &FAM);
     PassBuilder PB(TM, *PTO, std::nullopt, &PIC);
 #endif

--- a/ffi/newpassmanagers.cpp
+++ b/ffi/newpassmanagers.cpp
@@ -1,7 +1,6 @@
 #include "core.h"
 #include "llvm-c/TargetMachine.h"
 #include "llvm/Analysis/AliasAnalysisEvaluator.h"
-#include "llvm/IR/LLVMContext.h"
 #include "llvm/IR/PassManager.h"
 #include "llvm/IR/Verifier.h"
 #include "llvm/Passes/PassBuilder.h"

--- a/ffi/newpassmanagers.cpp
+++ b/ffi/newpassmanagers.cpp
@@ -59,8 +59,7 @@ LLVMPY_CreateNewModulePassManager() {
 
 API_EXPORT(void)
 LLVMPY_RunNewModulePassManager(LLVMModulePassManagerRef MPMRef,
-                               LLVMModuleRef mod,
-                               LLVMPassBuilderRef PBRef,
+                               LLVMModuleRef mod, LLVMPassBuilderRef PBRef,
                                LLVMPassInstrumentationCallbacksRef PICRef) {
 
     ModulePassManager *MPM = llvm::unwrap(MPMRef);
@@ -150,8 +149,7 @@ LLVMPY_CreateNewFunctionPassManager() {
 
 API_EXPORT(void)
 LLVMPY_RunNewFunctionPassManager(LLVMFunctionPassManagerRef FPMRef,
-                                 LLVMValueRef FRef,
-                                 LLVMPassBuilderRef PBRef,
+                                 LLVMValueRef FRef, LLVMPassBuilderRef PBRef,
                                  LLVMPassInstrumentationCallbacksRef PICRef) {
 
     FunctionPassManager *FPM = llvm::unwrap(FPMRef);
@@ -297,7 +295,8 @@ LLVMPY_CreatePassInstrumentationCallbacks() {
 }
 
 API_EXPORT(void)
-LLVMPY_DisposePassInstrumentationCallbacks(LLVMPassInstrumentationCallbacksRef PIC) {
+LLVMPY_DisposePassInstrumentationCallbacks(
+    LLVMPassInstrumentationCallbacksRef PIC) {
     delete llvm::unwrap(PIC);
 }
 

--- a/llvmlite/binding/ffi.py
+++ b/llvmlite/binding/ffi.py
@@ -42,6 +42,8 @@ LLVMOrcLLJITRef = _make_opaque_ref("LLVMOrcLLJITRef")
 LLVMOrcDylibTrackerRef = _make_opaque_ref("LLVMOrcDylibTrackerRef")
 
 LLVMPipelineTuningOptionsRef = _make_opaque_ref("LLVMPipeLineTuningOptions")
+LLVMPassInstrumentationCallbacksRef = \
+    _make_opaque_ref("LLVMPassInstrumentationCallbacks")
 LLVMModulePassManagerRef = _make_opaque_ref("LLVMModulePassManager")
 LLVMFunctionPassManagerRef = _make_opaque_ref("LLVMFunctionPassManager")
 LLVMPassBuilderRef = _make_opaque_ref("LLVMPassBuilder")

--- a/llvmlite/binding/ffi.py
+++ b/llvmlite/binding/ffi.py
@@ -42,8 +42,6 @@ LLVMOrcLLJITRef = _make_opaque_ref("LLVMOrcLLJITRef")
 LLVMOrcDylibTrackerRef = _make_opaque_ref("LLVMOrcDylibTrackerRef")
 
 LLVMPipelineTuningOptionsRef = _make_opaque_ref("LLVMPipeLineTuningOptions")
-LLVMPassInstrumentationCallbacksRef = \
-    _make_opaque_ref("LLVMPassInstrumentationCallbacks")
 LLVMModulePassManagerRef = _make_opaque_ref("LLVMModulePassManager")
 LLVMFunctionPassManagerRef = _make_opaque_ref("LLVMFunctionPassManager")
 LLVMPassBuilderRef = _make_opaque_ref("LLVMPassBuilder")

--- a/llvmlite/binding/newpassmanagers.py
+++ b/llvmlite/binding/newpassmanagers.py
@@ -26,7 +26,7 @@ class ModulePassManager(ffi.ObjectRef):
         super().__init__(ptr)
 
     def run(self, module, pb):
-        ffi.lib.LLVMPY_RunNewModulePassManager(self, pb, module)
+        ffi.lib.LLVMPY_RunNewModulePassManager(self, module, pb._pto, pb._tm)
 
     def add_verifier(self):
         ffi.lib.LLVMPY_AddVerifierPass(self)
@@ -61,7 +61,7 @@ class FunctionPassManager(ffi.ObjectRef):
         super().__init__(ptr)
 
     def run(self, fun, pb):
-        ffi.lib.LLVMPY_RunNewFunctionPassManager(self, pb, fun)
+        ffi.lib.LLVMPY_RunNewFunctionPassManager(self, fun, pb._pto, pb._tm)
 
     def add_aa_eval_pass(self):
         ffi.lib.LLVMPY_AddAAEvalPass_function(self)
@@ -193,9 +193,9 @@ class PassBuilder(ffi.ObjectRef):
 
 ffi.lib.LLVMPY_CreateNewModulePassManager.restype = ffi.LLVMModulePassManagerRef
 
-ffi.lib.LLVMPY_RunNewModulePassManager.argtypes = [ffi.LLVMModulePassManagerRef,
-                                                   ffi.LLVMPassBuilderRef,
-                                                   ffi.LLVMModuleRef,]
+ffi.lib.LLVMPY_RunNewModulePassManager.argtypes = [
+    ffi.LLVMModulePassManagerRef, ffi.LLVMModuleRef,
+    ffi.LLVMPipelineTuningOptionsRef, ffi.LLVMTargetMachineRef, ]
 
 ffi.lib.LLVMPY_AddVerifierPass.argtypes = [ffi.LLVMModulePassManagerRef,]
 ffi.lib.LLVMPY_AddAAEvalPass_module.argtypes = [ffi.LLVMModulePassManagerRef,]
@@ -223,9 +223,8 @@ ffi.lib.LLVMPY_CreateNewFunctionPassManager.restype = \
     ffi.LLVMFunctionPassManagerRef
 
 ffi.lib.LLVMPY_RunNewFunctionPassManager.argtypes = [
-    ffi.LLVMFunctionPassManagerRef,
-    ffi.LLVMPassBuilderRef,
-    ffi.LLVMValueRef,]
+    ffi.LLVMFunctionPassManagerRef, ffi.LLVMValueRef,
+    ffi.LLVMPipelineTuningOptionsRef, ffi.LLVMTargetMachineRef, ]
 
 ffi.lib.LLVMPY_AddAAEvalPass_function.argtypes = [
     ffi.LLVMFunctionPassManagerRef,]

--- a/llvmlite/binding/newpassmanagers.py
+++ b/llvmlite/binding/newpassmanagers.py
@@ -26,7 +26,7 @@ class ModulePassManager(ffi.ObjectRef):
         super().__init__(ptr)
 
     def run(self, module, pb):
-        ffi.lib.LLVMPY_RunNewModulePassManager(self, module, pb, pb._pic)
+        ffi.lib.LLVMPY_RunNewModulePassManager(self, module, pb)
 
     def add_verifier(self):
         ffi.lib.LLVMPY_AddVerifierPass(self)
@@ -61,7 +61,7 @@ class FunctionPassManager(ffi.ObjectRef):
         super().__init__(ptr)
 
     def run(self, fun, pb):
-        ffi.lib.LLVMPY_RunNewFunctionPassManager(self, fun, pb, pb._pic)
+        ffi.lib.LLVMPY_RunNewFunctionPassManager(self, fun, pb)
 
     def add_aa_eval_pass(self):
         ffi.lib.LLVMPY_AddAAEvalPass_function(self)
@@ -163,23 +163,12 @@ class PipelineTuningOptions(ffi.ObjectRef):
         ffi.lib.LLVMPY_DisposePipelineTuningOptions(self)
 
 
-class PassInstrumentationCallbacks(ffi.ObjectRef):
-
-    def __init__(self):
-        super().__init__(ffi.lib.LLVMPY_CreatePassInstrumentationCallbacks())
-
-    def _dispose(self):
-        return ffi.lib.LLVMPY_DisposePassInstrumentationCallbacks(self)
-
-
 class PassBuilder(ffi.ObjectRef):
 
     def __init__(self, tm, pto):
-        pic = PassInstrumentationCallbacks()
-        super().__init__(ffi.lib.LLVMPY_CreatePassBuilder(tm, pto, pic))
+        super().__init__(ffi.lib.LLVMPY_CreatePassBuilder(tm, pto))
         self._pto = pto
         self._tm = tm
-        self._pic = pic
 
     def getModulePassManager(self):
         return ModulePassManager(
@@ -206,7 +195,7 @@ ffi.lib.LLVMPY_CreateNewModulePassManager.restype = ffi.LLVMModulePassManagerRef
 
 ffi.lib.LLVMPY_RunNewModulePassManager.argtypes = [
     ffi.LLVMModulePassManagerRef, ffi.LLVMModuleRef,
-    ffi.LLVMPassBuilderRef, ffi.LLVMPassInstrumentationCallbacksRef,]
+    ffi.LLVMPassBuilderRef,]
 
 ffi.lib.LLVMPY_AddVerifierPass.argtypes = [ffi.LLVMModulePassManagerRef,]
 ffi.lib.LLVMPY_AddAAEvalPass_module.argtypes = [ffi.LLVMModulePassManagerRef,]
@@ -235,7 +224,7 @@ ffi.lib.LLVMPY_CreateNewFunctionPassManager.restype = \
 
 ffi.lib.LLVMPY_RunNewFunctionPassManager.argtypes = [
     ffi.LLVMFunctionPassManagerRef, ffi.LLVMValueRef,
-    ffi.LLVMPassBuilderRef, ffi.LLVMPassInstrumentationCallbacksRef, ]
+    ffi.LLVMPassBuilderRef,]
 
 ffi.lib.LLVMPY_AddAAEvalPass_function.argtypes = [
     ffi.LLVMFunctionPassManagerRef,]
@@ -293,12 +282,6 @@ ffi.lib.LLVMPY_PTOSetLoopUnrolling.argtypes = [
 
 ffi.lib.LLVMPY_DisposePipelineTuningOptions.argtypes = \
     [ffi.LLVMPipelineTuningOptionsRef,]
-
-# PassInstrumentationCallbacks
-ffi.lib.LLVMPY_CreatePassInstrumentationCallbacks.restype = \
-    ffi.LLVMPassInstrumentationCallbacksRef
-ffi.lib.LLVMPY_DisposePassInstrumentationCallbacks.argtypes = \
-    [ffi.LLVMPassInstrumentationCallbacksRef,]
 
 # PassBuilder
 

--- a/llvmlite/tests/test_binding.py
+++ b/llvmlite/tests/test_binding.py
@@ -3042,7 +3042,7 @@ class TestNewModulePassManager(BaseTest, NewPassManagerMixin):
 
     def run_o_n(self, level):
         mod = self.module()
-        orig_asm = str(self.module())
+        orig_asm = str(mod)
         pb = self.pb(speed_level=level, size_level=0)
         mpm = pb.getModulePassManager()
         mpm.run(mod, pb)
@@ -3075,16 +3075,16 @@ class TestNewModulePassManager(BaseTest, NewPassManagerMixin):
         self.assertNotIn("%.3", optimized_asm)
 
     def test_optnone(self):
-        # Module shouldn't be optimized if the function has `optnone` attached
         pb = self.pb(speed_level=3, size_level=0)
-        orig_asm_no_optnone = str(asm_alloca_optnone.replace("optnone ", ""))
-        mod = llvm.parse_assembly(orig_asm_no_optnone)
+        orig_asm = str(asm_alloca_optnone.replace("optnone ", ""))
+        mod = llvm.parse_assembly(orig_asm)
         mpm = pb.getModulePassManager()
         mpm.run(mod, pb)
-        optimized_asm_no_optnone = str(mod)
-        self.assertIn("alloca", orig_asm_no_optnone)
-        self.assertNotIn("alloca", optimized_asm_no_optnone)
+        optimized_asm = str(mod)
+        self.assertIn("alloca", orig_asm)
+        self.assertNotIn("alloca", optimized_asm)
 
+        # Module shouldn't be optimized if the function has `optnone` attached
         orig_asm_optnone = str(asm_alloca_optnone)
         mpm = pb.getModulePassManager()
         mod = llvm.parse_assembly(orig_asm_optnone)
@@ -3133,16 +3133,16 @@ class TestNewFunctionPassManager(BaseTest, NewPassManagerMixin):
         self.assertIn("%.4", optimized_asm)
 
     def test_optnone(self):
-        # Function shouldn't be optimized if the function has `optnone` attached
         pb = self.pb(speed_level=3, size_level=0)
-        orig_asm_no_optnone = str(asm_alloca_optnone.replace("optnone ", ""))
-        fun = llvm.parse_assembly(orig_asm_no_optnone).get_function("foo")
+        orig_asm = str(asm_alloca_optnone.replace("optnone ", ""))
+        fun = llvm.parse_assembly(orig_asm).get_function("foo")
         fpm = pb.getFunctionPassManager()
         fpm.run(fun, pb)
-        optimized_asm_no_optnone = str(fun)
-        self.assertIn("alloca", orig_asm_no_optnone)
-        self.assertNotIn("alloca", optimized_asm_no_optnone)
+        optimized_asm = str(fun)
+        self.assertIn("alloca", orig_asm)
+        self.assertNotIn("alloca", optimized_asm)
 
+        # Function shouldn't be optimized if the function has `optnone` attached
         orig_asm_optnone = str(asm_alloca_optnone)
         fun = llvm.parse_assembly(orig_asm_optnone).get_function("foo")
         fpm = pb.getFunctionPassManager()


### PR DESCRIPTION
The new pass manager relies on PIC callbacks for deciding
if a function needs to be skipped for optimization when
compiled with 'optnone'.