### PR TITLE
Fix CI by not removing nonexistent environment

### DIFF
--- a/buildscripts/incremental/setup_conda_environment.cmd
+++ b/buildscripts/incremental/setup_conda_environment.cmd
@@ -3,9 +3,6 @@
 @rem Display root environment (for debugging)
 call conda list
 
-@rem Clean up any left-over from a previous build
-call conda remove --all -q -y -n %CONDA_ENV%
-
 @rem Create and populate environment
 call conda create -n %CONDA_ENV% -q -y python=%PYTHON% cmake
 if %errorlevel% neq 0 exit /b %errorlevel%

--- a/buildscripts/incremental/setup_conda_environment.sh
+++ b/buildscripts/incremental/setup_conda_environment.sh
@@ -11,11 +11,7 @@ source deactivate
 set -v
 # Display root environment (for debugging)
 conda list
-# Clean up any left-over from a previous build
-# (note workaround for https://github.com/conda/conda/issues/2679:
-#  `conda env remove` issue)
-conda remove --all -q -y -n $CONDA_ENV
-# Scipy, CFFI, jinja2 and IPython are optional dependencies, but exercised in the test suite
+
 if [ "$PYTHON" == "pypy" ]; then
     conda create -c gmarkall -n $CONDA_ENV -q -y pypy
 else


### PR DESCRIPTION
It is now an error to try to remove a nonexistent environment. This removal of the environment appears to be a leftover from a previous build system that didn't start with a clean image, so the offending lines in the setup of the build / test environment are simply removed.