### PR TITLE
Fix Windows llvmdev build due to zlib linkage

### DIFF
--- a/.github/workflows/llvmdev_win_builder.yml
+++ b/.github/workflows/llvmdev_win_builder.yml
@@ -1,0 +1,55 @@
+name: llvmdev_win_builder
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - misc/win_wheel_fix
+
+
+jobs:
+
+  windows:
+    name: Windows • Py${{ matrix.config.python }}
+    runs-on: windows-2019
+    strategy:
+      matrix:
+        config:
+          - {python: '3.10'}
+    env:
+      CONDA_ENV: cienv
+      PYTHON: ${{ matrix.config.python }}
+      LLVM: ${{ matrix.config.llvm }}
+      OPAQUE_POINTERS: ${{ matrix.config.opaque_pointers }}
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Install Miniconda
+      shell: pwsh
+      run: |
+        $wc = New-Object net.webclient
+        $wc.Downloadfile("https://repo.anaconda.com/miniconda/Miniconda3-latest-Windows-x86_64.exe", "Miniconda3-latest-Windows-x86_64.exe")
+        Start-Process "Miniconda3-latest-Windows-x86_64.exe" "/S /D=C:\Miniconda3" -Wait
+
+    - name: Setup Conda Environment
+      shell: bash
+      run: |
+        source /c/Miniconda3/Scripts/activate
+        conda create -n builder conda-build -y
+        
+    - name: Build
+      shell: bash
+      run: |
+        source /c/Miniconda3/Scripts/activate
+        conda activate builder
+        RECIPE_NAME=./conda-recipes/llvmdev_manylinux
+        conda build $RECIPE_NAME
+        echo "OUTPUT=$(conda build --output $RECIPE_NAME)" >> $GITHUB_ENV
+
+
+    - name: Upload artifact
+      uses: actions/upload-artifact@v4
+      with:
+        name: llvmdev
+        path: ${{ env.OUTPUT }}

--- a/.github/workflows/llvmdev_win_builder.yml
+++ b/.github/workflows/llvmdev_win_builder.yml
@@ -2,10 +2,6 @@ name: llvmdev_win_builder
 
 on:
   workflow_dispatch:
-  push:
-    branches:
-      - misc/win_wheel_fix
-
 
 jobs:
 

--- a/.github/workflows/llvmdev_win_builder.yml
+++ b/.github/workflows/llvmdev_win_builder.yml
@@ -6,17 +6,8 @@ on:
 jobs:
 
   windows:
-    name: Windows • Py${{ matrix.config.python }}
+    name: Windows
     runs-on: windows-2019
-    strategy:
-      matrix:
-        config:
-          - {python: '3.10'}
-    env:
-      CONDA_ENV: cienv
-      PYTHON: ${{ matrix.config.python }}
-      LLVM: ${{ matrix.config.llvm }}
-      OPAQUE_POINTERS: ${{ matrix.config.opaque_pointers }}
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/llvmdev_win_builder.yml
+++ b/.github/workflows/llvmdev_win_builder.yml
@@ -33,7 +33,7 @@ jobs:
       run: |
         source /c/Miniconda3/Scripts/activate
         conda create -n builder conda-build -y
-        
+
     - name: Build
       shell: bash
       run: |

