### PR TITLE
Add llvmlite build gha

### DIFF
--- a/.github/workflows/llvmdev_build.yml
+++ b/.github/workflows/llvmdev_build.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Upload LLVMDEV artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: llvmdev-x86_64
+          name: llvmdev-linux-x86_64
           path: /home/runner/work/llvmlite/llvmlite/docker_output/linux-64/*.tar.bz2
           retention-days: 1
           if-no-files-found: error 
@@ -58,7 +58,7 @@ jobs:
       - name: Upload LLVMDEV artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: llvmdev-x86_64-windows
+          name: llvmdev-windows-x86_64
           path: ${{ env.OUTPUT }}
           retention-days: 1
           if-no-files-found: error

--- a/.github/workflows/llvmdev_build.yml
+++ b/.github/workflows/llvmdev_build.yml
@@ -1,0 +1,65 @@
+name: llvmdev-build
+
+on:
+  workflow_dispatch:
+
+jobs:
+  linux-64:
+    name: Build LLVMDEV (linux-64)
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+      
+      - name: Build LLVMDEV
+        run: |
+          mkdir -p /home/runner/work/llvmlite/llvmlite/docker_output
+          chmod 777 /home/runner/work/llvmlite/llvmlite/docker_output
+          cd buildscripts/manylinux
+          ./docker_run_x64.sh build_llvmdev.sh "${MINICONDA_FILE}"
+          RECIPE_NAME=./conda-recipes/llvmdev_manylinux
+          echo "OUTPUT=$(conda build --output $RECIPE_NAME)" >> $GITHUB_ENV
+
+      - name: Upload LLVMDEV artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: llvmdev-x86_64
+          path: /home/runner/work/llvmlite/llvmlite/docker_output/linux-64/*.tar.bz2
+          retention-days: 1
+          if-no-files-found: error 
+
+  win-64:
+    name: Build LLVMDEV (win-64)
+    runs-on: windows-2019
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Miniconda
+        shell: pwsh
+        run: |
+          $wc = New-Object net.webclient
+          $wc.Downloadfile("https://repo.anaconda.com/miniconda/Miniconda3-latest-Windows-x86_64.exe", "Miniconda3-latest-Windows-x86_64.exe")
+          Start-Process "Miniconda3-latest-Windows-x86_64.exe" "/S /D=C:\Miniconda3" -Wait
+
+      - name: Setup Conda Environment
+        shell: bash
+        run: |
+          source /c/Miniconda3/Scripts/activate
+          conda create -n builder conda-build -y
+
+      - name: Build
+        shell: bash
+        run: |
+          source /c/Miniconda3/Scripts/activate
+          conda activate builder
+          RECIPE_NAME=./conda-recipes/llvmdev_manylinux
+          conda build $RECIPE_NAME
+          echo "OUTPUT=$(conda build --output $RECIPE_NAME)" >> $GITHUB_ENV
+
+      - name: Upload LLVMDEV artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: llvmdev-x86_64-windows
+          path: ${{ env.OUTPUT }}
+          retention-days: 1
+          if-no-files-found: error
+

--- a/.github/workflows/llvmlite_build.yml
+++ b/.github/workflows/llvmlite_build.yml
@@ -133,3 +133,63 @@ jobs:
           retention-days: 7
           if-no-files-found: error
 
+  macos-build:
+    name: build_osx_64_py${{ matrix.python-version }}_npy1.11
+    runs-on: macos-13
+    strategy:
+      matrix:
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
+      fail-fast: false
+    
+    steps:
+      - uses: actions/checkout@v4
+      
+      - name: Install Miniconda
+        run: |
+          bash buildscripts/incremental/install_miniconda.sh
+      
+      - name: Add Conda to PATH
+        run: |
+          echo "$HOME/miniconda3/bin" >> $GITHUB_PATH
+          source "$HOME/miniconda3/etc/profile.d/conda.sh"
+          conda init bash
+      
+      - name: Create Build Environment
+        run: |
+          source "$HOME/miniconda3/etc/profile.d/conda.sh"
+          conda create -n build_env \
+            python=${{ matrix.python-version }} \
+            setuptools \
+            wheel \
+            -y
+          conda activate build_env
+          # Install LLVM with all dependencies for macOS
+          conda install -y -c numba/label/ci llvmdev
+
+      - name: build_osx_64_py${{ matrix.python-version }}_npy1.11
+        run: |
+          source "$HOME/miniconda3/etc/profile.d/conda.sh"
+          conda activate build_env
+          export MACOSX_DEPLOYMENT_TARGET=10.9
+          export CONDA_BUILD_SYSROOT=/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk
+          export LLVM_CONFIG="$CONDA_PREFIX/bin/llvm-config"
+          export LLVMLITE_SHARED=1
+          
+          python setup.py clean
+          python setup.py bdist_wheel
+
+      - name: test_osx_64_py${{ matrix.python-version }}_npyNone
+        run: |
+          source "$HOME/miniconda3/etc/profile.d/conda.sh"
+          conda activate build_env
+          python -m pip install dist/*.whl
+          python -m llvmlite.tests
+
+      - name: upload_osx_64_py${{ matrix.python-version }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: llvmlite-osx-64-py${{ matrix.python-version }}
+          path: dist/*.whl
+          retention-days: 7
+          if-no-files-found: error
+

--- a/.github/workflows/llvmlite_build.yml
+++ b/.github/workflows/llvmlite_build.yml
@@ -35,8 +35,8 @@ jobs:
             setuptools \
             wheel \
             -y
-          
           conda activate build_env
+          conda install -y numba/label/ci::llvmdev --no-deps
 
       - name: build_linux_64_py${{ matrix.python-version }}_npy1.11
         run: |

--- a/.github/workflows/llvmlite_build.yml
+++ b/.github/workflows/llvmlite_build.yml
@@ -11,6 +11,8 @@ jobs:
       matrix:
         python-version: ["3.10", "3.11", "3.12"]
       fail-fast: false
+    outputs:
+      matrix: ${{ toJSON(matrix) }}
     
     steps:
       - uses: actions/checkout@v4
@@ -20,10 +22,14 @@ jobs:
           bash buildscripts/incremental/install_miniconda.sh
       
       - name: Add Conda to PATH
-        run: echo "$HOME/miniconda3/bin" >> $GITHUB_PATH
+        run: |
+          echo "$HOME/miniconda3/bin" >> $GITHUB_PATH
+          source "$HOME/miniconda3/etc/profile.d/conda.sh"
+          conda init bash
       
       - name: Create Build Environment
         run: |
+          source "$HOME/miniconda3/etc/profile.d/conda.sh"
           conda create -n build_env \
             python=${{ matrix.python-version }} \
             conda-build \
@@ -35,6 +41,7 @@ jobs:
 
       - name: Build LLVMLITE
         run: |
+          source "$HOME/miniconda3/etc/profile.d/conda.sh"
           conda activate build_env
           conda build conda-recipes/llvmlite \
             --python ${{ matrix.python-version }} \
@@ -54,7 +61,7 @@ jobs:
     runs-on: ubuntu-24.04
     strategy:
       matrix:
-        python-version: ["3.10", "3.11", "3.12"]
+        python-version: ${{ fromJSON(needs.build-llvmlite.outputs.matrix).python-version }}
       fail-fast: false
 
     steps:
@@ -65,7 +72,10 @@ jobs:
           bash buildscripts/incremental/install_miniconda.sh
       
       - name: Add Conda to PATH
-        run: echo "$HOME/miniconda3/bin" >> $GITHUB_PATH
+        run: |
+          echo "$HOME/miniconda3/bin" >> $GITHUB_PATH
+          source "$HOME/miniconda3/etc/profile.d/conda.sh"
+          conda init bash
 
       - name: Download artifacts
         uses: actions/download-artifact@v4
@@ -75,6 +85,7 @@ jobs:
 
       - name: Create Test Environment
         run: |
+          source "$HOME/miniconda3/etc/profile.d/conda.sh"
           conda create -n test_env \
             python=${{ matrix.python-version }} \
             -y
@@ -84,5 +95,6 @@ jobs:
 
       - name: Run Tests
         run: |
+          source "$HOME/miniconda3/etc/profile.d/conda.sh"
           conda activate test_env
           python -m llvmlite.tests

--- a/.github/workflows/llvmlite_build.yml
+++ b/.github/workflows/llvmlite_build.yml
@@ -92,6 +92,8 @@ jobs:
           source "$HOME/miniconda3/etc/profile.d/conda.sh"
           conda create -n test_env \
             python=${{ matrix.python-version }} \
+            llvmdev \
+            -c numba \
             -y
           
           conda activate test_env
@@ -101,4 +103,7 @@ jobs:
         run: |
           source "$HOME/miniconda3/etc/profile.d/conda.sh"
           conda activate test_env
+          # List dependencies to verify
+          conda list
+          # Run tests
           python -m llvmlite.tests

--- a/.github/workflows/llvmlite_build.yml
+++ b/.github/workflows/llvmlite_build.yml
@@ -92,9 +92,11 @@ jobs:
             setuptools \
             wheel \
             cmake \
+            libxml2 \
             -y
           conda activate build_env
-          conda install -y -c numba/label/ci llvmdev --no-deps
+          # Install LLVM with all dependencies
+          conda install -y -c numba/label/ci llvmdev
 
       - name: Set Environment Variables
         shell: bash
@@ -104,6 +106,7 @@ jobs:
           echo "LLVM_CONFIG=C:/Miniconda3/envs/build_env/Library/bin/llvm-config" >> $GITHUB_ENV
           echo "LLVM_DIR=C:/Miniconda3/envs/build_env/Library/lib/cmake/llvm" >> $GITHUB_ENV
           echo "LLVM_SHARED=1" >> $GITHUB_ENV
+          echo "LIBXML2_ROOT=C:/Miniconda3/envs/build_env/Library" >> $GITHUB_ENV
 
       - name: build_win_64_py${{ matrix.python-version }}_npy1.11
         shell: cmd

--- a/.github/workflows/llvmlite_build.yml
+++ b/.github/workflows/llvmlite_build.yml
@@ -43,6 +43,10 @@ jobs:
         run: |
           source "$HOME/miniconda3/etc/profile.d/conda.sh"
           conda activate build_env
+          # Set version info for conda build
+          COMMIT_SHA=$(git rev-parse --short HEAD)
+          export GIT_DESCRIBE_TAG="v0.dev0+${COMMIT_SHA}"
+          export GIT_DESCRIBE_NUMBER=0
           conda build conda-recipes/llvmlite \
             --python ${{ matrix.python-version }} \
             --output-folder ./conda_output

--- a/.github/workflows/llvmlite_build.yml
+++ b/.github/workflows/llvmlite_build.yml
@@ -34,11 +34,11 @@ jobs:
             python=${{ matrix.python-version }} \
             conda-build \
             conda-verify \
-            llvmdev \
-            -c numba \
             -y
           
           conda activate build_env
+          # Install llvmdev without dependencies, like manylinux build
+          conda install -y numba/label/ci::llvmdev --no-deps
           conda config --set always_yes yes --set changeps1 no
 
       - name: Build LLVMLITE
@@ -49,8 +49,8 @@ jobs:
           COMMIT_SHA=$(git rev-parse --short HEAD)
           export GIT_DESCRIBE_TAG="v0.dev0+${COMMIT_SHA}"
           export GIT_DESCRIBE_NUMBER=0
-          # Debug: show environment
-          conda list
+          # Build with static linking like manylinux
+          export LLVMLITE_CXX_STATIC_LINK=1
           conda build conda-recipes/llvmlite \
             --python ${{ matrix.python-version }} \
             --output-folder ./conda_output

--- a/.github/workflows/llvmlite_build.yml
+++ b/.github/workflows/llvmlite_build.yml
@@ -9,27 +9,80 @@ jobs:
     runs-on: ubuntu-24.04
     strategy:
       matrix:
-        python-version: ["cp310-cp310", "cp311-cp311", "cp312-cp312"]
+        python-version: ["3.10", "3.11", "3.12"]
       fail-fast: false
     
     steps:
       - uses: actions/checkout@v4
       
-      - name: Create Output Directory
+      - name: Install Miniconda
         run: |
-          mkdir -p /home/runner/work/llvmlite/llvmlite/docker_output
-          chmod 777 /home/runner/work/llvmlite/llvmlite/docker_output
+          bash buildscripts/incremental/install_miniconda.sh
+      
+      - name: Add Conda to PATH
+        run: echo "$HOME/miniconda3/bin" >> $GITHUB_PATH
+      
+      - name: Create Build Environment
+        run: |
+          conda create -n build_env \
+            python=${{ matrix.python-version }} \
+            conda-build \
+            conda-verify \
+            -y
+          
+          conda activate build_env
+          conda config --set always_yes yes --set changeps1 no
 
       - name: Build LLVMLITE
         run: |
-          cd buildscripts/manylinux
-          chmod +x ./docker_run_x64.sh
-          ./docker_run_x64.sh build_llvmlite.sh "${{ matrix.python-version }}"
+          conda activate build_env
+          conda build conda-recipes/llvmlite \
+            --python ${{ matrix.python-version }} \
+            --output-folder ./conda_output
 
       - name: Upload LLVMLITE artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: llvmlite-${{ matrix.python-version }}
-          path: /home/runner/work/llvmlite/llvmlite/docker_output/dist_x86_64_${{ matrix.python-version }}/wheelhouse/*.whl
+          name: llvmlite-py${{ matrix.python-version }}
+          path: ./conda_output/linux-64/*.tar.bz2
           retention-days: 7
           if-no-files-found: error
+
+  test-llvmlite:
+    needs: build-llvmlite
+    name: Test LLVMLITE Python ${{ matrix.python-version }}
+    runs-on: ubuntu-24.04
+    strategy:
+      matrix:
+        python-version: ["3.10", "3.11", "3.12"]
+      fail-fast: false
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Miniconda
+        run: |
+          bash buildscripts/incremental/install_miniconda.sh
+      
+      - name: Add Conda to PATH
+        run: echo "$HOME/miniconda3/bin" >> $GITHUB_PATH
+
+      - name: Download artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: llvmlite-py${{ matrix.python-version }}
+          path: ./conda_pkg
+
+      - name: Create Test Environment
+        run: |
+          conda create -n test_env \
+            python=${{ matrix.python-version }} \
+            -y
+          
+          conda activate test_env
+          conda install -c ./conda_pkg llvmlite -y
+
+      - name: Run Tests
+        run: |
+          conda activate test_env
+          python -m llvmlite.tests

--- a/.github/workflows/llvmlite_build.yml
+++ b/.github/workflows/llvmlite_build.yml
@@ -57,9 +57,11 @@ jobs:
           export LLVMLITE_SHARED=1
           # Add LLVM lib directory to library path
           export LD_LIBRARY_PATH="$CONDA_PREFIX/lib:$LD_LIBRARY_PATH"
+          # Add libllvm15 as runtime dependency
           conda build conda-recipes/llvmlite \
             --python ${{ matrix.python-version }} \
-            --output-folder ./conda_output
+            --output-folder ./conda_output \
+            --extra-deps "libllvm15"
 
       - name: Upload LLVMLITE artifacts
         uses: actions/upload-artifact@v4

--- a/.github/workflows/llvmlite_build.yml
+++ b/.github/workflows/llvmlite_build.yml
@@ -57,11 +57,9 @@ jobs:
           export LLVMLITE_SHARED=1
           # Add LLVM lib directory to library path
           export LD_LIBRARY_PATH="$CONDA_PREFIX/lib:$LD_LIBRARY_PATH"
-          # Add libllvm15 as runtime dependency
           conda build conda-recipes/llvmlite \
             --python ${{ matrix.python-version }} \
-            --output-folder ./conda_output \
-            --extra-deps "libllvm15"
+            --output-folder ./conda_output
 
       - name: Upload LLVMLITE artifacts
         uses: actions/upload-artifact@v4

--- a/.github/workflows/llvmlite_build.yml
+++ b/.github/workflows/llvmlite_build.yml
@@ -30,8 +30,10 @@ jobs:
       - name: Create Build Environment
         run: |
           source "$HOME/miniconda3/etc/profile.d/conda.sh"
+          # Match Airflow build environment
           conda create -n build_env \
             python=${{ matrix.python-version }} \
+            numpy=1.11 \
             conda-build \
             conda-verify \
             -y
@@ -55,8 +57,6 @@ jobs:
           export LLVM_CONFIG="$CONDA_PREFIX/bin/llvm-config"
           # Ensure shared library is built
           export LLVMLITE_SHARED=1
-          # Add LLVM lib directory to library path
-          export LD_LIBRARY_PATH="$CONDA_PREFIX/lib:$LD_LIBRARY_PATH"
           conda build conda-recipes/llvmlite \
             --python ${{ matrix.python-version }} \
             --output-folder ./conda_output

--- a/.github/workflows/llvmlite_build.yml
+++ b/.github/workflows/llvmlite_build.yml
@@ -4,15 +4,13 @@ on:
   workflow_dispatch:
 
 jobs:
-  build-llvmlite:
+  linux-build:
     name: build_linux_64_py${{ matrix.python-version }}_npy1.11
     runs-on: ubuntu-24.04
     strategy:
       matrix:
         python-version: ["3.10", "3.11", "3.12", "3.13"]
       fail-fast: false
-    outputs:
-      matrix: ${{ toJSON(matrix) }}
     
     steps:
       - uses: actions/checkout@v4
@@ -42,16 +40,11 @@ jobs:
         run: |
           source "$HOME/miniconda3/etc/profile.d/conda.sh"
           conda activate build_env
-          # Build with static linking like manylinux
           export LLVMLITE_CXX_STATIC_LINK=1
-          # Set LLVM_CONFIG to point to the correct llvm-config
           export LLVM_CONFIG="$CONDA_PREFIX/bin/llvm-config"
-          # Ensure shared library is built
           export LLVMLITE_SHARED=1
           
-          # Clean up
           python setup.py clean
-          # Build wheel
           python setup.py bdist_wheel
 
       - name: test_linux_64_py${{ matrix.python-version }}_npyNone
@@ -64,7 +57,65 @@ jobs:
       - name: upload_linux_64_py${{ matrix.python-version }}
         uses: actions/upload-artifact@v4
         with:
-          name: llvmlite-py${{ matrix.python-version }}
+          name: llvmlite-linux-64-py${{ matrix.python-version }}
+          path: dist/*.whl
+          retention-days: 7
+          if-no-files-found: error
+
+  windows-build:
+    name: build_win_64_py${{ matrix.python-version }}_npy1.11
+    runs-on: windows-2019
+    strategy:
+      matrix:
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
+      fail-fast: false
+    
+    steps:
+      - uses: actions/checkout@v4
+      
+      - name: Install Miniconda
+        shell: pwsh
+        run: |
+          $wc = New-Object net.webclient
+          $wc.Downloadfile("https://repo.anaconda.com/miniconda/Miniconda3-latest-Windows-x86_64.exe", "Miniconda3-latest-Windows-x86_64.exe")
+          Start-Process "Miniconda3-latest-Windows-x86_64.exe" "/S /D=C:\Miniconda3" -Wait
+      
+      - name: Create Build Environment
+        shell: bash
+        run: |
+          ssource /c/Miniconda3/Scripts/activate
+          conda create -n build_env \
+            python=${{ matrix.python-version }} \
+            setuptools \
+            wheel \
+            -y
+          conda activate build_env
+          conda install -y numba/label/ci::llvmdev --no-deps
+
+      - name: build_win_64_py${{ matrix.python-version }}_npy1.11
+        shell: bash
+        run: |
+          source /c/Miniconda3/etc/profile.d/conda.sh
+          conda activate build_env
+          export LLVMLITE_CXX_STATIC_LINK=1
+          export LLVM_CONFIG="$CONDA_PREFIX/bin/llvm-config"
+          export LLVMLITE_SHARED=1
+          
+          python setup.py clean
+          python setup.py bdist_wheel
+
+      - name: test_win_64_py${{ matrix.python-version }}_npyNone
+        shell: bash
+        run: |
+          source /c/Miniconda3/etc/profile.d/conda.sh
+          conda activate build_env
+          python -m pip install dist/*.whl
+          python -m llvmlite.tests
+
+      - name: upload_win_64_py${{ matrix.python-version }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: llvmlite-win-64-py${{ matrix.python-version }}
           path: dist/*.whl
           retention-days: 7
           if-no-files-found: error

--- a/.github/workflows/llvmlite_build.yml
+++ b/.github/workflows/llvmlite_build.yml
@@ -30,10 +30,8 @@ jobs:
       - name: Create Build Environment
         run: |
           source "$HOME/miniconda3/etc/profile.d/conda.sh"
-          # Match Airflow build environment
           conda create -n build_env \
             python=${{ matrix.python-version }} \
-            numpy=1.11 \
             conda-build \
             conda-verify \
             -y

--- a/.github/workflows/llvmlite_build.yml
+++ b/.github/workflows/llvmlite_build.yml
@@ -34,6 +34,8 @@ jobs:
             python=${{ matrix.python-version }} \
             conda-build \
             conda-verify \
+            llvmdev \
+            -c numba \
             -y
           
           conda activate build_env
@@ -47,6 +49,8 @@ jobs:
           COMMIT_SHA=$(git rev-parse --short HEAD)
           export GIT_DESCRIBE_TAG="v0.dev0+${COMMIT_SHA}"
           export GIT_DESCRIBE_NUMBER=0
+          # Debug: show environment
+          conda list
           conda build conda-recipes/llvmlite \
             --python ${{ matrix.python-version }} \
             --output-folder ./conda_output

--- a/.github/workflows/llvmlite_build.yml
+++ b/.github/workflows/llvmlite_build.yml
@@ -51,6 +51,10 @@ jobs:
           export GIT_DESCRIBE_NUMBER=0
           # Build with static linking like manylinux
           export LLVMLITE_CXX_STATIC_LINK=1
+          # Set LLVM_CONFIG to point to the correct llvm-config
+          export LLVM_CONFIG="$CONDA_PREFIX/bin/llvm-config"
+          # Ensure shared library is built
+          export LLVMLITE_SHARED=1
           conda build conda-recipes/llvmlite \
             --python ${{ matrix.python-version }} \
             --output-folder ./conda_output
@@ -63,51 +67,3 @@ jobs:
           retention-days: 7
           if-no-files-found: error
 
-  test-llvmlite:
-    needs: build-llvmlite
-    name: Test LLVMLITE Python ${{ matrix.python-version }}
-    runs-on: ubuntu-24.04
-    strategy:
-      matrix:
-        python-version: ${{ fromJSON(needs.build-llvmlite.outputs.matrix).python-version }}
-      fail-fast: false
-
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Install Miniconda
-        run: |
-          bash buildscripts/incremental/install_miniconda.sh
-      
-      - name: Add Conda to PATH
-        run: |
-          echo "$HOME/miniconda3/bin" >> $GITHUB_PATH
-          source "$HOME/miniconda3/etc/profile.d/conda.sh"
-          conda init bash
-
-      - name: Download artifacts
-        uses: actions/download-artifact@v4
-        with:
-          name: llvmlite-py${{ matrix.python-version }}
-          path: ./conda_pkg
-
-      - name: Create Test Environment
-        run: |
-          source "$HOME/miniconda3/etc/profile.d/conda.sh"
-          conda create -n test_env \
-            python=${{ matrix.python-version }} \
-            llvmdev \
-            -c numba \
-            -y
-          
-          conda activate test_env
-          conda install -c ./conda_pkg llvmlite -y
-
-      - name: Run Tests
-        run: |
-          source "$HOME/miniconda3/etc/profile.d/conda.sh"
-          conda activate test_env
-          # List dependencies to verify
-          conda list
-          # Run tests
-          python -m llvmlite.tests

--- a/.github/workflows/llvmlite_build.yml
+++ b/.github/workflows/llvmlite_build.yml
@@ -73,6 +73,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       
+      - name: Install Visual Studio
+        uses: microsoft/setup-msbuild@v1.1
+        
       - name: Install Miniconda
         shell: pwsh
         run: |
@@ -88,28 +91,35 @@ jobs:
             python=${{ matrix.python-version }} \
             setuptools \
             wheel \
+            cmake \
             -y
           conda activate build_env
-          conda install -y numba/label/ci::llvmdev --no-deps
+          conda install -y -c numba/label/ci llvmdev --no-deps
 
-      - name: build_win_64_py${{ matrix.python-version }}_npy1.11
+      - name: Set Environment Variables
         shell: bash
         run: |
-          source /c/Miniconda3/etc/profile.d/conda.sh
-          conda activate build_env
-          export LLVMLITE_CXX_STATIC_LINK=1
-          export LLVM_CONFIG="$CONDA_PREFIX/bin/llvm-config"
-          export LLVMLITE_SHARED=1
-          
+          echo "CMAKE_GENERATOR=Visual Studio 16 2019" >> $GITHUB_ENV
+          echo "CMAKE_GENERATOR_PLATFORM=x64" >> $GITHUB_ENV
+          echo "LLVM_CONFIG=C:/Miniconda3/envs/build_env/Library/bin/llvm-config" >> $GITHUB_ENV
+          echo "LLVM_DIR=C:/Miniconda3/envs/build_env/Library/lib/cmake/llvm" >> $GITHUB_ENV
+          echo "LLVM_SHARED=1" >> $GITHUB_ENV
+
+      - name: build_win_64_py${{ matrix.python-version }}_npy1.11
+        shell: cmd
+        run: |
+          call C:\Miniconda3\Scripts\activate.bat build_env
+          set DISTUTILS_USE_SDK=1
+          set VS_VERSION=2019
+          set VS_PLATFORM=x64
           python setup.py clean
           python setup.py bdist_wheel
 
       - name: test_win_64_py${{ matrix.python-version }}_npyNone
-        shell: bash
+        shell: cmd
         run: |
-          source /c/Miniconda3/etc/profile.d/conda.sh
-          conda activate build_env
-          python -m pip install dist/*.whl
+          call C:\Miniconda3\Scripts\activate.bat build_env
+          python -m pip install dist\*.whl
           python -m llvmlite.tests
 
       - name: upload_win_64_py${{ matrix.python-version }}

--- a/.github/workflows/llvmlite_build.yml
+++ b/.github/workflows/llvmlite_build.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-24.04
     strategy:
       matrix:
-        python-version: ["3.10", "3.11", "3.12"]
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
       fail-fast: false
     outputs:
       matrix: ${{ toJSON(matrix) }}
@@ -32,38 +32,35 @@ jobs:
           source "$HOME/miniconda3/etc/profile.d/conda.sh"
           conda create -n build_env \
             python=${{ matrix.python-version }} \
-            conda-build \
-            conda-verify \
+            setuptools \
+            wheel \
             -y
           
           conda activate build_env
           # Install llvmdev without dependencies, like manylinux build
           conda install -y numba/label/ci::llvmdev --no-deps
-          conda config --set always_yes yes --set changeps1 no
 
       - name: Build LLVMLITE
         run: |
           source "$HOME/miniconda3/etc/profile.d/conda.sh"
           conda activate build_env
-          # Set version info for conda build
-          COMMIT_SHA=$(git rev-parse --short HEAD)
-          export GIT_DESCRIBE_TAG="v0.dev0+${COMMIT_SHA}"
-          export GIT_DESCRIBE_NUMBER=0
           # Build with static linking like manylinux
           export LLVMLITE_CXX_STATIC_LINK=1
           # Set LLVM_CONFIG to point to the correct llvm-config
           export LLVM_CONFIG="$CONDA_PREFIX/bin/llvm-config"
           # Ensure shared library is built
           export LLVMLITE_SHARED=1
-          conda build conda-recipes/llvmlite \
-            --python ${{ matrix.python-version }} \
-            --output-folder ./conda_output
+          
+          # Clean up
+          python setup.py clean
+          # Build wheel
+          python setup.py bdist_wheel
 
       - name: Upload LLVMLITE artifacts
         uses: actions/upload-artifact@v4
         with:
           name: llvmlite-py${{ matrix.python-version }}
-          path: ./conda_output/linux-64/*.tar.bz2
+          path: dist/*.whl
           retention-days: 7
           if-no-files-found: error
 

--- a/.github/workflows/llvmlite_build.yml
+++ b/.github/workflows/llvmlite_build.yml
@@ -83,7 +83,7 @@ jobs:
       - name: Create Build Environment
         shell: bash
         run: |
-          ssource /c/Miniconda3/Scripts/activate
+          source /c/Miniconda3/Scripts/activate
           conda create -n build_env \
             python=${{ matrix.python-version }} \
             setuptools \

--- a/.github/workflows/llvmlite_build.yml
+++ b/.github/workflows/llvmlite_build.yml
@@ -55,6 +55,8 @@ jobs:
           export LLVM_CONFIG="$CONDA_PREFIX/bin/llvm-config"
           # Ensure shared library is built
           export LLVMLITE_SHARED=1
+          # Add LLVM lib directory to library path
+          export LD_LIBRARY_PATH="$CONDA_PREFIX/lib:$LD_LIBRARY_PATH"
           conda build conda-recipes/llvmlite \
             --python ${{ matrix.python-version }} \
             --output-folder ./conda_output

--- a/.github/workflows/llvmlite_build.yml
+++ b/.github/workflows/llvmlite_build.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   build-llvmlite:
-    name: Build LLVMLITE Python ${{ matrix.python-version }}
+    name: build_linux_64_py${{ matrix.python-version }}_npy1.11
     runs-on: ubuntu-24.04
     strategy:
       matrix:
@@ -37,10 +37,8 @@ jobs:
             -y
           
           conda activate build_env
-          # Install llvmdev without dependencies, like manylinux build
-          conda install -y numba/label/ci::llvmdev --no-deps
 
-      - name: Build LLVMLITE
+      - name: build_linux_64_py${{ matrix.python-version }}_npy1.11
         run: |
           source "$HOME/miniconda3/etc/profile.d/conda.sh"
           conda activate build_env
@@ -56,7 +54,14 @@ jobs:
           # Build wheel
           python setup.py bdist_wheel
 
-      - name: Upload LLVMLITE artifacts
+      - name: test_linux_64_py${{ matrix.python-version }}_npyNone
+        run: |
+          source "$HOME/miniconda3/etc/profile.d/conda.sh"
+          conda activate build_env
+          python -m pip install dist/*.whl
+          python -m llvmlite.tests
+
+      - name: upload_linux_64_py${{ matrix.python-version }}
         uses: actions/upload-artifact@v4
         with:
           name: llvmlite-py${{ matrix.python-version }}

--- a/.github/workflows/llvmlite_build.yml
+++ b/.github/workflows/llvmlite_build.yml
@@ -1,0 +1,35 @@
+name: llvmlite-build
+
+on:
+  workflow_dispatch:
+
+jobs:
+  build-llvmlite:
+    name: Build LLVMLITE Python ${{ matrix.python-version }}
+    runs-on: ubuntu-24.04
+    strategy:
+      matrix:
+        python-version: ["cp310-cp310", "cp311-cp311", "cp312-cp312"]
+      fail-fast: false
+    
+    steps:
+      - uses: actions/checkout@v4
+      
+      - name: Create Output Directory
+        run: |
+          mkdir -p /home/runner/work/llvmlite/llvmlite/docker_output
+          chmod 777 /home/runner/work/llvmlite/llvmlite/docker_output
+
+      - name: Build LLVMLITE
+        run: |
+          cd buildscripts/manylinux
+          chmod +x ./docker_run_x64.sh
+          ./docker_run_x64.sh build_llvmlite.sh "${{ matrix.python-version }}"
+
+      - name: Upload LLVMLITE artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: llvmlite-${{ matrix.python-version }}
+          path: /home/runner/work/llvmlite/llvmlite/docker_output/dist_x86_64_${{ matrix.python-version }}/wheelhouse/*.whl
+          retention-days: 7
+          if-no-files-found: error

--- a/buildscripts/manylinux/docker_run.sh
+++ b/buildscripts/manylinux/docker_run.sh
@@ -18,4 +18,4 @@ echo "MINICONDA_FILE=$MINICONDA_FILE"
 # Ensure the latest docker image
 IMAGE_URI="quay.io/pypa/${MANYLINUX_IMAGE}:latest"
 docker pull $IMAGE_URI
-docker run --rm -it -v $SRCDIR:/root/llvmlite $IMAGE_URI ${PRECMD} /root/llvmlite/buildscripts/manylinux/$1 ${MINICONDA_FILE} $2
+docker run --rm -t -v $SRCDIR:/root/llvmlite $IMAGE_URI ${PRECMD} /root/llvmlite/buildscripts/manylinux/$1 ${MINICONDA_FILE} $2

--- a/conda-recipes/llvmdev_manylinux/bld.bat
+++ b/conda-recipes/llvmdev_manylinux/bld.bat
@@ -1,0 +1,59 @@
+REM base on https://github.com/AnacondaRecipes/llvmdev-feedstock/blob/master/recipe/bld.bat
+echo on
+
+mkdir build
+cd build
+
+REM remove GL flag for now
+set "CXXFLAGS=-MD"
+set "CC=cl.exe"
+set "CXX=cl.exe"
+
+cmake -G "Ninja" ^
+    -DCMAKE_BUILD_TYPE="Release" ^
+    -DCMAKE_PREFIX_PATH=%LIBRARY_PREFIX% ^
+    -DCMAKE_INSTALL_PREFIX:PATH=%LIBRARY_PREFIX% ^
+    -DLLVM_USE_INTEL_JITEVENTS=ON ^
+    -DLLVM_ENABLE_LIBXML2=OFF ^
+    -DLLVM_ENABLE_RTTI=ON ^
+    -DLLVM_ENABLE_ZLIB=OFF ^
+    -DLLVM_ENABLE_ZSTD=OFF ^
+    -DLLVM_INCLUDE_BENCHMARKS=OFF ^
+    -DLLVM_INCLUDE_DOCS=OFF ^
+    -DLLVM_INCLUDE_EXAMPLES=OFF ^
+    -DLLVM_INCLUDE_TESTS=ON ^
+    -DLLVM_INCLUDE_UTILS=ON ^
+    -DLLVM_INSTALL_UTILS=ON ^
+    -DLLVM_UTILS_INSTALL_DIR=libexec\llvm ^
+    -DLLVM_BUILD_LLVM_C_DYLIB=no ^
+    -DLLVM_EXPERIMENTAL_TARGETS_TO_BUILD=WebAssembly ^
+    -DCMAKE_POLICY_DEFAULT_CMP0111=NEW ^
+    -DLLVM_ENABLE_PROJECTS:STRING=lld;compiler-rt ^
+    -DLLVM_ENABLE_ASSERTIONS=ON ^
+    -DLLVM_ENABLE_DIA_SDK=OFF ^
+    -DCOMPILER_RT_BUILD_BUILTINS=ON ^
+    -DCOMPILER_RT_BUILTINS_HIDE_SYMBOLS=OFF ^
+    -DCOMPILER_RT_BUILD_LIBFUZZER=OFF ^
+    -DCOMPILER_RT_BUILD_CRT=OFF ^
+    -DCOMPILER_RT_BUILD_MEMPROF=OFF ^
+    -DCOMPILER_RT_BUILD_PROFILE=OFF ^
+    -DCOMPILER_RT_BUILD_SANITIZERS=OFF ^
+    -DCOMPILER_RT_BUILD_XRAY=OFF ^
+    -DCOMPILER_RT_BUILD_GWP_ASAN=OFF ^
+    -DCOMPILER_RT_BUILD_ORC=OFF ^
+    -DCOMPILER_RT_INCLUDE_TESTS=OFF ^
+    %SRC_DIR%/llvm
+if %ERRORLEVEL% neq 0 exit 1
+
+cmake --build .
+if %ERRORLEVEL% neq 0 exit 1
+
+cmake --build . --target install
+
+if %ERRORLEVEL% neq 0 exit 1
+
+REM bin\opt -S -vector-library=SVML -mcpu=haswell -O3 %RECIPE_DIR%\numba-3016.ll | bin\FileCheck %RECIPE_DIR%\numba-3016.ll
+REM if %ERRORLEVEL% neq 0 exit 1
+
+cd ..\llvm\test
+python ..\..\build\bin\llvm-lit.py -vv Transforms ExecutionEngine Analysis CodeGen/X86

--- a/conda-recipes/llvmdev_manylinux/conda_build_config.yaml
+++ b/conda-recipes/llvmdev_manylinux/conda_build_config.yaml
@@ -1,0 +1,20 @@
+# # Numba/llvmlite stack needs an older compiler for backwards compatability.
+# c_compiler_version:         # [linux]
+#   - 7                       # [linux and (x86_64 or ppc64le)]
+#   - 11                      # [linux and aarch64]
+
+# cxx_compiler_version:       # [linux]
+#   - 7                       # [linux and (x86_64 or ppc64le)]
+#   - 11                      # [linux and aarch64]
+
+# fortran_compiler_version:   # [linux]
+#   - 7                       # [linux and (x86_64 or ppc64le)]
+#   - 11                      # [linux and aarch64]
+
+c_compiler:              # [win]
+  - vs2019               # [win]
+cxx_compiler:            # [win]
+  - vs2019               # [win]
+
+MACOSX_SDK_VERSION:    # [osx and x86_64]
+  - 10.12              # [osx and x86_64]

--- a/conda-recipes/llvmdev_manylinux/meta.yaml
+++ b/conda-recipes/llvmdev_manylinux/meta.yaml
@@ -2,7 +2,7 @@
 {% set shortversion = "15.0" %}
 {% set version = "15.0.7" %}
 {% set sha256_llvm = "8b5fcb24b4128cf04df1b0b9410ce8b1a729cb3c544e6da885d234280dedeac6" %}
-{% set build_number = "0" %}
+{% set build_number = "1" %}
 
 package:
   name: llvmdev
@@ -17,13 +17,18 @@ source:
     - ../llvm15-svml.patch
     - ../compiler-rt-cfi-startproc-war.patch
     - ../compiler-rt-macos-build.patch
+    # Patches from conda-forge needed for windows to build
+    # backport of zlib patches, can be dropped for vs15.0.3, see
+    # https://reviews.llvm.org/D135457 & https://reviews.llvm.org/D136065
+    - ../llvmdev/patches/0002-CMake-Fix-Findzstd-module-for-shared-DLL-on-Windows.patch
+    - ../llvmdev/patches/no-windows-symlinks.patch
 
 build:
   number: {{ build_number }}
   string: "manylinux"
   script_env:
-    - CFLAGS
-    - CXXFLAGS
+    - CFLAGS        [linux]
+    - CXXFLAGS      [linux]
     - PY_VCRUNTIME_REDIST
   ignore_run_exports:
     # Is static-linked
@@ -31,32 +36,33 @@ build:
 
 requirements:
   build:
-    # Do not use the compiler
-    # - {{ compiler('cxx') }} 
+    # Do not use the compiler on linux
+    - {{ compiler('cxx') }}  # [not linux]
     - cmake
     - ninja
     - python >=3
-    # - libcxx      # it is not defined{{ cxx_compiler_version }}  # [osx]
+    - libcxx      # it is not defined{{ cxx_compiler_version }}  # [osx]
     - patch       # [not win]
-    # - m2-patch    # [win]
+    - m2-patch    # [win]
     - git         # [(linux and x86_64)]
 
   host:
-    #- libcxx    # it is not defined{{ cxx_compiler_version }}  # [osx]
+    - libcxx    # it is not defined{{ cxx_compiler_version }}  # [osx]
     - libffi    # [unix]
     # # libxml2 supports a windows-only feature, see https://github.com/llvm/llvm-project/blob/llvmorg-17.0.6/llvm/include/llvm/WindowsManifest/WindowsManifestMerger.h
     # - libxml2   # [win]
-    - zlib 
+    - zlib      # [not win]
 
 test:
-  files:
-    - numba-3016.ll
+  # Unused test file
+  # files:
+  #   - numba-3016.ll
   commands:
     - $PREFIX/bin/llvm-config --libs                         # [not win]
     - $PREFIX/bin/llc -version                               # [not win]
 
-    # - if not exist %LIBRARY_INC%\\llvm\\Pass.h exit 1        # [win]
-    # - if not exist %LIBRARY_LIB%\\LLVMSupport.lib exit 1     # [win]
+    - if not exist %LIBRARY_INC%\\llvm\\Pass.h exit 1        # [win]
+    - if not exist %LIBRARY_LIB%\\LLVMSupport.lib exit 1     # [win]
 
     - test -f $PREFIX/include/llvm/Pass.h                    # [unix]
     - test -f $PREFIX/lib/libLLVMSupport.a                   # [unix]
@@ -65,7 +71,7 @@ test:
 
     # LLD tests
     - ld.lld --version                                       # [unix]
-    # - lld-link /?                                            # [win]
+    - lld-link /?                                            # [win]
 
 about:
   home: http://llvm.org/

--- a/conda-recipes/llvmlite/meta.yaml
+++ b/conda-recipes/llvmlite/meta.yaml
@@ -44,6 +44,7 @@ requirements:
     - libcxx >=4.0.1 # [osx]
     - zlib 
     - zstd 
+    - libllvm15  # [linux64]
 
 test:
   imports:

--- a/conda-recipes/llvmlite/meta.yaml
+++ b/conda-recipes/llvmlite/meta.yaml
@@ -44,7 +44,6 @@ requirements:
     - libcxx >=4.0.1 # [osx]
     - zlib 
     - zstd 
-    - libllvm15  # [linux64]
 
 test:
   imports:


### PR DESCRIPTION
This PR introduces a new GitHub Actions workflow (`llvmlite_build.yml`) to automate the building and testing of llvmlite wheels across multiple platforms and Python versions.

### Key Features
- Cross-platform builds for:
  - Linux (ubuntu-24.04)
  - Windows (windows-2019)
  - macOS (macos-13)
- Python version matrix support:
  - Python 3.10
  - Python 3.11
  - Python 3.12
  - Python 3.13
- Automated testing of built wheels
- artifact upload with 1 day retention