### PR TITLE
Add llvmdev builds gha

### DIFF
--- a/.github/workflows/llvmdev_build.yml
+++ b/.github/workflows/llvmdev_build.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Upload LLVMDEV artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: llvmdev-x86_64
+          name: llvmdev-linux-x86_64
           path: /home/runner/work/llvmlite/llvmlite/docker_output/linux-64/*.tar.bz2
           retention-days: 1
           if-no-files-found: error 
@@ -58,7 +58,7 @@ jobs:
       - name: Upload LLVMDEV artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: llvmdev-x86_64-windows
+          name: llvmdev-windows-x86_64
           path: ${{ env.OUTPUT }}
           retention-days: 1
           if-no-files-found: error

--- a/.github/workflows/llvmdev_build.yml
+++ b/.github/workflows/llvmdev_build.yml
@@ -1,0 +1,65 @@
+name: llvmdev-build
+
+on:
+  workflow_dispatch:
+
+jobs:
+  linux-64:
+    name: Build LLVMDEV (linux-64)
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+      
+      - name: Build LLVMDEV
+        run: |
+          mkdir -p /home/runner/work/llvmlite/llvmlite/docker_output
+          chmod 777 /home/runner/work/llvmlite/llvmlite/docker_output
+          cd buildscripts/manylinux
+          ./docker_run_x64.sh build_llvmdev.sh "${MINICONDA_FILE}"
+          RECIPE_NAME=./conda-recipes/llvmdev_manylinux
+          echo "OUTPUT=$(conda build --output $RECIPE_NAME)" >> $GITHUB_ENV
+
+      - name: Upload LLVMDEV artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: llvmdev-x86_64
+          path: /home/runner/work/llvmlite/llvmlite/docker_output/linux-64/*.tar.bz2
+          retention-days: 1
+          if-no-files-found: error 
+
+  win-64:
+    name: Build LLVMDEV (win-64)
+    runs-on: windows-2019
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Miniconda
+        shell: pwsh
+        run: |
+          $wc = New-Object net.webclient
+          $wc.Downloadfile("https://repo.anaconda.com/miniconda/Miniconda3-latest-Windows-x86_64.exe", "Miniconda3-latest-Windows-x86_64.exe")
+          Start-Process "Miniconda3-latest-Windows-x86_64.exe" "/S /D=C:\Miniconda3" -Wait
+
+      - name: Setup Conda Environment
+        shell: bash
+        run: |
+          source /c/Miniconda3/Scripts/activate
+          conda create -n builder conda-build -y
+
+      - name: Build
+        shell: bash
+        run: |
+          source /c/Miniconda3/Scripts/activate
+          conda activate builder
+          RECIPE_NAME=./conda-recipes/llvmdev_manylinux
+          conda build $RECIPE_NAME
+          echo "OUTPUT=$(conda build --output $RECIPE_NAME)" >> $GITHUB_ENV
+
+      - name: Upload LLVMDEV artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: llvmdev-x86_64-windows
+          path: ${{ env.OUTPUT }}
+          retention-days: 1
+          if-no-files-found: error
+

--- a/buildscripts/manylinux/docker_run.sh
+++ b/buildscripts/manylinux/docker_run.sh
@@ -18,4 +18,4 @@ echo "MINICONDA_FILE=$MINICONDA_FILE"
 # Ensure the latest docker image
 IMAGE_URI="quay.io/pypa/${MANYLINUX_IMAGE}:latest"
 docker pull $IMAGE_URI
-docker run --rm -it -v $SRCDIR:/root/llvmlite $IMAGE_URI ${PRECMD} /root/llvmlite/buildscripts/manylinux/$1 ${MINICONDA_FILE} $2
+docker run --rm -t -v $SRCDIR:/root/llvmlite $IMAGE_URI ${PRECMD} /root/llvmlite/buildscripts/manylinux/$1 ${MINICONDA_FILE} $2

--- a/conda-recipes/llvmdev_manylinux/bld.bat
+++ b/conda-recipes/llvmdev_manylinux/bld.bat
@@ -1,0 +1,59 @@
+REM base on https://github.com/AnacondaRecipes/llvmdev-feedstock/blob/master/recipe/bld.bat
+echo on
+
+mkdir build
+cd build
+
+REM remove GL flag for now
+set "CXXFLAGS=-MD"
+set "CC=cl.exe"
+set "CXX=cl.exe"
+
+cmake -G "Ninja" ^
+    -DCMAKE_BUILD_TYPE="Release" ^
+    -DCMAKE_PREFIX_PATH=%LIBRARY_PREFIX% ^
+    -DCMAKE_INSTALL_PREFIX:PATH=%LIBRARY_PREFIX% ^
+    -DLLVM_USE_INTEL_JITEVENTS=ON ^
+    -DLLVM_ENABLE_LIBXML2=OFF ^
+    -DLLVM_ENABLE_RTTI=ON ^
+    -DLLVM_ENABLE_ZLIB=OFF ^
+    -DLLVM_ENABLE_ZSTD=OFF ^
+    -DLLVM_INCLUDE_BENCHMARKS=OFF ^
+    -DLLVM_INCLUDE_DOCS=OFF ^
+    -DLLVM_INCLUDE_EXAMPLES=OFF ^
+    -DLLVM_INCLUDE_TESTS=ON ^
+    -DLLVM_INCLUDE_UTILS=ON ^
+    -DLLVM_INSTALL_UTILS=ON ^
+    -DLLVM_UTILS_INSTALL_DIR=libexec\llvm ^
+    -DLLVM_BUILD_LLVM_C_DYLIB=no ^
+    -DLLVM_EXPERIMENTAL_TARGETS_TO_BUILD=WebAssembly ^
+    -DCMAKE_POLICY_DEFAULT_CMP0111=NEW ^
+    -DLLVM_ENABLE_PROJECTS:STRING=lld;compiler-rt ^
+    -DLLVM_ENABLE_ASSERTIONS=ON ^
+    -DLLVM_ENABLE_DIA_SDK=OFF ^
+    -DCOMPILER_RT_BUILD_BUILTINS=ON ^
+    -DCOMPILER_RT_BUILTINS_HIDE_SYMBOLS=OFF ^
+    -DCOMPILER_RT_BUILD_LIBFUZZER=OFF ^
+    -DCOMPILER_RT_BUILD_CRT=OFF ^
+    -DCOMPILER_RT_BUILD_MEMPROF=OFF ^
+    -DCOMPILER_RT_BUILD_PROFILE=OFF ^
+    -DCOMPILER_RT_BUILD_SANITIZERS=OFF ^
+    -DCOMPILER_RT_BUILD_XRAY=OFF ^
+    -DCOMPILER_RT_BUILD_GWP_ASAN=OFF ^
+    -DCOMPILER_RT_BUILD_ORC=OFF ^
+    -DCOMPILER_RT_INCLUDE_TESTS=OFF ^
+    %SRC_DIR%/llvm
+if %ERRORLEVEL% neq 0 exit 1
+
+cmake --build .
+if %ERRORLEVEL% neq 0 exit 1
+
+cmake --build . --target install
+
+if %ERRORLEVEL% neq 0 exit 1
+
+REM bin\opt -S -vector-library=SVML -mcpu=haswell -O3 %RECIPE_DIR%\numba-3016.ll | bin\FileCheck %RECIPE_DIR%\numba-3016.ll
+REM if %ERRORLEVEL% neq 0 exit 1
+
+cd ..\llvm\test
+python ..\..\build\bin\llvm-lit.py -vv Transforms ExecutionEngine Analysis CodeGen/X86

--- a/conda-recipes/llvmdev_manylinux/conda_build_config.yaml
+++ b/conda-recipes/llvmdev_manylinux/conda_build_config.yaml
@@ -1,0 +1,20 @@
+# # Numba/llvmlite stack needs an older compiler for backwards compatability.
+# c_compiler_version:         # [linux]
+#   - 7                       # [linux and (x86_64 or ppc64le)]
+#   - 11                      # [linux and aarch64]
+
+# cxx_compiler_version:       # [linux]
+#   - 7                       # [linux and (x86_64 or ppc64le)]
+#   - 11                      # [linux and aarch64]
+
+# fortran_compiler_version:   # [linux]
+#   - 7                       # [linux and (x86_64 or ppc64le)]
+#   - 11                      # [linux and aarch64]
+
+c_compiler:              # [win]
+  - vs2019               # [win]
+cxx_compiler:            # [win]
+  - vs2019               # [win]
+
+MACOSX_SDK_VERSION:    # [osx and x86_64]
+  - 10.12              # [osx and x86_64]

--- a/conda-recipes/llvmdev_manylinux/meta.yaml
+++ b/conda-recipes/llvmdev_manylinux/meta.yaml
@@ -2,7 +2,7 @@
 {% set shortversion = "15.0" %}
 {% set version = "15.0.7" %}
 {% set sha256_llvm = "8b5fcb24b4128cf04df1b0b9410ce8b1a729cb3c544e6da885d234280dedeac6" %}
-{% set build_number = "0" %}
+{% set build_number = "1" %}
 
 package:
   name: llvmdev
@@ -17,13 +17,18 @@ source:
     - ../llvm15-svml.patch
     - ../compiler-rt-cfi-startproc-war.patch
     - ../compiler-rt-macos-build.patch
+    # Patches from conda-forge needed for windows to build
+    # backport of zlib patches, can be dropped for vs15.0.3, see
+    # https://reviews.llvm.org/D135457 & https://reviews.llvm.org/D136065
+    - ../llvmdev/patches/0002-CMake-Fix-Findzstd-module-for-shared-DLL-on-Windows.patch
+    - ../llvmdev/patches/no-windows-symlinks.patch
 
 build:
   number: {{ build_number }}
   string: "manylinux"
   script_env:
-    - CFLAGS
-    - CXXFLAGS
+    - CFLAGS        [linux]
+    - CXXFLAGS      [linux]
     - PY_VCRUNTIME_REDIST
   ignore_run_exports:
     # Is static-linked
@@ -31,32 +36,33 @@ build:
 
 requirements:
   build:
-    # Do not use the compiler
-    # - {{ compiler('cxx') }} 
+    # Do not use the compiler on linux
+    - {{ compiler('cxx') }}  # [not linux]
     - cmake
     - ninja
     - python >=3
-    # - libcxx      # it is not defined{{ cxx_compiler_version }}  # [osx]
+    - libcxx      # it is not defined{{ cxx_compiler_version }}  # [osx]
     - patch       # [not win]
-    # - m2-patch    # [win]
+    - m2-patch    # [win]
     - git         # [(linux and x86_64)]
 
   host:
-    #- libcxx    # it is not defined{{ cxx_compiler_version }}  # [osx]
+    - libcxx    # it is not defined{{ cxx_compiler_version }}  # [osx]
     - libffi    # [unix]
     # # libxml2 supports a windows-only feature, see https://github.com/llvm/llvm-project/blob/llvmorg-17.0.6/llvm/include/llvm/WindowsManifest/WindowsManifestMerger.h
     # - libxml2   # [win]
-    - zlib 
+    - zlib      # [not win]
 
 test:
-  files:
-    - numba-3016.ll
+  # Unused test file
+  # files:
+  #   - numba-3016.ll
   commands:
     - $PREFIX/bin/llvm-config --libs                         # [not win]
     - $PREFIX/bin/llc -version                               # [not win]
 
-    # - if not exist %LIBRARY_INC%\\llvm\\Pass.h exit 1        # [win]
-    # - if not exist %LIBRARY_LIB%\\LLVMSupport.lib exit 1     # [win]
+    - if not exist %LIBRARY_INC%\\llvm\\Pass.h exit 1        # [win]
+    - if not exist %LIBRARY_LIB%\\LLVMSupport.lib exit 1     # [win]
 
     - test -f $PREFIX/include/llvm/Pass.h                    # [unix]
     - test -f $PREFIX/lib/libLLVMSupport.a                   # [unix]
@@ -65,7 +71,7 @@ test:
 
     # LLD tests
     - ld.lld --version                                       # [unix]
-    # - lld-link /?                                            # [win]
+    - lld-link /?                                            # [win]
 
 about:
   home: http://llvm.org/


### PR DESCRIPTION
This PR introduces a new GitHub Actions workflow (`llvmdev_build.yml`) to automate the building of llvmdev packages for linux and windows platforms.

### Key Features
- Builds LLVMDEV packages for:
  - Linux (x86_64) using ubuntu-24.04
  - Windows (x86_64) using windows-2019
- uploads build artifacts with 1-day retention
- Manual trigger via workflow_dispatch
- Uses conda-build for package creation, using existing recipe: ./conda-recipes/llvmdev_manylinux