### PR TITLE
Enable pass timings reporting with NewPassManager

### DIFF
--- a/docs/source/user-guide/binding/optimization-passes.rst
+++ b/docs/source/user-guide/binding/optimization-passes.rst
@@ -88,6 +88,14 @@ and module pass managers:
       Return a populated :class:`FunctionPassManager` object based on PTO
       settings.
 
+.. method:: start_pass_timing()
+
+      Enable the pass timers.
+
+.. method:: finish_pass_timing()
+
+      Returns a string containing the LLVM-generated timing report and disables
+      the pass timers.
 
 The :class:`ModulePassManager` and :class:`FunctionPassManager` classes
 implement the module and function pass managers:

--- a/docs/source/user-guide/binding/optimization-passes.rst
+++ b/docs/source/user-guide/binding/optimization-passes.rst
@@ -88,11 +88,11 @@ and module pass managers:
       Return a populated :class:`FunctionPassManager` object based on PTO
       settings.
 
-.. method:: start_pass_timing()
+   .. method:: start_pass_timing()
 
       Enable the pass timers.
 
-.. method:: finish_pass_timing()
+   .. method:: finish_pass_timing()
 
       Returns a string containing the LLVM-generated timing report and disables
       the pass timers.

--- a/docs/source/user-guide/binding/pass_timings.rst
+++ b/docs/source/user-guide/binding/pass_timings.rst
@@ -2,17 +2,19 @@
 Pass Timings
 ============
 
+.. currentmodule:: llvmlite.binding
+
 LLVM provides functionality to time optimization and analysis passes.
 
 New Pass Manager APIs
 =====================
 
-See :meth:`PassBuilder.start_pass_timing` and :meth:`PassBuilder.finish_pass_timing` in :doc:`optimization-passes`.
+See :meth:`PassBuilder.start_pass_timing` and
+:meth:`PassBuilder.finish_pass_timing` in :doc:`optimization-passes`.
 
 Legacy Pass Manager APIs
 ========================
 
-.. currentmodule:: llvmlite.binding
 
 .. function:: set_time_passes(enable)
 

--- a/docs/source/user-guide/binding/pass_timings.rst
+++ b/docs/source/user-guide/binding/pass_timings.rst
@@ -2,6 +2,16 @@
 Pass Timings
 ============
 
+LLVM provides functionality to time optimization and analysis passes.
+
+New Pass Manager APIs
+=====================
+
+See :meth:`PassBuilder.start_pass_timing` and :meth:`PassBuilder.finish_pass_timing` in :doc:`optimization-passes`.
+
+Legacy Pass Manager APIs
+========================
+
 .. currentmodule:: llvmlite.binding
 
 .. function:: set_time_passes(enable)

