### PR TITLE
apply fixes from clang-format

### DIFF
--- a/ffi/custom_passes.cpp
+++ b/ffi/custom_passes.cpp
@@ -1307,12 +1307,10 @@ LLVMPY_DumpRefPruneStats(PRUNESTATS *buf, bool do_print) {
      * do_print if set will print the stats to stderr.
      */
     if (do_print) {
-        errs() << "refprune stats "
-               << "per-BB " << RefPrune::stats_per_bb << " "
-               << "diamond " << RefPrune::stats_diamond << " "
-               << "fanout " << RefPrune::stats_fanout << " "
-               << "fanout+raise " << RefPrune::stats_fanout_raise << " "
-               << "\n";
+        errs() << "refprune stats " << "per-BB " << RefPrune::stats_per_bb
+               << " " << "diamond " << RefPrune::stats_diamond << " "
+               << "fanout " << RefPrune::stats_fanout << " " << "fanout+raise "
+               << RefPrune::stats_fanout_raise << " " << "\n";
     };
 
     buf->basicblock = RefPrune::stats_per_bb;


### PR DESCRIPTION
This fixes the issue observed at:

https://dev.azure.com/numba/numba/_build/results?buildId=18814&view=logs&jobId=ccd86a3e-caa4-5b69-30f4-0f78a94b1864&j=ccd86a3e-caa4-5b69-30f4-0f78a94b1864&t=ae6da53c-21b7-51ec-70ac-f160952a79c1

```
ffi/custom_passes.cpp:1310:36: error: code should be clang-formatted [-Wclang-format-violations]
        errs() << "refprune stats "
                                   ^
ffi/custom_passes.cpp:1311:54: error: code should be clang-formatted [-Wclang-format-violations]
               << "per-BB " << RefPrune::stats_per_bb << " "
                                                     ^
ffi/custom_passes.cpp:1311:61: error: code should be clang-formatted [-Wclang-format-violations]
               << "per-BB " << RefPrune::stats_per_bb << " "
                                                            ^
ffi/custom_passes.cpp:1313:61: error: code should be clang-formatted [-Wclang-format-violations]
               << "fanout " << RefPrune::stats_fanout << " "
                                                            ^
ffi/custom_passes.cpp:1314:34: error: code should be clang-formatted [-Wclang-format-violations]
               << "fanout+raise " << RefPrune::stats_fanout_raise << " "
                                 ^
ffi/custom_passes.cpp:1314:73: error: code should be clang-formatted [-Wclang-format-violations]
               << "fanout+raise " << RefPrune::stats_fanout_raise << " "
```

This is the result of running:

`clang-format -i -Werror ffi/*.cpp ffi/*.h`

in an Ubuntu on Docker.

```
root@ubuntu-24.04:/mnt/local# clang-format -version
Ubuntu clang-format version 18.1.3 (1ubuntu1)
```

Note that I was unable to reproduce this using `clang-format-18` on osx-arm64 and using the `conda-forge` channel and was only able to fix this using ubuntu on docker.

Note also, that during the debugging of this issue, I noticed that `clang-format` is being run twice on Azure.

Once, on ubuntu, installed via `apt:

https://github.com/numba/llvmlite/blob/release0.44/azure-pipelines.yml#L93-L101

And once on some linux based tests:

https://github.com/numba/llvmlite/blob/release0.44/buildscripts/azure/azure-linux-macos.yml#L52-L59

It would probably be a good idea to streamline this linting process instead of linting twice with two different versions of the same tool.

Needs discussion during dev meet.