### PR TITLE
bump compiler for linux-aarch64 to 11

### DIFF
--- a/conda-recipes/llvmdev/conda_build_config.yaml
+++ b/conda-recipes/llvmdev/conda_build_config.yaml
@@ -1,15 +1,15 @@
 # Numba/llvmlite stack needs an older compiler for backwards compatability.
 c_compiler_version:         # [linux]
   - 7                       # [linux and (x86_64 or ppc64le)]
-  - 9                       # [linux and aarch64]
+  - 11                      # [linux and aarch64]
 
 cxx_compiler_version:       # [linux]
   - 7                       # [linux and (x86_64 or ppc64le)]
-  - 9                       # [linux and aarch64]
+  - 11                      # [linux and aarch64]
 
 fortran_compiler_version:   # [linux]
   - 7                       # [linux and (x86_64 or ppc64le)]
-  - 9                       # [linux and aarch64]
+  - 11                      # [linux and aarch64]
 
 c_compiler:              # [win]
   - vs2019               # [win]

--- a/conda-recipes/llvmdev/meta.yaml
+++ b/conda-recipes/llvmdev/meta.yaml
@@ -1,7 +1,7 @@
 {% set shortversion = "15.0" %}
 {% set version = "15.0.7" %}
 {% set sha256_llvm = "8b5fcb24b4128cf04df1b0b9410ce8b1a729cb3c544e6da885d234280dedeac6" %}
-{% set build_number = "1" %}
+{% set build_number = "2" %}
 
 package:
   name: llvmdev

--- a/conda-recipes/llvmlite/conda_build_config.yaml
+++ b/conda-recipes/llvmlite/conda_build_config.yaml
@@ -1,15 +1,15 @@
 # Numba/llvmlite stack needs an older compiler for backwards compatability.
 c_compiler_version:         # [linux]
   - 7                       # [linux and (x86_64 or ppc64le)]
-  - 9                       # [linux and aarch64]
+  - 11                      # [linux and aarch64]
 
 cxx_compiler_version:       # [linux]
   - 7                       # [linux and (x86_64 or ppc64le)]
-  - 9                       # [linux and aarch64]
+  - 11                      # [linux and aarch64]
 
 fortran_compiler_version:   # [linux]
   - 7                       # [linux and (x86_64 or ppc64le)]
-  - 9                       # [linux and aarch64]
+  - 11                      # [linux and aarch64]
 
 c_compiler:              # [win]
   - vs2019               # [win]


### PR DESCRIPTION
Numba team build system for linux-aarch64 is being updated from Miniforge3 to miniconda3 based docker containers. `llvmlite` fails to compile from `main` with current recipe specification as compiler version 9 is not available for that architecture. We bump to 11 which is the default as referenced by:

https://github.com/AnacondaRecipes/aggregate/blob/master/conda_build_config.yaml

For reference, the error was:

```
The following packages are incompatible
├─ gcc_linux-aarch64 9.*  does not exist (perhaps a typo or a missing channel);
└─ gxx_linux-aarch64 9.*  does not exist (perhaps a typo or a missing channel).
```