### PR TITLE
Add convenience func and args

### DIFF
--- a/docs/source/user-guide/ir/types.rst
+++ b/docs/source/user-guide/ir/types.rst
@@ -38,10 +38,16 @@ instantiated, a type should be considered immutable.
         to the *target_data*---an
         :class:`llvmlite.binding.TargetData` instance.
 
-        NOTE: :meth:`get_abi_size` and :meth:`get_abi_alignment`
-        call into the LLVM C++ API to get the requested
-        information.
+   * .. method:: get_element_offset(target_data, position)
 
+        Get the byte offset for the struct element at position,
+        according to the *target_data*---an
+        :class:`llvmlite.binding.TargetData` instance.
+
+        NOTE: :meth:`get_abi_size`, :meth:`get_abi_alignment`,
+        and :meth:`get_element_offset` call into the LLVM C++
+        API to get the requested information.
+        
    * .. method:: __call__(value)
 
         A convenience method to create a :class:`Constant` of

--- a/docs/source/user-guide/ir/types.rst
+++ b/docs/source/user-guide/ir/types.rst
@@ -40,7 +40,7 @@ instantiated, a type should be considered immutable.
 
    * .. method:: get_element_offset(target_data, position)
 
-        Get the byte offset for the struct element at position,
+        Get the byte offset for the struct element at *position*,
         according to the *target_data*---an
         :class:`llvmlite.binding.TargetData` instance.
 

--- a/docs/source/user-guide/ir/values.rst
+++ b/docs/source/user-guide/ir/values.rst
@@ -234,12 +234,14 @@ A :ref:`module` consists mostly of values.
       * Returns a constant array containing the *elements*, in
         order.
 
-   .. classmethod:: literal_struct(elements)
+   .. classmethod:: literal_struct(elements, packed=False)
 
       An alternate constructor for constant structs.
 
       * *elements* is a sequence of values, :class:`Constant` or
-        otherwise. Returns a constant struct containing the
+        otherwise.
+      * *packed* controls whether to use packed layout.
+      * Returns a constant struct containing the
         *elements* in order.
 
    .. method:: gep(indices)

--- a/llvmlite/ir/context.py
+++ b/llvmlite/ir/context.py
@@ -7,10 +7,10 @@ class Context(object):
         self.scope = _utils.NameScope()
         self.identified_types = {}
 
-    def get_identified_type(self, name):
+    def get_identified_type(self, name, packed=False):
         if name not in self.identified_types:
             self.scope.register(name)
-            ty = types.IdentifiedStructType(self, name)
+            ty = types.IdentifiedStructType(self, name, packed)
             self.identified_types[name] = ty
         else:
             ty = self.identified_types[name]

--- a/llvmlite/ir/types.py
+++ b/llvmlite/ir/types.py
@@ -55,6 +55,10 @@ class Type(_StrCaching):
         llty = self._get_ll_global_value_type(target_data, context)
         return target_data.get_abi_size(llty)
 