--- a/conda-recipes/llvmdev_manylinux/bld.bat
+++ b/conda-recipes/llvmdev_manylinux/bld.bat
@@ -1,0 +1,59 @@
+REM base on https://github.com/AnacondaRecipes/llvmdev-feedstock/blob/master/recipe/bld.bat
+echo on
+
+mkdir build
+cd build
+
+REM remove GL flag for now
+set "CXXFLAGS=-MD"
+set "CC=cl.exe"
+set "CXX=cl.exe"
+
+cmake -G "Ninja" ^
+    -DCMAKE_BUILD_TYPE="Release" ^
+    -DCMAKE_PREFIX_PATH=%LIBRARY_PREFIX% ^
+    -DCMAKE_INSTALL_PREFIX:PATH=%LIBRARY_PREFIX% ^
+    -DLLVM_USE_INTEL_JITEVENTS=ON ^
+    -DLLVM_ENABLE_LIBXML2=OFF ^
+    -DLLVM_ENABLE_RTTI=ON ^
+    -DLLVM_ENABLE_ZLIB=OFF ^
+    -DLLVM_ENABLE_ZSTD=OFF ^
+    -DLLVM_INCLUDE_BENCHMARKS=OFF ^
+    -DLLVM_INCLUDE_DOCS=OFF ^
+    -DLLVM_INCLUDE_EXAMPLES=OFF ^
+    -DLLVM_INCLUDE_TESTS=ON ^
+    -DLLVM_INCLUDE_UTILS=ON ^
+    -DLLVM_INSTALL_UTILS=ON ^
+    -DLLVM_UTILS_INSTALL_DIR=libexec\llvm ^
+    -DLLVM_BUILD_LLVM_C_DYLIB=no ^
+    -DLLVM_EXPERIMENTAL_TARGETS_TO_BUILD=WebAssembly ^
+    -DCMAKE_POLICY_DEFAULT_CMP0111=NEW ^
+    -DLLVM_ENABLE_PROJECTS:STRING=lld;compiler-rt ^
+    -DLLVM_ENABLE_ASSERTIONS=ON ^
+    -DLLVM_ENABLE_DIA_SDK=OFF ^
+    -DCOMPILER_RT_BUILD_BUILTINS=ON ^
+    -DCOMPILER_RT_BUILTINS_HIDE_SYMBOLS=OFF ^
+    -DCOMPILER_RT_BUILD_LIBFUZZER=OFF ^
+    -DCOMPILER_RT_BUILD_CRT=OFF ^
+    -DCOMPILER_RT_BUILD_MEMPROF=OFF ^
+    -DCOMPILER_RT_BUILD_PROFILE=OFF ^
+    -DCOMPILER_RT_BUILD_SANITIZERS=OFF ^
+    -DCOMPILER_RT_BUILD_XRAY=OFF ^
+    -DCOMPILER_RT_BUILD_GWP_ASAN=OFF ^
+    -DCOMPILER_RT_BUILD_ORC=OFF ^
+    -DCOMPILER_RT_INCLUDE_TESTS=OFF ^
+    %SRC_DIR%/llvm
+if %ERRORLEVEL% neq 0 exit 1
+
+cmake --build .
+if %ERRORLEVEL% neq 0 exit 1
+
+cmake --build . --target install
+
+if %ERRORLEVEL% neq 0 exit 1
+
+REM bin\opt -S -vector-library=SVML -mcpu=haswell -O3 %RECIPE_DIR%\numba-3016.ll | bin\FileCheck %RECIPE_DIR%\numba-3016.ll
+REM if %ERRORLEVEL% neq 0 exit 1
+
+cd ..\llvm\test
+python ..\..\build\bin\llvm-lit.py -vv Transforms ExecutionEngine Analysis CodeGen/X86

--- a/conda-recipes/llvmdev_manylinux/conda_build_config.yaml
+++ b/conda-recipes/llvmdev_manylinux/conda_build_config.yaml
@@ -1,0 +1,20 @@
+# # Numba/llvmlite stack needs an older compiler for backwards compatability.
+# c_compiler_version:         # [linux]
+#   - 7                       # [linux and (x86_64 or ppc64le)]
+#   - 11                      # [linux and aarch64]
+
+# cxx_compiler_version:       # [linux]
+#   - 7                       # [linux and (x86_64 or ppc64le)]
+#   - 11                      # [linux and aarch64]
+
+# fortran_compiler_version:   # [linux]
+#   - 7                       # [linux and (x86_64 or ppc64le)]
+#   - 11                      # [linux and aarch64]
+
+c_compiler:              # [win]
+  - vs2019               # [win]
+cxx_compiler:            # [win]
+  - vs2019               # [win]
+
+MACOSX_SDK_VERSION:    # [osx and x86_64]
+  - 10.12              # [osx and x86_64]

--- a/conda-recipes/llvmdev_manylinux/meta.yaml
+++ b/conda-recipes/llvmdev_manylinux/meta.yaml
@@ -51,9 +51,7 @@ requirements:
     - libffi    # [unix]
     # # libxml2 supports a windows-only feature, see https://github.com/llvm/llvm-project/blob/llvmorg-17.0.6/llvm/include/llvm/WindowsManifest/WindowsManifestMerger.h
     # - libxml2   # [win]
-    # Remove compression libs
-    # - zlib 
-    # - zstd 
+    - zlib      # [not win]
 
 test:
   # Unused test file

--- a/conda-recipes/llvmdev_manylinux/meta.yaml
+++ b/conda-recipes/llvmdev_manylinux/meta.yaml
@@ -51,10 +51,12 @@ requirements:
     - libffi    # [unix]
     # # libxml2 supports a windows-only feature, see https://github.com/llvm/llvm-project/blob/llvmorg-17.0.6/llvm/include/llvm/WindowsManifest/WindowsManifestMerger.h
     # - libxml2   # [win]
