### PR TITLE
Updated date and llvm versioning for 0.44.0rc1

### DIFF
--- a/CHANGE_LOG
+++ b/CHANGE_LOG
@@ -1,5 +1,5 @@
-v0.44.0rc1 (November 8, 2024)
------------------------------
+v0.44.0rc1 (November 18, 2024)
+------------------------------
 
 Highlights of this release are:
 

--- a/README.rst
+++ b/README.rst
@@ -60,14 +60,15 @@ Compatibility
 llvmlite has been tested with Python 3.10 -- 3.13 and is likely to work with
 greater versions.
 
-As of version 0.41.0, llvmlite requires LLVM 14.x.x on all architectures
+As of version 0.44.0, llvmlite requires LLVM 15.x.x on all architectures
 
 Historical compatibility table:
 
 =================  ========================
 llvmlite versions  compatible LLVM versions
 =================  ========================
-0.41.0 - ...       14.x.x
+0.44.0 - ......    15.x.x
+0.41.0 - 0.43.0    14.x.x
 0.40.0 - 0.40.1    11.x.x and 14.x.x (12.x.x and 13.x.x untested but may work)
 0.37.0 - 0.39.1    11.x.x
 0.34.0 - 0.36.0    10.0.x (9.0.x for  ``aarch64`` only)

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -301,7 +301,7 @@ texinfo_documents = [
 # Example configuration for intersphinx: refer to the Python standard library.
 intersphinx_mapping = {
     'python': ('https://docs.python.org/3', None),
-    'llvm': ('http://llvm.org/releases/14.0.0/docs', None),
+    'llvm': ('http://llvm.org/releases/15.0.0/docs', None),
     }
 
 nitpicky = True


### PR DESCRIPTION
As titled this PR updates the date and llvm versioning for the `0.44.0cr1` release. 