+    def get_element_offset(self, target_data, ndx, context=None):
+        llty = self._get_ll_global_value_type(target_data, context)
+        return target_data.get_element_offset(llty, ndx)
+
     def get_abi_alignment(self, target_data, context=None):
         """
         Get the minimum ABI alignment of this type according to data layout

--- a/llvmlite/ir/values.py
+++ b/llvmlite/ir/values.py
@@ -482,12 +482,12 @@ class Constant(_StrCaching, _StringReferenceCaching, _ConstOpMixin, Value):
         return cls(types.ArrayType(ty, len(elems)), elems)
 
     @classmethod
-    def literal_struct(cls, elems):
+    def literal_struct(cls, elems, packed=False):
         """
         Construct a literal structure constant made of the given members.
         """
         tys = [el.type for el in elems]
-        return cls(types.LiteralStructType(tys), elems)
+        return cls(types.LiteralStructType(tys, packed), elems)
 
     @property
     def addrspace(self):

--- a/llvmlite/tests/test_binding.py
+++ b/llvmlite/tests/test_binding.py
@@ -2701,6 +2701,12 @@ class TestTypeParsing(BaseTest):
             # Also test constant text repr
             gv.initializer = ir.Constant(typ, [1])
 
+        # Packed layout2
+        with self.check_parsing() as mod:
+            const = ir.Constant.literal_struct([ir.IntType(32)(1),
+                                                ir.IntType(32)(2)])
+            gv = ir.GlobalVariable(mod, const.type, "foo")
+            gv.initializer = const
 
 class TestGlobalConstructors(TestMCJit):
     def test_global_ctors_dtors(self):

--- a/llvmlite/tests/test_binding.py
+++ b/llvmlite/tests/test_binding.py
@@ -2708,6 +2708,7 @@ class TestTypeParsing(BaseTest):
             gv = ir.GlobalVariable(mod, const.type, "foo")
             gv.initializer = const
 
+
 class TestGlobalConstructors(TestMCJit):
     def test_global_ctors_dtors(self):
         # test issue #303

--- a/llvmlite/tests/test_binding.py
+++ b/llvmlite/tests/test_binding.py
@@ -2704,7 +2704,8 @@ class TestTypeParsing(BaseTest):
         # Packed layout2
         with self.check_parsing() as mod:
             const = ir.Constant.literal_struct([ir.IntType(32)(1),
-                                                ir.IntType(32)(2)])
+                                                ir.IntType(32)(2)],
+                                               packed=True)
             gv = ir.GlobalVariable(mod, const.type, "foo")
             gv.initializer = const
 

--- a/llvmlite/tests/test_binding.py
+++ b/llvmlite/tests/test_binding.py
@@ -2701,7 +2701,7 @@ class TestTypeParsing(BaseTest):
             # Also test constant text repr
             gv.initializer = ir.Constant(typ, [1])
 
-        # Packed layout2
+        # Packed layout created from Constant.literal_struct
         with self.check_parsing() as mod:
             const = ir.Constant.literal_struct([ir.IntType(32)(1),
                                                 ir.IntType(32)(2)],

--- a/llvmlite/tests/test_ir.py
+++ b/llvmlite/tests/test_ir.py
@@ -2552,11 +2552,11 @@ class TestTypes(TestBase):
         self.assert_valid_ir(module)
         oldstr = str(module)
         mytype.set_body(ir.IntType(16), ir.IntType(64), ir.FloatType())
-        self.assertEqual(mytype.get_element_offset (td, 1, context), 2)
+        self.assertEqual(mytype.get_element_offset(td, 1, context), 2)
         self.assertFalse(mytype.is_opaque)
         self.assert_valid_ir(module)
         self.assertNotEqual(oldstr, str(module))
-        
+
     def test_target_data_non_default_context(self):
         context = ir.Context()
         mytype = context.get_identified_type("MyType")

--- a/llvmlite/tests/test_ir.py
+++ b/llvmlite/tests/test_ir.py
@@ -2543,6 +2543,20 @@ class TestTypes(TestBase):
         self.assert_valid_ir(module)
         self.assertNotEqual(oldstr, str(module))
 
+    def test_identified_struct_packed(self):
+        td = llvm.create_target_data("e-m:e-i64:64-f80:128-n8:16:32:64-S128")
+        context = ir.Context()
+        mytype = context.get_identified_type("MyType", True)
+        module = ir.Module(context=context)
+        self.assertTrue(mytype.is_opaque)
+        self.assert_valid_ir(module)
+        oldstr = str(module)
+        mytype.set_body(ir.IntType(16), ir.IntType(64), ir.FloatType())
+        self.assertEqual(mytype.get_element_offset (td, 1, context), 2)
+        self.assertFalse(mytype.is_opaque)
+        self.assert_valid_ir(module)
+        self.assertNotEqual(oldstr, str(module))
+        
     def test_target_data_non_default_context(self):
         context = ir.Context()
         mytype = context.get_identified_type("MyType")


### PR DESCRIPTION
I found these helpful in a recent project. Not sure if there is a better way to do this. This is my first pull request so hopefully getting it right!

types.py: add get_element_offset to Type
values.py: add packed arg to literal_struct
context: add packed arg to get_identified_type
tests: add test cases