+    # Remove compression libs
     # - zlib 
     # - zstd 
 
 test:
+  # Unused test file
   # files:
   #   - numba-3016.ll
   commands:

--- a/conda-recipes/llvmdev_manylinux/meta.yaml
+++ b/conda-recipes/llvmdev_manylinux/meta.yaml
@@ -2,7 +2,7 @@
 {% set shortversion = "15.0" %}
 {% set version = "15.0.7" %}
 {% set sha256_llvm = "8b5fcb24b4128cf04df1b0b9410ce8b1a729cb3c544e6da885d234280dedeac6" %}
-{% set build_number = "0" %}
+{% set build_number = "1" %}
 
 package:
   name: llvmdev
@@ -17,13 +17,18 @@ source:
     - ../llvm15-svml.patch
     - ../compiler-rt-cfi-startproc-war.patch
     - ../compiler-rt-macos-build.patch
+    # Patches from conda-forge needed for windows to build
+    # backport of zlib patches, can be dropped for vs15.0.3, see
+    # https://reviews.llvm.org/D135457 & https://reviews.llvm.org/D136065
+    - ../llvmdev/patches/0002-CMake-Fix-Findzstd-module-for-shared-DLL-on-Windows.patch
+    - ../llvmdev/patches/no-windows-symlinks.patch
 
 build:
   number: {{ build_number }}
   string: "manylinux"
   script_env:
-    - CFLAGS
-    - CXXFLAGS
+    - CFLAGS        [linux]
+    - CXXFLAGS      [linux]
     - PY_VCRUNTIME_REDIST
   ignore_run_exports:
     # Is static-linked
@@ -31,14 +36,14 @@ build:
 
 requirements:
   build:
-    # Do not use the compiler
-    - {{ compiler('cxx') }}    # [osx]
+    # Do not use the compiler on linux
+    - {{ compiler('cxx') }}  # [not linux]
     - cmake
     - ninja
     - python >=3
     - libcxx      # it is not defined{{ cxx_compiler_version }}  # [osx]
     - patch       # [not win]
-    # - m2-patch    # [win]
+    - m2-patch    # [win]
     - git         # [(linux and x86_64)]
 
   host:
@@ -46,17 +51,18 @@ requirements:
     - libffi    # [unix]
     # # libxml2 supports a windows-only feature, see https://github.com/llvm/llvm-project/blob/llvmorg-17.0.6/llvm/include/llvm/WindowsManifest/WindowsManifestMerger.h
     # - libxml2   # [win]
-    - zlib 
+    # - zlib 
+    # - zstd 
 
 test:
-  files:
-    - numba-3016.ll
+  # files:
+  #   - numba-3016.ll
   commands:
     - $PREFIX/bin/llvm-config --libs                         # [not win]
     - $PREFIX/bin/llc -version                               # [not win]
 
-    # - if not exist %LIBRARY_INC%\\llvm\\Pass.h exit 1        # [win]
-    # - if not exist %LIBRARY_LIB%\\LLVMSupport.lib exit 1     # [win]
+    - if not exist %LIBRARY_INC%\\llvm\\Pass.h exit 1        # [win]
+    - if not exist %LIBRARY_LIB%\\LLVMSupport.lib exit 1     # [win]
 
     - test -f $PREFIX/include/llvm/Pass.h                    # [unix]
     - test -f $PREFIX/lib/libLLVMSupport.a                   # [unix]
@@ -65,7 +71,7 @@ test:
 
     # LLD tests
     - ld.lld --version                                       # [unix]
-    # - lld-link /?                                            # [win]
+    - lld-link /?                                            # [win]
 
 about:
   home: http://llvm.org/


### PR DESCRIPTION
(Based on #1104)

Users have reported error using the windows wheel for llvmlite on official CPython distribution (non-Anaconda builds). The error was due to `zlib.dll` dependency that is not available on the installed Python. 

This patch fixes the problem by using `llvmdev_manylinux` recipe which disabled zlib and zstd.

Note: With this patch, all wheel builds use `llvmdev_manylinux` recipe. The recipe folder should rename to `llvmdev_wheels` later. Don't want to do that now which will require changing more buildfarm scripts.

In addition, a GHA workflow is added to build the llvmdev for wheels. Example run: https://github.com/sklam/llvmlite/actions/runs/12186143333/job/33993961959
