### PR TITLE
Add MSVC `-GL` workaround

### DIFF
--- a/ffi/build.py
+++ b/ffi/build.py
@@ -99,7 +99,28 @@ def find_windows_generator():
     raise RuntimeError("No compatible cmake generator installed on this machine")
 
 
+def remove_msvc_whole_program_optimization():
+    """Remove MSVC whole-program optimization flags.
+    This workaround a segfault issue on windows.
+    Note: conda-build is known to enable the `-GL` flag.
+    """
+    def drop_gl(flags):
+        try:
+            flags.remove('-GL')
+        except ValueError:
+            pass
+        else:
+            print(f"removed '-GL' flag in {flags}")
+    cflags = os.environ.get('CFLAGS', '').split(' ')
+    cxxflags = os.environ.get('CXXFLAGS', '').split(' ')
+    drop_gl(cflags)
+    drop_gl(cxxflags)
+    os.environ['CFLAGS'] = ' '.join(cflags)
+    os.environ['CXXFLAGS'] = ' '.join(cxxflags)
+
+
 def main_windows():
+    remove_msvc_whole_program_optimization()
     generator = find_windows_generator()
     config = 'Release'
     if not os.path.exists(build_dir):


### PR DESCRIPTION
On windows, [HEAD](https://github.com/numba/llvmlite/commit/8cc8944f6234ca2eee0ecc817b834e5a7a27d2c5) is suffering from a segfault problem when running the testsuite. The problem is associated with the use of `-GL` flag on MSVC. The flag enables whole-program optimization. I cannot find any mentioning of this issue on LLVM issue tracker. 

The patch simply discard `-GL` from `CFLAGS` and `CXXFLAGS`. These environment variables can be set by user or build system (e.g. conda-build).

<details>
<summary>an ipython reproducer</summary>

```python
!python -m llvmlite.tests -vb
ct = 0
while _exit_code == 0:
    !python -m llvmlite.tests -vb
    ct += 1
print("count", ct)
```
This loops until it fails because it may takes several trial to reproduce. Usually within 3 runs. 
</details>