### PR TITLE
Fix store to opaque ptr

### DIFF
--- a/llvmlite/ir/builder.py
+++ b/llvmlite/ir/builder.py
@@ -774,7 +774,7 @@ class IRBuilder(object):
         if not isinstance(ptr.type, types.PointerType):
             msg = "cannot store to value of type %s (%r): not a pointer"
             raise TypeError(msg % (ptr.type, str(ptr)))
-        if ptr.type.pointee != value.type:
+        if not ptr.type.is_opaque and ptr.type.pointee != value.type:
             raise TypeError("cannot store %s to %s: mismatching types"
                             % (value.type, ptr.type))
         st = instructions.StoreInstr(self.block, value, ptr)

--- a/llvmlite/tests/test_ir.py
+++ b/llvmlite/tests/test_ir.py
@@ -1069,6 +1069,26 @@ my_block:
                     %"k" = load atomic i32, i32* %"c" seq_cst, align 4
                 """)
 
+    def test_store(self):
+        block = self.block(name='my_block')
+        builder = ir.IRBuilder(block)
+        if opaque_pointers_enabled:
+            ptr = ir.Constant(ir.PointerType(), None)
+        else:
+            ptr = ir.Constant(ir.PointerType(int32), None)
+        builder.store(ir.Constant(int32, 5), ptr)
+        # FIXME: Remove `else' once TP are no longer supported.
+        if opaque_pointers_enabled:
+            self.check_block(block, """\
+                my_block:
+                    store i32 5, ptr null
+                """)
+        else:
+            self.check_block(block, """\
+                my_block:
+                    store i32 5, i32* null
+                """)
+
     def test_gep(self):
         block = self.block(name='my_block')
         builder = ir.IRBuilder(block)

--- a/llvmlite/tests/test_ir.py
+++ b/llvmlite/tests/test_ir.py
@@ -1027,6 +1027,11 @@ my_block:
         self.assertEqual(j.type, ir.VoidType())
         k = builder.load_atomic(c, ordering="seq_cst", align=4, name='k')
         self.assertEqual(k.type, int32)
+        if opaque_pointers_enabled:
+            ptr = ir.Constant(ir.PointerType(), None)
+        else:
+            ptr = ir.Constant(ir.PointerType(int32), None)
+        builder.store(ir.Constant(int32, 5), ptr)
         # Not pointer types
         with self.assertRaises(TypeError):
             builder.store(b, a)
@@ -1035,6 +1040,7 @@ my_block:
         # Mismatching pointer type
         with self.assertRaises(TypeError) as cm:
             builder.store(b, e)
+
         # FIXME: Remove `else' once TP are no longer supported.
         if opaque_pointers_enabled:
             self.assertEqual(str(cm.exception),
@@ -1051,6 +1057,7 @@ my_block:
                     %"i" = load i32, ptr %"c", align 1
                     store atomic i32 %".2", ptr %"c" seq_cst, align 4
                     %"k" = load atomic i32, ptr %"c" seq_cst, align 4
+                    store i32 5, ptr null
                 """)
         else:
             self.assertEqual(str(cm.exception),
@@ -1067,25 +1074,6 @@ my_block:
                     %"i" = load i32, i32* %"c", align 1
                     store atomic i32 %".2", i32* %"c" seq_cst, align 4
                     %"k" = load atomic i32, i32* %"c" seq_cst, align 4
-                """)
-
-    def test_store(self):
-        block = self.block(name='my_block')
-        builder = ir.IRBuilder(block)
-        if opaque_pointers_enabled:
-            ptr = ir.Constant(ir.PointerType(), None)
-        else:
-            ptr = ir.Constant(ir.PointerType(int32), None)
-        builder.store(ir.Constant(int32, 5), ptr)
-        # FIXME: Remove `else' once TP are no longer supported.
-        if opaque_pointers_enabled:
-            self.check_block(block, """\
-                my_block:
-                    store i32 5, ptr null
-                """)
-        else:
-            self.check_block(block, """\
-                my_block:
                     store i32 5, i32* null
                 """)
 


### PR DESCRIPTION
If ptr.type.is_opaque is True it doesn't need to have ptr.type.pointee attribute.
Add a unit test.