### PR TITLE
gha/fix llvmlite linux workflows for version tags

### DIFF
--- a/.github/workflows/llvmlite_linux-64_wheel_builder.yml
+++ b/.github/workflows/llvmlite_linux-64_wheel_builder.yml
@@ -76,8 +76,7 @@ jobs:
           docker run --rm \
             -v "$(pwd):/root/llvmlite" \
             quay.io/pypa/manylinux2014_x86_64 \
-            /root/llvmlite/buildscripts/manylinux/build_llvmlite.sh \
-            "${{ env.MINICONDA_FILE }}" "${{ env.PYTHON_PATH }}"
+            bash -c "git config --global --add safe.directory /root/llvmlite && /root/llvmlite/buildscripts/manylinux/build_llvmlite.sh ${{ env.MINICONDA_FILE }} ${{ env.PYTHON_PATH }}"
 
           # Create wheelhouse directory for artifact upload
           mkdir -p wheelhouse

--- a/.github/workflows/llvmlite_linux-64_wheel_builder.yml
+++ b/.github/workflows/llvmlite_linux-64_wheel_builder.yml
@@ -20,6 +20,7 @@ env:
   CONDA_CHANNEL_NUMBA: numba/label/manylinux2014_x86_64
   VALIDATION_PYTHON_VERSION: "3.12"
   ARTIFACT_RETENTION_DAYS: 7
+  MANYLINUX_IMAGE: "manylinux2014_x86_64"
 
 jobs:
   linux-64-build:
@@ -75,7 +76,7 @@ jobs:
           # Run the build script in manylinux container using the existing script
           docker run --rm \
             -v "$(pwd):/root/llvmlite" \
-            quay.io/pypa/manylinux2014_x86_64 \
+            quay.io/pypa/${{ env.MANYLINUX_IMAGE }} \
             bash -c "git config --global --add safe.directory /root/llvmlite && /root/llvmlite/buildscripts/manylinux/build_llvmlite.sh ${{ env.MINICONDA_FILE }} ${{ env.PYTHON_PATH }}"
 
           # Create wheelhouse directory for artifact upload

--- a/.github/workflows/llvmlite_linux-arm64_wheel_builder.yml
+++ b/.github/workflows/llvmlite_linux-arm64_wheel_builder.yml
@@ -77,8 +77,7 @@ jobs:
           docker run --rm \
             -v "$(pwd):/root/llvmlite" \
             quay.io/pypa/${{ env.MANYLINUX_IMAGE }} \
-            /root/llvmlite/buildscripts/manylinux/build_llvmlite.sh \
-            "${{ env.MINICONDA_FILE }}" "${{ env.PYTHON_PATH }}"
+            bash -c "git config --global --add safe.directory /root/llvmlite && /root/llvmlite/buildscripts/manylinux/build_llvmlite.sh ${{ env.MINICONDA_FILE }} ${{ env.PYTHON_PATH }}"
 
           # Create wheelhouse directory for artifact upload
           mkdir -p wheelhouse


### PR DESCRIPTION
This workflow uses git config to mark mounted dir safe in order to get correct version string generated off tags in manylinux container when building. 
Also, small cosmetic change to use env var for manylinux image - "manylinux2014_x86_64" to make it consistent with linux-arm64 workflow.