### PR TITLE
bump Ubuntu to 24.04

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -33,7 +33,7 @@ jobs:
 - template: buildscripts/azure/azure-linux-macos.yml
   parameters:
     name: Linux
-    vmImage: ubuntu-20.04
+    vmImage: ubuntu-24.04
     matrix:
       py310:
         PYTHON: '3.10'


### PR DESCRIPTION
As per https://github.com/actions/runner-images/issues/11101 -- 20.04 is being phased out.