### PR TITLE
Fix flag condition when creating SimpleLoopUnswitchLegacyPass

### DIFF
--- a/ffi/passmanagers.cpp
+++ b/ffi/passmanagers.cpp
@@ -334,7 +334,7 @@ LLVMPY_AddLoopUnrollAndJamPass(LLVMPassManagerRef PM) {
 API_EXPORT(void)
 LLVMPY_AddLoopUnswitchPass(LLVMPassManagerRef PM, bool optimizeForSize,
                            bool hasBranchDivergence) {
-    unwrap(PM)->add(createSimpleLoopUnswitchLegacyPass(optimizeForSize));
+    unwrap(PM)->add(createSimpleLoopUnswitchLegacyPass(!optimizeForSize));
 }
 
 API_EXPORT(void)


### PR DESCRIPTION
Looking at the `unswitchLoop` function here: https://github.com/llvm/llvm-project/blob/fc3c4e1725273df3c701d57458373a50f215069b/llvm/lib/Transforms/Scalar/SimpleLoopUnswitch.cpp#L3561-L3563

It seems the pass shall skip the "NonTrivial" transformation when "OptimizeForSize" is set true.
For a reference, here's the use of `OptimizeForSize` in LLVM versions < 15:
https://github.com/llvm/llvm-project/blob/f28c006a5895fc0e329fe15fead81e37457cb1d1/llvm/lib/Transforms/Scalar/LoopUnswitch.cpp#L673-L675