### PR TITLE
Add target attributes to LLVM IR Module getting optimized

### DIFF
--- a/ffi/targets.cpp
+++ b/ffi/targets.cpp
@@ -265,6 +265,21 @@ LLVMPY_CreateTargetMachineData(LLVMTargetMachineRef TM) {
         new llvm::DataLayout(llvm::unwrap(TM)->createDataLayout()));
 }
 
+API_EXPORT(const char *)
+LLVMPY_getTargetTriple(LLVMTargetMachineRef TM) {
+    return llvm::unwrap(TM)->getTargetTriple().getTriple().c_str();
+}
+
+API_EXPORT(const char *)
+LLVMPY_getTargetCPU(LLVMTargetMachineRef TM) {
+    return llvm::unwrap(TM)->getTargetCPU().data();
+}
+
+API_EXPORT(const char *)
+LLVMPY_getTargetFeatureString(LLVMTargetMachineRef TM) {
+    return llvm::unwrap(TM)->getTargetFeatureString().data();
+}
+
 API_EXPORT(void)
 LLVMPY_AddAnalysisPasses(LLVMTargetMachineRef TM, LLVMPassManagerRef PM) {
     LLVMAddAnalysisPasses(TM, PM);

--- a/llvmlite/binding/targets.py
+++ b/llvmlite/binding/targets.py
@@ -376,6 +376,18 @@ class TargetMachine(ffi.ObjectRef):
         finally:
             ffi.lib.LLVMPY_DisposeMemoryBuffer(mb)
 
+    def get_target_triple(self):
+        s = ffi.lib.LLVMPY_getTargetTriple(self)
+        return _decode_string(s)
+
+    def get_target_cpu(self):
+        s = ffi.lib.LLVMPY_getTargetCPU(self)
+        return _decode_string(s)
+
+    def get_target_feature_string(self):
+        s = ffi.lib.LLVMPY_getTargetFeatureString(self)
+        return _decode_string(s)
+
     @property
     def target_data(self):
         return TargetData(ffi.lib.LLVMPY_CreateTargetMachineData(self))
@@ -510,6 +522,15 @@ ffi.lib.LLVMPY_GetBufferSize.argtypes = [ffi.LLVMMemoryBufferRef]
 ffi.lib.LLVMPY_GetBufferSize.restype = c_size_t
 
 ffi.lib.LLVMPY_DisposeMemoryBuffer.argtypes = [ffi.LLVMMemoryBufferRef]
+
+ffi.lib.LLVMPY_getTargetTriple.argtypes = [ffi.LLVMTargetMachineRef]
+ffi.lib.LLVMPY_getTargetTriple.restype = c_char_p
+
+ffi.lib.LLVMPY_getTargetCPU.argtypes = [ffi.LLVMTargetMachineRef]
+ffi.lib.LLVMPY_getTargetCPU.restype = c_char_p
+
+ffi.lib.LLVMPY_getTargetFeatureString.argtypes = [ffi.LLVMTargetMachineRef]
+ffi.lib.LLVMPY_getTargetFeatureString.restype = c_char_p
 
 ffi.lib.LLVMPY_CreateTargetMachineData.argtypes = [
     ffi.LLVMTargetMachineRef,

--- a/llvmlite/tests/test_binding.py
+++ b/llvmlite/tests/test_binding.py
@@ -3021,6 +3021,15 @@ class TestPipelineTuningOptions(BaseTest):
 
 
 class NewPassManagerMixin(object):
+    def icelake_pass_builder(self, speed_level=0, size_level=0):
+        llvm.initialize_all_targets()
+        target = llvm.Target.from_triple("x86_64-unknown-unknown")
+        tm = target.create_target_machine(
+            cpu='skylake-avx512',
+            features="+avx,+aes,+sahf,+pclmul,-xop,+crc32", opt=3)
+
+        pto = llvm.create_pipeline_tuning_options(speed_level, size_level)
+        return llvm.create_pass_builder(tm, pto)
 
     def pb(self, speed_level=0, size_level=0):
         tm = self.target_machine(jit=False)
@@ -3126,6 +3135,21 @@ class TestNewModulePassManager(BaseTest, NewPassManagerMixin):
         mpm.add_instruction_combine_pass()
         mpm.add_jump_threading_pass()
         mpm.add_refprune_pass()
+
+    def test_target(self):
+        pb = self.icelake_pass_builder(3, 0)
+        mpm = pb.getModulePassManager()
+        mod = llvm.parse_assembly("define void @foo() { entry: ret void }")
+        mpm.run(mod, pb)
+
+        # Check for target triple
+        self.assertIn('x86_64-unknown-unknown', str(mod))
+
+        # Check for target-cpu
+        self.assertIn('skylake-avx512', str(mod))
+
+        # Check for target-features
+        self.assertIn("+avx,+aes,+sahf,+pclmul,-xop,+crc32", str(mod))
 
 
 class TestNewFunctionPassManager(BaseTest, NewPassManagerMixin):


### PR DESCRIPTION
LLVM IR that is passed down from Numba frontend to LLVM backend does not contain some basic target specific attributes(`target-cpu`, `target-features`) which is added by Clang frontend (when compiling C++) or either by tools such as `opt` and `llc` when optimizing the LLVM-IR directly with the help of `cli` flags. 

I have mimicked the flow of `opt` optimizer from llvm, which adds these details to the IR module before running the optimization pipeline. 

This change shouldn't affect any functionality and correctness, it's just to add more details to the IR involved and to make it more more verbose and portable across tools.