### PR TITLE
Fix RTD build, no need for get_html_theme_path().

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -123,7 +123,6 @@ todo_include_todos = False
 # a list of builtin themes.
 
 html_theme = 'sphinx_rtd_theme'
-html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the


### PR DESCRIPTION
As title. This follows the instructions suggested in the warning message coming from RTD as noted in #1083, essentially, it removes the definition of html_theme_path which is set by calling the function in the title.

Fixes #1083