--- a/ffi/newpassmanagers.cpp
+++ b/ffi/newpassmanagers.cpp
@@ -339,7 +339,7 @@ LLVMPY_CreatePassBuilder(LLVMTargetMachineRef TMRef,
     TargetMachine *TM = llvm::unwrap(TMRef);
     PipelineTuningOptions *PTO = llvm::unwrap(PTORef);
     PassInstrumentationCallbacks *PIC = llvm::unwrap(PICRef);
-#if VERSION_MAJOR < 16
+#if LLVM_VERSION_MAJOR < 16
     return llvm::wrap(new PassBuilder(TM, *PTO, None, PIC));
 #else
     return llvm::wrap(new PassBuilder(TM, *PTO, std::nullopt, PIC));

--- a/ffi/newpassmanagers.cpp
+++ b/ffi/newpassmanagers.cpp
@@ -281,12 +281,23 @@ LLVMPY_DisposePipelineTuningOptions(LLVMPipelineTuningOptionsRef PTO) {
 
 // PB
 
+API_EXPORT(PassInstrumentationCallbacks *)
+LLVMPY_LLVMPassInstrumentationCallbacksCreate() {
+    return new PassInstrumentationCallbacks();
+}
+
+API_EXPORT(void)
+LLVMPY_LLVMPassInstrumentationCallbacksDispose(
+    PassInstrumentationCallbacks *PIC) {
+    delete PIC;
+}
+
 API_EXPORT(LLVMPassBuilderRef)
 LLVMPY_CreatePassBuilder(LLVMTargetMachineRef TM,
-                         LLVMPipelineTuningOptionsRef PTO) {
+                         LLVMPipelineTuningOptionsRef PTO,
+                         PassInstrumentationCallbacks *PIC) {
     TargetMachine *target = llvm::unwrap(TM);
     PipelineTuningOptions *pt = llvm::unwrap(PTO);
-    PassInstrumentationCallbacks *PIC = new PassInstrumentationCallbacks();
 #if LLVM_VERSION_MAJOR < 16
     return llvm::wrap(new PassBuilder(target, *pt, None, PIC));
 #else

--- a/ffi/newpassmanagers.cpp
+++ b/ffi/newpassmanagers.cpp
@@ -286,17 +286,19 @@ LLVMPY_DisposePipelineTuningOptions(LLVMPipelineTuningOptionsRef PTO) {
 // PB
 
 API_EXPORT(LLVMTimePassesHandlerRef)
-LLVMPY_CreateLLVMTimePassesHandler() {
-    return llvm::wrap(new TimePassesHandler(true));
+LLVMPY_CreateTimePassesHandler() {
+    bool enabled = true;
+    return llvm::wrap(new TimePassesHandler(enabled));
 }
 
 API_EXPORT(void)
-LLVMPY_DisposeLLVMTimePassesHandler(LLVMTimePassesHandlerRef TimePassesRef) {
+LLVMPY_DisposeTimePassesHandler(LLVMTimePassesHandlerRef TimePassesRef) {
     delete llvm::unwrap(TimePassesRef);
 }
 
 API_EXPORT(void)
-LLVMPY_SetTimePassesNPM(LLVMPassBuilderRef PBRef, LLVMTimePassesHandlerRef TimePassesRef) {
+LLVMPY_EnableTimePasses(LLVMPassBuilderRef PBRef,
+                        LLVMTimePassesHandlerRef TimePassesRef) {
     TimePassesHandler *TP = llvm::unwrap(TimePassesRef);
     TimePassesIsEnabled = true;
     PassBuilder *PB = llvm::unwrap(PBRef);
@@ -305,8 +307,8 @@ LLVMPY_SetTimePassesNPM(LLVMPassBuilderRef PBRef, LLVMTimePassesHandlerRef TimeP
 }
 
 API_EXPORT(void)
-LLVMPY_ReportAndResetTimingsNPM(LLVMTimePassesHandlerRef TimePassesRef,
-                                const char **outmsg) {
+LLVMPY_ReportAndDisableTimePasses(LLVMTimePassesHandlerRef TimePassesRef,
+                                  const char **outmsg) {
     std::string osbuf;
     raw_string_ostream os(osbuf);
     TimePassesHandler *TP = llvm::unwrap(TimePassesRef);

--- a/ffi/newpassmanagers.cpp
+++ b/ffi/newpassmanagers.cpp
@@ -315,7 +315,7 @@ API_EXPORT(void)
 LLVMPY_SetTimePassesNPM(LLVMTimePassesHandlerRef TimePasses,
                         LLVMPassInstrumentationCallbacksRef PIC) {
     TimePassesHandler *TP = llvm::unwrap(TimePasses);
-    TP->print();
+    TimePassesIsEnabled = true;
     TP->registerCallbacks(*llvm::unwrap(PIC));
 }
 
@@ -329,6 +329,7 @@ LLVMPY_ReportAndResetTimingsNPM(LLVMTimePassesHandlerRef TimePasses,
     TP->print();
     os.flush();
     *outmsg = LLVMPY_CreateString(os.str().c_str());
+    TimePassesIsEnabled = false;
 }
 
 API_EXPORT(LLVMPassBuilderRef)

--- a/ffi/newpassmanagers.cpp
+++ b/ffi/newpassmanagers.cpp
@@ -297,8 +297,8 @@ LLVMPY_LLVMPassInstrumentationCallbacksCreate() {
 
 API_EXPORT(void)
 LLVMPY_LLVMPassInstrumentationCallbacksDispose(
-    LLVMPassInstrumentationCallbacksRef PIC) {
-    delete llvm::unwrap(PIC);
+    LLVMPassInstrumentationCallbacksRef PICRef) {
+    delete llvm::unwrap(PICRef);
 }
 
 API_EXPORT(LLVMTimePassesHandlerRef)
@@ -307,24 +307,24 @@ LLVMPY_CreateLLVMTimePassesHandler() {
 }
 
 API_EXPORT(void)
-LLVMPY_DisposeLLVMTimePassesHandler(LLVMTimePassesHandlerRef TimePasses) {
-    delete llvm::unwrap(TimePasses);
+LLVMPY_DisposeLLVMTimePassesHandler(LLVMTimePassesHandlerRef TimePassesRef) {
+    delete llvm::unwrap(TimePassesRef);
 }
 
 API_EXPORT(void)
-LLVMPY_SetTimePassesNPM(LLVMTimePassesHandlerRef TimePasses,
-                        LLVMPassInstrumentationCallbacksRef PIC) {
-    TimePassesHandler *TP = llvm::unwrap(TimePasses);
+LLVMPY_SetTimePassesNPM(LLVMTimePassesHandlerRef TimePassesRef,
+                        LLVMPassInstrumentationCallbacksRef PICRef) {
+    TimePassesHandler *TP = llvm::unwrap(TimePassesRef);
     TimePassesIsEnabled = true;
-    TP->registerCallbacks(*llvm::unwrap(PIC));
+    TP->registerCallbacks(*llvm::unwrap(PICRef));
 }
 
 API_EXPORT(void)
-LLVMPY_ReportAndResetTimingsNPM(LLVMTimePassesHandlerRef TimePasses,
+LLVMPY_ReportAndResetTimingsNPM(LLVMTimePassesHandlerRef TimePassesRef,
                                 const char **outmsg) {
     std::string osbuf;
     raw_string_ostream os(osbuf);
-    TimePassesHandler *TP = llvm::unwrap(TimePasses);
+    TimePassesHandler *TP = llvm::unwrap(TimePassesRef);
     TP->setOutStream(os);
     TP->print();
     os.flush();
@@ -333,20 +333,23 @@ LLVMPY_ReportAndResetTimingsNPM(LLVMTimePassesHandlerRef TimePasses,
 }
 
 API_EXPORT(LLVMPassBuilderRef)
-LLVMPY_CreatePassBuilder(LLVMTargetMachineRef TM,
-                         LLVMPipelineTuningOptionsRef PTO,
-                         PassInstrumentationCallbacks *PIC) {
-    TargetMachine *target = llvm::unwrap(TM);
-    PipelineTuningOptions *pt = llvm::unwrap(PTO);
+LLVMPY_CreatePassBuilder(LLVMTargetMachineRef TMRef,
+                         LLVMPipelineTuningOptionsRef PTORef,
+                         LLVMPassInstrumentationCallbacksRef PICRef) {
+    TargetMachine *TM = llvm::unwrap(TMRef);
+    PipelineTuningOptions *PTO = llvm::unwrap(PTORef);
+    PassInstrumentationCallbacks *PIC = llvm::unwrap(PICRef);
 #if VERSION_MAJOR < 16
-    return llvm::wrap(new PassBuilder(target, *pt, None, PIC));
+    return llvm::wrap(new PassBuilder(TM, *PTO, None, PIC));
 #else
-    return llvm::wrap(new PassBuilder(target, *pt, std::nullopt, PIC));
+    return llvm::wrap(new PassBuilder(TM, *PTO, std::nullopt, PIC));
 #endif
 }
 
 API_EXPORT(void)
-LLVMPY_DisposePassBuilder(LLVMPassBuilderRef PB) { delete llvm::unwrap(PB); }
+LLVMPY_DisposePassBuilder(LLVMPassBuilderRef PBRef) {
+    delete llvm::unwrap(PBRef);
+}
 
 static OptimizationLevel mapLevel(int speed_level, int size_level) {
     switch (size_level) {

--- a/llvmlite/binding/ffi.py
+++ b/llvmlite/binding/ffi.py
@@ -40,6 +40,7 @@ LLVMObjectFileRef = _make_opaque_ref("LLVMObjectFile")
 LLVMSectionIteratorRef = _make_opaque_ref("LLVMSectionIterator")
 LLVMOrcLLJITRef = _make_opaque_ref("LLVMOrcLLJITRef")
 LLVMOrcDylibTrackerRef = _make_opaque_ref("LLVMOrcDylibTrackerRef")
+LLVMPassInstrumentationCallbacks = _make_opaque_ref("LLVMPassInstrumentationCallbacks")
 
 LLVMPipelineTuningOptionsRef = _make_opaque_ref("LLVMPipeLineTuningOptions")
 LLVMModulePassManagerRef = _make_opaque_ref("LLVMModulePassManager")

--- a/llvmlite/binding/ffi.py
+++ b/llvmlite/binding/ffi.py
@@ -40,8 +40,6 @@ LLVMObjectFileRef = _make_opaque_ref("LLVMObjectFile")
 LLVMSectionIteratorRef = _make_opaque_ref("LLVMSectionIterator")
 LLVMOrcLLJITRef = _make_opaque_ref("LLVMOrcLLJITRef")
 LLVMOrcDylibTrackerRef = _make_opaque_ref("LLVMOrcDylibTrackerRef")
-LLVMPassInstrumentationCallbacksRef = \
-    _make_opaque_ref("LLVMPassInstrumentationCallbacks")
 LLVMTimePassesHandlerRef = _make_opaque_ref("LLVMTimePassesHandler")
 LLVMPipelineTuningOptionsRef = _make_opaque_ref("LLVMPipeLineTuningOptions")
 LLVMModulePassManagerRef = _make_opaque_ref("LLVMModulePassManager")

--- a/llvmlite/binding/ffi.py
+++ b/llvmlite/binding/ffi.py
@@ -40,8 +40,9 @@ LLVMObjectFileRef = _make_opaque_ref("LLVMObjectFile")
 LLVMSectionIteratorRef = _make_opaque_ref("LLVMSectionIterator")
 LLVMOrcLLJITRef = _make_opaque_ref("LLVMOrcLLJITRef")
 LLVMOrcDylibTrackerRef = _make_opaque_ref("LLVMOrcDylibTrackerRef")
-LLVMPassInstrumentationCallbacks = _make_opaque_ref("LLVMPassInstrumentationCallbacks")
-
+LLVMPassInstrumentationCallbacksRef = \
+    _make_opaque_ref("LLVMPassInstrumentationCallbacks")
+LLVMTimePassesHandlerRef = _make_opaque_ref("LLVMTimePassesHandler")
 LLVMPipelineTuningOptionsRef = _make_opaque_ref("LLVMPipeLineTuningOptions")
 LLVMModulePassManagerRef = _make_opaque_ref("LLVMModulePassManager")
 LLVMFunctionPassManagerRef = _make_opaque_ref("LLVMFunctionPassManager")

--- a/llvmlite/binding/newpassmanagers.py
+++ b/llvmlite/binding/newpassmanagers.py
@@ -208,32 +208,19 @@ class PipelineTuningOptions(ffi.ObjectRef):
         ffi.lib.LLVMPY_DisposePipelineTuningOptions(self)
 
 
-class TimePassesHandler(ffi.ObjectRef):
-    def __init__(self):
-        super().__init__(ffi.lib.LLVMPY_CreateLLVMTimePassesHandler())
-
-    def _dispose(self):
-        ffi.lib.LLVMPY_DisposeLLVMTimePassesHandler(self)
-
-
-class PassInstrumentationCallbacks(ffi.ObjectRef):
-    def __init__(self):
-        super().__init__(
-            ffi.lib.LLVMPY_LLVMPassInstrumentationCallbacksCreate()
-        )
-
-    def _dispose(self):
-        ffi.lib.LLVMPY_LLVMPassInstrumentationCallbacksDispose(self)
-
-
 class PassBuilder(ffi.ObjectRef):
+    class TimePassesHandler(ffi.ObjectRef):
+        def __init__(self):
+            super().__init__(ffi.lib.LLVMPY_CreateLLVMTimePassesHandler())
+
+        def _dispose(self):
+            ffi.lib.LLVMPY_DisposeLLVMTimePassesHandler(self)
 
     def __init__(self, tm, pto):
-        self._pic = PassInstrumentationCallbacks()
-        self._time_passes = TimePassesHandler()
-        super().__init__(ffi.lib.LLVMPY_CreatePassBuilder(tm, pto, self._pic))
+        super().__init__(ffi.lib.LLVMPY_CreatePassBuilder(tm, pto))
         self._pto = pto
         self._tm = tm
+        self._time_passes = self.TimePassesHandler()
 
     def getModulePassManager(self):
         return ModulePassManager(
@@ -250,7 +237,7 @@ class PassBuilder(ffi.ObjectRef):
     def set_time_passes(self):
         """Enable the pass timers.
         """
-        ffi.lib.LLVMPY_SetTimePassesNPM(self._time_passes, self._pic)
+        ffi.lib.LLVMPY_SetTimePassesNPM(self, self._time_passes)
 
     def report_and_reset_timings(self):
         """Returns the pass timings report and resets the LLVM internal timers.
@@ -380,7 +367,6 @@ ffi.lib.LLVMPY_CreatePassBuilder.restype = ffi.LLVMPassBuilderRef
 ffi.lib.LLVMPY_CreatePassBuilder.argtypes = [
     ffi.LLVMTargetMachineRef,
     ffi.LLVMPipelineTuningOptionsRef,
-    ffi.LLVMPassInstrumentationCallbacksRef,
 ]
 
 ffi.lib.LLVMPY_DisposePassBuilder.argtypes = [ffi.LLVMPassBuilderRef,]
@@ -392,22 +378,14 @@ ffi.lib.LLVMPY_DisposeLLVMTimePassesHandler.argtypes = [
     ffi.LLVMTimePassesHandlerRef,]
 
 ffi.lib.LLVMPY_SetTimePassesNPM.argtypes = [
+    ffi.LLVMPassBuilderRef,
     ffi.LLVMTimePassesHandlerRef,
-    ffi.LLVMPassInstrumentationCallbacksRef,
 ]
 
 ffi.lib.LLVMPY_ReportAndResetTimingsNPM.argtypes = [
     ffi.LLVMTimePassesHandlerRef,
     POINTER(c_char_p),
 ]
-
-ffi.lib.LLVMPY_LLVMPassInstrumentationCallbacksCreate.restype = (
-    ffi.LLVMPassInstrumentationCallbacksRef
-)
-
-ffi.lib.LLVMPY_LLVMPassInstrumentationCallbacksDispose.argtypes = (
-    ffi.LLVMPassInstrumentationCallbacksRef,
-)
 
 # Pipeline builders
 

--- a/llvmlite/binding/newpassmanagers.py
+++ b/llvmlite/binding/newpassmanagers.py
@@ -247,13 +247,8 @@ class PassBuilder(ffi.ObjectRef):
                 self, self._pto.speed_level, self._pto.size_level)
         )
 
-    def set_time_passes(self, enable):
-        """Enable or disable the pass timers.
-        Parameters
-        ----------
-        enable : bool
-            Set to True to enable the pass timers.
-            Set to False to disable the pass timers.
+    def set_time_passes(self):
+        """Enable the pass timers.
         """
         ffi.lib.LLVMPY_SetTimePassesNPM(self._time_passes, self._pic)
 

--- a/llvmlite/binding/newpassmanagers.py
+++ b/llvmlite/binding/newpassmanagers.py
@@ -207,11 +207,18 @@ class PipelineTuningOptions(ffi.ObjectRef):
     def _dispose(self):
         ffi.lib.LLVMPY_DisposePipelineTuningOptions(self)
 
+class PassInstrumentationCallbacks(ffi.ObjectRef):
+    def __init__(self):
+        super().__init__(ffi.lib.LLVMPY_LLVMPassInstrumentationCallbacksCreate())
+
+    def _dispose(self):
+        ffi.lib.LLVMPY_LLVMPassInstrumentationCallbacksDispose(self)
 
 class PassBuilder(ffi.ObjectRef):
 
     def __init__(self, tm, pto):
-        super().__init__(ffi.lib.LLVMPY_CreatePassBuilder(tm, pto))
+        self._pic = PassInstrumentationCallbacks()
+        super().__init__(ffi.lib.LLVMPY_CreatePassBuilder(tm, pto, self._pic))
         self._pto = pto
         self._tm = tm
 
@@ -340,9 +347,18 @@ ffi.lib.LLVMPY_DisposePipelineTuningOptions.argtypes = \
 
 ffi.lib.LLVMPY_CreatePassBuilder.restype = ffi.LLVMPassBuilderRef
 ffi.lib.LLVMPY_CreatePassBuilder.argtypes = [ffi.LLVMTargetMachineRef,
-                                             ffi.LLVMPipelineTuningOptionsRef,]
+                                             ffi.LLVMPipelineTuningOptionsRef,
+                                             ffi.LLVMPassInstrumentationCallbacks,]
 
 ffi.lib.LLVMPY_DisposePassBuilder.argtypes = [ffi.LLVMPassBuilderRef,]
+
+ffi.lib.LLVMPY_LLVMPassInstrumentationCallbacksCreate.restype = (
+    ffi.LLVMPassInstrumentationCallbacks
+)
+
+ffi.lib.LLVMPY_LLVMPassInstrumentationCallbacksDispose.argtypes = (
+    ffi.LLVMPassInstrumentationCallbacks,
+)
 
 # Pipeline builders
 

--- a/llvmlite/binding/newpassmanagers.py
+++ b/llvmlite/binding/newpassmanagers.py
@@ -245,8 +245,7 @@ class PassBuilder(ffi.ObjectRef):
             If pass timing is already enabled.
         """
         if self._time_passes_handler:
-            raise RuntimeError("Pass builder should only have one \
-                pass timer at a time")
+            raise RuntimeError("Pass timing can only be done once")
         self._time_passes_handler = TimePassesHandler()
         ffi.lib.LLVMPY_EnableTimePasses(self, self._time_passes_handler)
 

--- a/llvmlite/tests/test_binding.py
+++ b/llvmlite/tests/test_binding.py
@@ -3071,10 +3071,10 @@ class TestPassBuilder(BaseTest, NewPassManagerMixin):
         def run_with_timing(speed_level):
             mod = self.module()
             pb = self.pb(speed_level=speed_level, size_level=0)
-            pb.set_time_passes()
+            pb.start_pass_timing()
             mpm = pb.getModulePassManager()
             mpm.run(mod, pb)
-            report = pb.report_and_reset_timings()
+            report = pb.finish_pass_timing()
             pb.close()
             return report
 
@@ -3091,7 +3091,7 @@ class TestPassBuilder(BaseTest, NewPassManagerMixin):
         pb = self.pb()
         mpm = pb.getModulePassManager()
         mpm.run(mod, pb)
-        report = pb.report_and_reset_timings()
+        report = pb.finish_pass_timing()
         pb.close()
         self.assertFalse(report)
 

--- a/llvmlite/tests/test_binding.py
+++ b/llvmlite/tests/test_binding.py
@@ -3066,6 +3066,27 @@ class TestPassBuilder(BaseTest, NewPassManagerMixin):
         fpm.run(self.module().get_function("sum"), pb)
         pb.close()
 
+    def test_time_passes(self):
+        """Test pass timing reports for O3 and O0 optimization levels"""
+        def run_with_timing(speed_level):
+            mod = self.module()
+            pb = self.pb(speed_level=speed_level, size_level=0)
+            pb.set_time_passes(True)
+            mpm = pb.getModulePassManager()
+            mpm.run(mod, pb)
+            report = pb.report_and_reset_timings()
+            pb.set_time_passes(False)
+            pb.close()
+            return report
+
+        report_O3 = run_with_timing(3)
+        report_O0 = run_with_timing(0)
+
+        self.assertIsInstance(report_O3, str)
+        self.assertIsInstance(report_O0, str)
+        self.assertEqual(report_O3.count("Pass execution timing report"), 1)
+        self.assertEqual(report_O0.count("Pass execution timing report"), 1)
+
 
 class TestNewModulePassManager(BaseTest, NewPassManagerMixin):
     def pm(self):

--- a/llvmlite/tests/test_binding.py
+++ b/llvmlite/tests/test_binding.py
@@ -3103,7 +3103,7 @@ class TestPassBuilder(BaseTest, NewPassManagerMixin):
         mpm = pb.getModulePassManager()
         mpm.run(mod, pb)
         pb.finish_pass_timing()
-        with self.assertRaises(RuntimeError):
+        with self.assertRaisesRegex(RuntimeError, "only be done once"):
             pb.start_pass_timing()
         pb.close()
 
@@ -3112,7 +3112,7 @@ class TestPassBuilder(BaseTest, NewPassManagerMixin):
         pb = self.pb()
         mpm = pb.getModulePassManager()
         mpm.run(mod, pb)
-        with self.assertRaises(RuntimeError):
+        with self.assertRaisesRegex(RuntimeError, "not enabled"):
             pb.finish_pass_timing()
         pb.close()
 

--- a/llvmlite/tests/test_binding.py
+++ b/llvmlite/tests/test_binding.py
@@ -3091,9 +3091,30 @@ class TestPassBuilder(BaseTest, NewPassManagerMixin):
         pb = self.pb()
         mpm = pb.getModulePassManager()
         mpm.run(mod, pb)
+        pb.start_pass_timing()
         report = pb.finish_pass_timing()
         pb.close()
         self.assertFalse(report)
+
+    def test_multiple_timers_error(self):
+        mod = self.module()
+        pb = self.pb()
+        pb.start_pass_timing()
+        mpm = pb.getModulePassManager()
+        mpm.run(mod, pb)
+        pb.finish_pass_timing()
+        with self.assertRaises(RuntimeError):
+            pb.start_pass_timing()
+        pb.close()
+
+    def test_empty_report_error(self):
+        mod = self.module()
+        pb = self.pb()
+        mpm = pb.getModulePassManager()
+        mpm.run(mod, pb)
+        with self.assertRaises(RuntimeError):
+            pb.finish_pass_timing()
+        pb.close()
 
 
 class TestNewModulePassManager(BaseTest, NewPassManagerMixin):

--- a/llvmlite/tests/test_binding.py
+++ b/llvmlite/tests/test_binding.py
@@ -3071,11 +3071,10 @@ class TestPassBuilder(BaseTest, NewPassManagerMixin):
         def run_with_timing(speed_level):
             mod = self.module()
             pb = self.pb(speed_level=speed_level, size_level=0)
-            pb.set_time_passes(True)
+            pb.set_time_passes()
             mpm = pb.getModulePassManager()
             mpm.run(mod, pb)
             report = pb.report_and_reset_timings()
-            pb.set_time_passes(False)
             pb.close()
             return report
 
@@ -3086,6 +3085,15 @@ class TestPassBuilder(BaseTest, NewPassManagerMixin):
         self.assertIsInstance(report_O0, str)
         self.assertEqual(report_O3.count("Pass execution timing report"), 1)
         self.assertEqual(report_O0.count("Pass execution timing report"), 1)
+
+    def test_empty_report(self):
+        mod = self.module()
+        pb = self.pb()
+        mpm = pb.getModulePassManager()
+        mpm.run(mod, pb)
+        report = pb.report_and_reset_timings()
+        pb.close()
+        self.assertFalse(report)
 
 
 class TestNewModulePassManager(BaseTest, NewPassManagerMixin):


### PR DESCRIPTION
Enable LLVM Pass timings reporting with NewPassManager, to be used by Numba