### PR TITLE
Drop binding layer typed pointer support.

### DIFF
--- a/ffi/build.py
+++ b/ffi/build.py
@@ -188,13 +188,8 @@ def main_posix(kind, library_ext):
     else:
         (version, _) = out.split('.', 1)
         version = int(version)
-        if version == 16:
-            msg = ("Building with LLVM 16; note that LLVM 16 support is "
-                   "presently experimental")
-            show_warning(msg)
-        elif version != 15:
-
-            msg = ("Building llvmlite requires LLVM 15, got "
+        if version not in (15, 16):
+            msg = ("Building llvmlite requires LLVM 15 or 16, got "
                    "{!r}. Be sure to set LLVM_CONFIG to the right executable "
                    "path.\nRead the documentation at "
                    "http://llvmlite.pydata.org/ for more information about "

--- a/ffi/build.py
+++ b/ffi/build.py
@@ -188,8 +188,13 @@ def main_posix(kind, library_ext):
     else:
         (version, _) = out.split('.', 1)
         version = int(version)
-        if version not in (15, 16):
-            msg = ("Building llvmlite requires LLVM 15 or 16, got "
+        if version == 16:
+            msg = ("Building with LLVM 16; note that LLVM 16 support is "
+                   "presently experimental")
+            show_warning(msg)
+        elif version != 15:
+
+            msg = ("Building llvmlite requires LLVM 15, got "
                    "{!r}. Be sure to set LLVM_CONFIG to the right executable "
                    "path.\nRead the documentation at "
                    "http://llvmlite.pydata.org/ for more information about "

--- a/ffi/core.cpp
+++ b/ffi/core.cpp
@@ -23,12 +23,16 @@ LLVMPY_DisposeString(const char *msg) { free(const_cast<char *>(msg)); }
 API_EXPORT(LLVMContextRef)
 LLVMPY_GetGlobalContext() {
     auto context = LLVMGetGlobalContext();
+    // FIXME: Remove with LLVM >= 17.
+    LLVMContextSetOpaquePointers(context, true);
     return context;
 }
 
 API_EXPORT(LLVMContextRef)
 LLVMPY_ContextCreate() {
     LLVMContextRef context = LLVMContextCreate();
+    // FIXME: Remove with LLVM >= 17.
+    LLVMContextSetOpaquePointers(context, true);
     return context;
 }
 

--- a/ffi/core.cpp
+++ b/ffi/core.cpp
@@ -20,19 +20,15 @@ LLVMPY_CreateByteString(const char *buf, size_t len) {
 API_EXPORT(void)
 LLVMPY_DisposeString(const char *msg) { free(const_cast<char *>(msg)); }
 
-// FIXME: Remove `enableOpaquePointers' once typed pointers are removed.
 API_EXPORT(LLVMContextRef)
-LLVMPY_GetGlobalContext(bool enableOpaquePointers) {
+LLVMPY_GetGlobalContext() {
     auto context = LLVMGetGlobalContext();
-    LLVMContextSetOpaquePointers(context, enableOpaquePointers);
     return context;
 }
 
-// FIXME: Remove `enableOpaquePointers' once typed pointers are removed.
 API_EXPORT(LLVMContextRef)
-LLVMPY_ContextCreate(bool enableOpaquePointers) {
+LLVMPY_ContextCreate() {
     LLVMContextRef context = LLVMContextCreate();
-    LLVMContextSetOpaquePointers(context, enableOpaquePointers);
     return context;
 }
 

--- a/ffi/core.h
+++ b/ffi/core.h
@@ -31,13 +31,11 @@ LLVMPY_CreateByteString(const char *buf, size_t len);
 API_EXPORT(void)
 LLVMPY_DisposeString(const char *msg);
 
-// FIXME: Remove `enableOpaquePointers' once typed pointers are removed.
 API_EXPORT(LLVMContextRef)
-LLVMPY_GetGlobalContext(bool enableOpaquePointers);
+LLVMPY_GetGlobalContext();
 
-// FIXME: Remove `enableOpaquePointers' once typed pointers are removed.
 API_EXPORT(LLVMContextRef)
-LLVMPY_ContextCreate(bool enableOpaquePointers);
+LLVMPY_ContextCreate();
 
 } /* end extern "C" */
 

--- a/ffi/targets.cpp
+++ b/ffi/targets.cpp
@@ -121,26 +121,6 @@ LLVMPY_ABIAlignmentOfType(LLVMTargetDataRef TD, LLVMTypeRef Ty) {
     return (long long)LLVMABIAlignmentOfType(TD, Ty);
 }
 
-// FIXME: Remove me once typed pointers are no longer supported.
-API_EXPORT(long long)
-LLVMPY_ABISizeOfElementType(LLVMTargetDataRef TD, LLVMTypeRef Ty) {
-    llvm::Type *tp = llvm::unwrap(Ty);
-    if (!tp->isPointerTy())
-        return -1;
-    tp = tp->getPointerElementType();
-    return (long long)LLVMABISizeOfType(TD, llvm::wrap(tp));
-}
-
-// FIXME: Remove me once typed pointers are no longer supported.
-API_EXPORT(long long)
-LLVMPY_ABIAlignmentOfElementType(LLVMTargetDataRef TD, LLVMTypeRef Ty) {
-    llvm::Type *tp = llvm::unwrap(Ty);
-    if (!tp->isPointerTy())
-        return -1;
-    tp = tp->getPointerElementType();
-    return (long long)LLVMABIAlignmentOfType(TD, llvm::wrap(tp));
-}
-
 API_EXPORT(LLVMTargetRef)
 LLVMPY_GetTargetFromTriple(const char *Triple, const char **ErrOut) {
     char *ErrorMessage;

--- a/ffi/type.cpp
+++ b/ffi/type.cpp
@@ -144,22 +144,7 @@ API_EXPORT(uint64_t)
 LLVMPY_GetTypeBitWidth(LLVMTypeRef type) {
     llvm::Type *unwrapped = llvm::unwrap(type);
     auto size = unwrapped->getPrimitiveSizeInBits();
-    return size.getFixedSize();
-}
-
-// FIXME: Remove me once typed pointers support is removed.
-API_EXPORT(LLVMTypeRef)
-LLVMPY_GetElementType(LLVMTypeRef type) {
-    llvm::Type *unwrapped = llvm::unwrap(type);
-    llvm::PointerType *ty = llvm::dyn_cast<llvm::PointerType>(unwrapped);
-    if (ty != nullptr) {
-#if LLVM_VERSION_MAJOR < 14
-        return llvm::wrap(ty->getElementType());
-#else
-        return llvm::wrap(ty->getPointerElementType());
-#endif
-    }
-    return nullptr;
+    return size.getFixedValue();
 }
 
 API_EXPORT(LLVMTypeRef)

--- a/llvmlite/__init__.py
+++ b/llvmlite/__init__.py
@@ -2,9 +2,6 @@ from ._version import get_versions
 __version__ = get_versions()['version']
 del get_versions
 
-# FIXME: Remove me once typed pointers are no longer supported.
-# Opaque pointers unconditionally required for later LLVM versions
-opaque_pointers_enabled = True
 # We default to IR layer typed pointers being enabled, since they're needed in
 # the most common usage scenarios with later LLVMs.
 def _ir_layer_typed_pointers_enabled():

--- a/llvmlite/binding/context.py
+++ b/llvmlite/binding/context.py
@@ -1,18 +1,14 @@
 from llvmlite.binding import ffi
 
-# FIXME: Remove me once typed pointers are no longer supported.
-from llvmlite import opaque_pointers_enabled
-from ctypes import c_bool
-
 
 def create_context():
     return ContextRef(
-        ffi.lib.LLVMPY_ContextCreate(opaque_pointers_enabled))
+        ffi.lib.LLVMPY_ContextCreate())
 
 
 def get_global_context():
     return GlobalContextRef(
-        ffi.lib.LLVMPY_GetGlobalContext(opaque_pointers_enabled))
+        ffi.lib.LLVMPY_GetGlobalContext())
 
 
 class ContextRef(ffi.ObjectRef):
@@ -28,12 +24,8 @@ class GlobalContextRef(ContextRef):
         pass
 
 
-# FIXME: Remove argtypes once typed pointers are no longer supported.
-ffi.lib.LLVMPY_GetGlobalContext.argtypes = [c_bool]
 ffi.lib.LLVMPY_GetGlobalContext.restype = ffi.LLVMContextRef
 
-# FIXME: Remove argtypes once typed pointers are no longer supported.
-ffi.lib.LLVMPY_ContextCreate.argtypes = [c_bool]
 ffi.lib.LLVMPY_ContextCreate.restype = ffi.LLVMContextRef
 
 ffi.lib.LLVMPY_ContextDispose.argtypes = [ffi.LLVMContextRef]

--- a/llvmlite/binding/targets.py
+++ b/llvmlite/binding/targets.py
@@ -7,10 +7,6 @@ from llvmlite.binding.initfini import llvm_version_info
 from llvmlite.binding.common import _decode_string, _encode_string
 from collections import namedtuple
 
-# FIXME: Remove `opaque_pointers_enabled` once typed pointers are no longer
-# supported.
-from llvmlite import opaque_pointers_enabled
-
 Triple = namedtuple('Triple', ['Arch', 'SubArch', 'Vendor',
                                'OS', 'Env', 'ObjectFormat'])
 
@@ -201,30 +197,6 @@ class TargetData(ffi.ObjectRef):
         Get minimum ABI alignment of LLVM type *ty*.
         """
         return ffi.lib.LLVMPY_ABIAlignmentOfType(self, ty)
-
-    def get_pointee_abi_size(self, ty):
-        """
-        Get ABI size of pointee type of LLVM pointer type *ty*.
-        """
-        if opaque_pointers_enabled:
-            raise RuntimeError("Cannot get pointee type in opaque pointer "
-                               "mode.")
-        size = ffi.lib.LLVMPY_ABISizeOfElementType(self, ty)
-        if size == -1:
-            raise RuntimeError("Not a pointer type: %s" % (ty,))
-        return size
-
-    def get_pointee_abi_alignment(self, ty):
-        """
-        Get minimum ABI alignment of pointee type of LLVM pointer type *ty*.
-        """
-        if opaque_pointers_enabled:
-            raise RuntimeError("Cannot get pointee type in opaque pointer "
-                               "mode.")
-        size = ffi.lib.LLVMPY_ABIAlignmentOfElementType(self, ty)
-        if size == -1:
-            raise RuntimeError("Not a pointer type: %s" % (ty,))
-        return size
 
 
 RELOC = frozenset(['default', 'static', 'pic', 'dynamicnopic'])
@@ -439,16 +411,6 @@ ffi.lib.LLVMPY_OffsetOfElement.restype = c_longlong
 ffi.lib.LLVMPY_ABIAlignmentOfType.argtypes = [ffi.LLVMTargetDataRef,
                                               ffi.LLVMTypeRef]
 ffi.lib.LLVMPY_ABIAlignmentOfType.restype = c_longlong
-
-# FIXME: Remove me once typed pointers are no longer supported.
-ffi.lib.LLVMPY_ABISizeOfElementType.argtypes = [ffi.LLVMTargetDataRef,
-                                                ffi.LLVMTypeRef]
-ffi.lib.LLVMPY_ABISizeOfElementType.restype = c_longlong
-
-# FIXME: Remove me once typed pointers are no longer supported.
-ffi.lib.LLVMPY_ABIAlignmentOfElementType.argtypes = [ffi.LLVMTargetDataRef,
-                                                     ffi.LLVMTypeRef]
-ffi.lib.LLVMPY_ABIAlignmentOfElementType.restype = c_longlong
 
 ffi.lib.LLVMPY_GetTargetFromTriple.argtypes = [c_char_p, POINTER(c_char_p)]
 ffi.lib.LLVMPY_GetTargetFromTriple.restype = ffi.LLVMTargetRef

--- a/llvmlite/binding/typeref.py
+++ b/llvmlite/binding/typeref.py
@@ -4,9 +4,6 @@ import enum
 from llvmlite import ir
 from llvmlite.binding import ffi
 
-# FIXME: Remove `opaque_pointers_enabled' when TP's are removed.
-from llvmlite import opaque_pointers_enabled
-
 
 class TypeKind(enum.IntEnum):
     # The LLVMTypeKind enum from llvm-c/Core.h
@@ -108,7 +105,7 @@ class TypeRef(ffi.ObjectRef):
         """
         Returns iterator over enclosing types
         """
-        if self.is_pointer and opaque_pointers_enabled:
+        if self.is_pointer:
             raise ValueError("Type {} doesn't contain elements.".format(self))
         return _TypeListIterator(ffi.lib.LLVMPY_ElementIter(self))
 
@@ -225,10 +222,6 @@ class _TypeListIterator(_TypeIterator):
 
 ffi.lib.LLVMPY_PrintType.argtypes = [ffi.LLVMTypeRef]
 ffi.lib.LLVMPY_PrintType.restype = c_void_p
-
-# FIXME: Remove me once typed pointers support is removed.
-ffi.lib.LLVMPY_GetElementType.argtypes = [ffi.LLVMTypeRef]
-ffi.lib.LLVMPY_GetElementType.restype = ffi.LLVMTypeRef
 
 ffi.lib.LLVMPY_TypeIsPointer.argtypes = [ffi.LLVMTypeRef]
 ffi.lib.LLVMPY_TypeIsPointer.restype = c_bool

--- a/llvmlite/ir/types.py
+++ b/llvmlite/ir/types.py
@@ -193,7 +193,9 @@ class _TypedPointerType(PointerType):
 
     @property
     def intrinsic_name(self):
-        return 'p%d%s' % (self.addrspace, self.pointee.intrinsic_name)
+        if ir_layer_typed_pointers_enabled:
+            return 'p%d%s' % (self.addrspace, self.pointee.intrinsic_name)
+        return super(_TypedPointerType, self).intrinsic_name
 
 
 class VoidType(Type):

--- a/llvmlite/tests/test_binding.py
+++ b/llvmlite/tests/test_binding.py
@@ -18,9 +18,6 @@ from llvmlite import binding as llvm
 from llvmlite.binding import ffi
 from llvmlite.tests import TestCase
 
-# FIXME: Remove me once typed pointers are no longer supported.
-from llvmlite import opaque_pointers_enabled
-
 # arvm7l needs extra ABI symbols to link successfully
 if platform.machine() == 'armv7l':
     llvm.load_library_permanently('libgcc_s.so.1')
@@ -1655,12 +1652,7 @@ class TestValueRef(BaseTest):
         mod = self.module()
         st = mod.get_global_variable("glob_struct")
         self.assertTrue(st.type.is_pointer)
-        # FIXME: Remove `else' once TP are no longer supported.
-        if opaque_pointers_enabled:
-            self.assertIsNotNone(re.match(r'ptr', str(st.type)))
-        else:
-            self.assertIsNotNone(re.match(r'%struct\.glob_type(\.[\d]+)?\*',
-                                          str(st.type)))
+        self.assertIsNotNone(re.match(r'ptr', str(st.type)))
         self.assertIsNotNone(re.match(
             r"%struct\.glob_type(\.[\d]+)? = type { i64, \[2 x i64\] }",
             str(st.global_value_type)))
@@ -1849,11 +1841,7 @@ class TestValueRef(BaseTest):
         inst = list(list(func.blocks)[0].instructions)[0]
         arg = list(inst.operands)[0]
         self.assertTrue(arg.is_constant)
-        # FIXME: Remove `else' once TP are no longer supported.
-        if opaque_pointers_enabled:
-            self.assertEqual(arg.get_constant_value(), 'ptr null')
-        else:
-            self.assertEqual(arg.get_constant_value(), 'i64* null')
+        self.assertEqual(arg.get_constant_value(), 'ptr null')
 
     def test_incoming_phi_blocks(self):
         mod = self.module(asm_phi_blocks)
@@ -1958,12 +1946,7 @@ class TestTypeRef(BaseTest):
         self.assertTrue(func.type.is_pointer)
         with self.assertRaises(ValueError) as raises:
             func.type.is_function_vararg
-        # FIXME: Remove `else' once TP are no longer supported.
-        if opaque_pointers_enabled:
-            self.assertIn("Type ptr is not a function", str(raises.exception))
-        else:
-            self.assertIn("Type i32 (i32, i32)* is not a function",
-                          str(raises.exception))
+        self.assertIn("Type ptr is not a function", str(raises.exception))
 
     def test_function_typeref_as_ir(self):
         mod = self.module()

--- a/llvmlite/tests/test_ir.py
+++ b/llvmlite/tests/test_ir.py
@@ -281,9 +281,9 @@ class TestFunction(TestBase):
             declare double @"llvm.powi.f64"(double %".1", i32 %".2")""")
         if not ir_layer_typed_pointers_enabled:
             self.check_descr(self.descr(memset).strip(), """\
-                declare void @"llvm.memset.p0i8.i32"(ptr %".1", i8 %".2", i32 %".3", i1 %".4")""")  # noqa E501
+                declare void @"llvm.memset.p0.i32"(ptr %".1", i8 %".2", i32 %".3", i1 %".4")""")  # noqa E501
             self.check_descr(self.descr(memcpy).strip(), """\
-                declare void @"llvm.memcpy.p0i8.p0i8.i32"(ptr %".1", ptr %".2", i32 %".3", i1 %".4")""")  # noqa E501
+                declare void @"llvm.memcpy.p0.p0.i32"(ptr %".1", ptr %".2", i32 %".3", i1 %".4")""")  # noqa E501
         else:
             self.check_descr(self.descr(memset).strip(), """\
                 declare void @"llvm.memset.p0i8.i32"(i8* %".1", i8 %".2", i32 %".3", i1 %".4")""")  # noqa E501
@@ -2451,9 +2451,12 @@ class TestTypes(TestBase):
     def test_ptr_intrinsic_name(self):
         self.assertEqual(ir.PointerType().intrinsic_name, 'p0')
         self.assertEqual(ir.PointerType(addrspace=1).intrinsic_name, 'p1')
-        # Note: Should this be adjusted based on the pointer mode?
-        self.assertEqual(ir.PointerType(int1).intrinsic_name, 'p0i1')
-        self.assertEqual(ir.PointerType(int1, 1).intrinsic_name, 'p1i1')
+        if not ir_layer_typed_pointers_enabled:
+            self.assertEqual(ir.PointerType(int1).intrinsic_name, 'p0')
+            self.assertEqual(ir.PointerType(int1, 1).intrinsic_name, 'p1')
+        else:
+            self.assertEqual(ir.PointerType(int1).intrinsic_name, 'p0i1')
+            self.assertEqual(ir.PointerType(int1, 1).intrinsic_name, 'p1i1')
 
     def test_str(self):
         """

--- a/llvmlite/tests/test_refprune.py
+++ b/llvmlite/tests/test_refprune.py
@@ -7,9 +7,6 @@ import llvmlite.tests.refprune_proto as proto
 
 # TODO:: Get rid of Legacy tests once completely transitioned to NewPassManager
 
-# FIXME: Remove me once typed pointers are no longer supported.
-from llvmlite import opaque_pointers_enabled
-
 
 def _iterate_cases(generate_test):
     def wrap(fn):
@@ -259,21 +256,13 @@ define void @main(i8* %ptr) {
         mod, stats = self.check(self.per_bb_ir_2)
         self.assertEqual(stats.basicblock, 4)
         # not pruned
-        # FIXME: Remove `else' once TP are no longer supported.
-        if opaque_pointers_enabled:
-            self.assertIn("call void @NRT_incref(ptr %ptr)", str(mod))
-        else:
-            self.assertIn("call void @NRT_incref(i8* %ptr)", str(mod))
+        self.assertIn("call void @NRT_incref(ptr %ptr)", str(mod))
 
     def test_per_bb_2_legacy(self):
         mod, stats = self.check_legacy(self.per_bb_ir_2)
         self.assertEqual(stats.basicblock, 4)
         # not pruned
-        # FIXME: Remove `else' once TP are no longer supported.
-        if opaque_pointers_enabled:
-            self.assertIn("call void @NRT_incref(ptr %ptr)", str(mod))
-        else:
-            self.assertIn("call void @NRT_incref(i8* %ptr)", str(mod))
+        self.assertIn("call void @NRT_incref(ptr %ptr)", str(mod))
 
     per_bb_ir_3 = r"""
 define void @main(ptr %ptr, ptr %other) {
@@ -283,35 +272,19 @@ define void @main(ptr %ptr, ptr %other) {
     call void @NRT_decref(ptr %other)
     ret void
 }
-""" if opaque_pointers_enabled else r"""
-define void @main(i8* %ptr, i8* %other) {
-    call void @NRT_incref(i8* %ptr)
-    call void @NRT_incref(i8* %ptr)
-    call void @NRT_decref(i8* %ptr)
-    call void @NRT_decref(i8* %other)
-    ret void
-}
 """
 
     def test_per_bb_3(self):
         mod, stats = self.check(self.per_bb_ir_3)
         self.assertEqual(stats.basicblock, 2)
         # not pruned
-        # FIXME: Remove `else' once TP are no longer supported.
-        if opaque_pointers_enabled:
-            self.assertIn("call void @NRT_decref(ptr %other)", str(mod))
-        else:
-            self.assertIn("call void @NRT_decref(i8* %other)", str(mod))
+        self.assertIn("call void @NRT_decref(ptr %other)", str(mod))
 
     def test_per_bb_3_legacy(self):
         mod, stats = self.check_legacy(self.per_bb_ir_3)
         self.assertEqual(stats.basicblock, 2)
         # not pruned
-        # FIXME: Remove `else' once TP are no longer supported.
-        if opaque_pointers_enabled:
-            self.assertIn("call void @NRT_decref(ptr %other)", str(mod))
-        else:
-            self.assertIn("call void @NRT_decref(i8* %other)", str(mod))
+        self.assertIn("call void @NRT_decref(ptr %other)", str(mod))
 
     per_bb_ir_4 = r"""
 ; reordered
@@ -323,37 +296,19 @@ define void @main(ptr %ptr, ptr %other) {
     call void @NRT_incref(ptr %ptr)
     ret void
 }
-""" if opaque_pointers_enabled else r"""
-; reordered
-define void @main(i8* %ptr, i8* %other) {
-    call void @NRT_incref(i8* %ptr)
-    call void @NRT_decref(i8* %ptr)
-    call void @NRT_decref(i8* %ptr)
-    call void @NRT_decref(i8* %other)
-    call void @NRT_incref(i8* %ptr)
-    ret void
-}
 """
 
     def test_per_bb_4(self):
         mod, stats = self.check(self.per_bb_ir_4)
         self.assertEqual(stats.basicblock, 4)
         # not pruned
-        # FIXME: Remove `else' once TP are no longer supported.
-        if opaque_pointers_enabled:
-            self.assertIn("call void @NRT_decref(ptr %other)", str(mod))
-        else:
-            self.assertIn("call void @NRT_decref(i8* %other)", str(mod))
+        self.assertIn("call void @NRT_decref(ptr %other)", str(mod))
 
     def test_per_bb_4_legacy(self):
         mod, stats = self.check_legacy(self.per_bb_ir_4)
         self.assertEqual(stats.basicblock, 4)
         # not pruned
-        # FIXME: Remove `else' once TP are no longer supported.
-        if opaque_pointers_enabled:
-            self.assertIn("call void @NRT_decref(ptr %other)", str(mod))
-        else:
-            self.assertIn("call void @NRT_decref(i8* %other)", str(mod))
+        self.assertIn("call void @NRT_decref(ptr %other)", str(mod))
 
 
 class TestDiamond(BaseTestByIR):


### PR DESCRIPTION
At the LLVM level, going forward typed pointers are no longer supported.

This patch removes typed pointer support from the LLVM binding layer.

Initially, it also attempted to bump the LLVM version used to LLVM 16, but due to unrelated reasons with Anaconda, it seems it's easier to do that separately as a follow-up patch.