### PR TITLE
Extend pre-commit config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,40 @@
 repos:
-- repo: https://github.com/pre-commit/mirrors-clang-format
-  rev: v13.0.1
-  hooks:
-  - id: clang-format
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v5.0.0
+    hooks:
+      - id: check-added-large-files
+      - id: fix-byte-order-marker
+      - id: check-case-conflict
+      - id: check-json
+      - id: check-yaml
+        exclude: ^.*meta\.yaml$
+  - repo: https://github.com/pre-commit/mirrors-clang-format
+    rev: v13.0.1
+    hooks:
+      - id: clang-format
+        types_or: [c++, c, c#, cuda, metal]
+  - repo: https://github.com/PyCQA/flake8
+    rev: 7.1.1
+    hooks:
+      - id: flake8
+        exclude: ^docs/.*|examples/.*|ffi/.*|versioneer.py$
+  - repo: https://github.com/jumanjihouse/pre-commit-hook-yamlfmt
+    rev: 0.2.3
+    hooks:
+      - id: yamlfmt
+        args: [--mapping, '2', --offset, '2', --sequence, '4', --implicit_start]
+        files: .pre-commit-config.yaml$
+  - repo: https://github.com/python-jsonschema/check-jsonschema
+    rev: 0.31.1
+    hooks:
+      - id: check-azure-pipelines
+      - id: check-github-workflows
+      - id: check-renovate
+  - repo: https://github.com/rhysd/actionlint
+    rev: v1.7.7
+    hooks:
+      - id: actionlint
+  - repo: meta
+    hooks:
+      - id: check-hooks-apply
+      - id: check-useless-excludes

--- a/renovate.json
+++ b/renovate.json
@@ -3,5 +3,8 @@
   "extends": [
     "config:recommended"
   ],
+  "pre-commit": {
+    "enabled": true
+  },
   "ignorePaths": ["docs/rtd-requirements.txt"]
 }

--- a/run_coverage.py
+++ b/run_coverage.py
@@ -6,7 +6,6 @@ an HTML report in "htmlcov".
 
 import os
 import shutil
-import sys
 
 try:
     import coverage

--- a/runtests.py
+++ b/runtests.py
@@ -1,7 +1,5 @@
 #!/usr/bin/env python
 
-import sys
-
 from llvmlite.tests import main
 
 

--- a/setup.py
+++ b/setup.py
@@ -21,6 +21,8 @@ from distutils.spawn import spawn
 import os
 import sys
 
+import versioneer
+
 
 min_python_version = (3, 10)
 
@@ -41,9 +43,6 @@ def _guard_py_ver():
 
 
 _guard_py_ver()
-
-
-import versioneer
 
 versioneer.VCS = 'git'
 versioneer.versionfile_source = 'llvmlite/_version.py'


### PR DESCRIPTION
While working on the Github Action workflow https://github.com/numba/llvmlite/pull/1144 I was relying on a local extended .pre-commit-config.yaml that I now share / propose for addition to the repo:
* Add actionlint hook which does lots of schema checking + shellcheck-ing (!) action step code
* Add check-jsonschema for pure schema checking of workflows and more
* Reducing the clang-format hook to `types_or: [c++, c, c#, cuda, metal]` as it would otherwise also format json files with lots of diff for the repo
* Adding flake8 hook: checks everything that is not excluded... so it includes new files to `./buildscripts/*` :)
* Fixed some .py file lints of files in the repo-root that are now not excluded anymore
* Adding yamlfmt to format the updated .pre-commit-config.yaml (applying to whole repo would be lots of noise)
* Adding the general pre-commit-hooks for json/yaml validation and more
* Adding the meta hooks for pre-commit hygiene
* Updated the renovate.json so that renovate also updates the pre-commit hooks

The config currently cleanly applies (via `pre-commit run -a -v`) to the whole repo (in under 5 seconds!) and was of great help while working on https://github.com/numba/llvmlite/pull/1144

I can also add a Github Workflow that runs pre-commit etc if there is greater interest from the team.