### PR TITLE
Make pre-commit super fast via caching + avoiding updating miniconda

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -10,19 +10,24 @@ on:
 
 jobs:
   pre-commit:
-    runs-on: ubuntu-latest
-    defaults:
-      run:
-        shell: bash -el {0}
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - name: Setup Miniconda
-        uses: conda-incubator/setup-miniconda@v3
-        with:
-          auto-update-conda: true
-          auto-activate-base: false
       - name: Install pre-commit
-        run: conda install -c conda-forge pre-commit
+        run: |
+          source "${CONDA}/etc/profile.d/conda.sh"
+          # avoid future conflicts with base environment
+          conda create --name pre-commit -c conda-forge pre-commit
+          conda activate pre-commit
+          echo "versions='$(python --version)-$(pre-commit --version)'" | tee -a "${GITHUB_ENV}"
+      # inspired by https://github.com/pre-commit/action/blob/main/action.yml
+      - uses: actions/cache@v4
+        with:
+          path: ~/.cache/pre-commit
+          key: pre-commit|${{ env.versions }}|${{ hashFiles('.pre-commit-config.yaml') }}
       - name: Lint code with pre-commit
-        run: pre-commit run --verbose --all-files
+        run: |
+          source "${CONDA}/etc/profile.d/conda.sh"
+          conda activate pre-commit
+          pre-commit run --verbose --all-files --show-diff-on-failure --color=always

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,6 +13,11 @@ repos:
     hooks:
       - id: clang-format
         types_or: [c++, c, c#, cuda, metal]
+  - repo: https://github.com/psf/black-pre-commit-mirror
+    rev: 25.1.0
+    hooks:
+      - id: black
+        files: buildscripts/.*\.py$
   - repo: https://github.com/PyCQA/flake8
     rev: 7.1.1
     hooks:


### PR DESCRIPTION
pre-commit spends most of its time setting up the hooks (=cloning their repos and installing each hook into its own virtual env).

Caching helps to give faster feedback (~30 secs vs 73 secs before) on new PRs. And it protects against rate limit issues in situations of many fast PR updates as every hook is a repo that is cloned. The cache invalidates when the python version, pre-commit version or pre-commit config changes.

Also avoiding the setup-miniconda action as that anyways uses the miniconda already present on the runners to save time.

Also adding black hook to pre-commit and limit to buildscripts.

Note: This uses https://github.com/psf/black-pre-commit-mirror and not https://github.com/psf/black to avoid cloning the entire black repo (=faster).