### PR TITLE
add llvmlite win builder GH actions workflow

### DIFF
--- a/.github/workflows/llvmlite_win_builder.yml
+++ b/.github/workflows/llvmlite_win_builder.yml
@@ -32,6 +32,21 @@ jobs:
 
       - name: Install Visual Studio
         uses: microsoft/setup-msbuild@v1.1
+        with:
+          vs-version: '[16.11,16.12)'
+          vs-prerelease: false
+        
+      - name: Install Visual Studio Components
+        shell: powershell
+        run: |
+          # Install required VS components
+          $vsPath = & vswhere -latest -property installationPath
+          $vsInstallerPath = "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vs_installer.exe"
+          & $vsInstallerPath modify `
+            --installPath "$vsPath" `
+            --quiet --norestart --nocache `
+            --add Microsoft.VisualStudio.Component.VC.DiagnosticTools `
+            --add Microsoft.VisualStudio.Component.Windows10SDK
         
       - name: Install Miniconda
         shell: pwsh
@@ -54,12 +69,12 @@ jobs:
             -y
           conda activate build_env
           if [ "${{ inputs.llvmdev_run_id }}" != "" ]; then
-            # Install local llvmdev package if workflow ID provided
             conda install -y ./llvmdev-pkg/*.tar.bz2
           else
-            # Install from numba channel if no workflow ID
             conda install -y -c numba/label/ci llvmdev
           fi
+          # Set environment variable to disable DIA SDK requirement
+          echo "LLVM_ENABLE_DIA_SDK=OFF" >> $GITHUB_ENV
 
       - name: Build Conda Package
         shell: bash

--- a/.github/workflows/llvmlite_win_builder.yml
+++ b/.github/workflows/llvmlite_win_builder.yml
@@ -1,0 +1,79 @@
+name: llvmlite-build
+
+on:
+  workflow_dispatch:
+    inputs:
+      llvmdev_run_id:
+        description: 'llvmdev workflow run ID (optional)'
+        required: false
+        type: string
+
+jobs:
+  windows:
+    name: windows
+    runs-on: windows-2019
+    strategy:
+      matrix:
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
+      fail-fast: false
+    
+    steps:
+      - uses: actions/checkout@v4
+      
+      - name: Download LLVMDEV Artifact
+        if: ${{ inputs.llvmdev_run_id != '' }}
+        uses: actions/download-artifact@v4
+        with:
+          name: llvmdev-windows-x86_64
+          path: llvmdev-pkg
+          run-id: ${{ inputs.llvmdev_run_id }}
+          repository: ${{ github.repository }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Install Visual Studio
+        uses: microsoft/setup-msbuild@v1.1
+        
+      - name: Install Miniconda
+        shell: pwsh
+        run: |
+          $wc = New-Object net.webclient
+          $wc.Downloadfile("https://repo.anaconda.com/miniconda/Miniconda3-latest-Windows-x86_64.exe", "Miniconda3-latest-Windows-x86_64.exe")
+          Start-Process "Miniconda3-latest-Windows-x86_64.exe" "/S /D=C:\Miniconda3" -Wait
+
+      - name: Create Build Environment
+        shell: bash
+        run: |
+          source /c/Miniconda3/Scripts/activate
+          conda create -n build_env \
+            python=${{ matrix.python-version }} \
+            conda-build \
+            setuptools \
+            wheel \
+            cmake \
+            libxml2 \
+            -y
+          conda activate build_env
+          if [ "${{ inputs.llvmdev_run_id }}" != "" ]; then
+            # Install local llvmdev package if workflow ID provided
+            conda install -y ./llvmdev-pkg/*.tar.bz2
+          else
+            # Install from numba channel if no workflow ID
+            conda install -y -c numba/label/ci llvmdev
+          fi
+
+      - name: Build Conda Package
+        shell: bash
+        run: |
+          source /c/Miniconda3/Scripts/activate
+          conda activate build_env
+          RECIPE_NAME=./conda-recipes/llvmlite
+          conda build $RECIPE_NAME
+          echo "CONDA_PKG=$(conda build --output $RECIPE_NAME)" >> $GITHUB_ENV
+
+      - name: Upload Conda Package
+        uses: actions/upload-artifact@v4
+        with:
+          name: llvmlite-win-64-py${{ matrix.python-version }}
+          path: ${{ env.CONDA_PKG }}
+          retention-days: 7
+          if-no-files-found: error

--- a/.github/workflows/llvmlite_win_builder.yml
+++ b/.github/workflows/llvmlite_win_builder.yml
@@ -69,8 +69,10 @@ jobs:
             -y
           conda activate build_env
           if [ "${{ inputs.llvmdev_run_id }}" != "" ]; then
+            # Install local llvmdev package if workflow ID provided
             conda install -y ./llvmdev-pkg/*.tar.bz2
           else
+            # Install from numba channel if no workflow ID
             conda install -y -c numba/label/ci llvmdev
           fi
           # Set environment variable to disable DIA SDK requirement

--- a/conda-recipes/llvmlite/bld.bat
+++ b/conda-recipes/llvmlite/bld.bat
@@ -1,4 +1,3 @@
-
 @rem Let CMake know about the LLVM install path, for find_package()
 set CMAKE_PREFIX_PATH=%LIBRARY_PREFIX%
 
@@ -18,5 +17,9 @@ set CMAKE_GENERATOR_TOOLKIT=v142
 @rem Ensure there are no build leftovers (CMake can complain)
 if exist ffi\build rmdir /S /Q ffi\build
 
+set "VS_VERSION=2019"
+set "VS_PLATFORM=x64"
+set "LLVM_ENABLE_DIA_SDK=OFF"
+%PYTHON% setup.py clean
 %PYTHON% setup.py install
 if errorlevel 1 exit 1


### PR DESCRIPTION
This PR introduces a new GitHub Actions workflow ( llvmlite_win_builder.yml) to automate the building and testing of llvmlite conda package and wheel for win-64 platforms and Python versions.
python versions -
["3.10", "3.11", "3.12", "3.13"]
artifact retention: 7 days

