### PR TITLE
unify clang format check

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -96,7 +96,7 @@ jobs:
     vmImage: 'ubuntu-latest'
   steps:
   - script: |
-      set -elx
+      set -ex
       buildscripts/incremental/install_miniconda.sh
       export PATH=$HOME/miniconda3/bin:$PATH
       conda install -c conda-forge -y clang-format-20

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -44,19 +44,16 @@ jobs:
         PYTHON: '3.11'
         CONDA_ENV: cienv
         RUN_FLAKE8: yes
-        RUN_CLANG_FORMAT: yes
         DIST_TEST: yes
       py312:
         PYTHON: '3.12'
         CONDA_ENV: cienv
         RUN_FLAKE8: yes
-        RUN_CLANG_FORMAT: yes
         DIST_TEST: yes
       py313:
         PYTHON: '3.13'
         CONDA_ENV: cienv
         RUN_FLAKE8: yes
-        RUN_CLANG_FORMAT: yes
         DIST_TEST: yes
 # temporarily disabled
 #       pypy:
@@ -93,3 +90,15 @@ jobs:
   parameters:
     name: Windows
     vmImage: windows-2019
+
+- job: check_formatting
+  pool:
+    vmImage: 'ubuntu-latest'
+  steps:
+  - script: |
+      set -e
+      buildscripts/incremental/install_miniconda.sh
+      export PATH=$HOME/miniconda3/bin:$PATH
+      conda install -c conda-forge -y clang-format-20
+      clang-format-20 -n -Werror ffi/*.cpp ffi/*.h
+    displayName: Check C++ formatting

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -96,7 +96,7 @@ jobs:
     vmImage: 'ubuntu-latest'
   steps:
   - script: |
-      set -e
+      set -elx
       buildscripts/incremental/install_miniconda.sh
       export PATH=$HOME/miniconda3/bin:$PATH
       conda install -c conda-forge -y clang-format-20

--- a/buildscripts/azure/azure-linux-macos.yml
+++ b/buildscripts/azure/azure-linux-macos.yml
@@ -49,11 +49,3 @@ jobs:
         export PATH=$HOME/miniconda3/bin:$PATH
         buildscripts/incremental/test.sh
       displayName: 'Test'
-# This is last because we need to install a bunch of LLVM stuff that will pollute the build environment
-    - script: |
-         set -e
-         export PATH=$HOME/miniconda3/bin:$PATH
-         conda install -c conda-forge -y clang-format-13
-         clang-format-13 -n -Werror ffi/*.cpp ffi/*.h
-      displayName: Check C++ formatting
-      condition: eq(variables['RUN_CLANG_FORMAT'], 'yes')


### PR DESCRIPTION
As per https://github.com/numba/llvmlite/pull/1208#issuecomment-2839151540 this refactors the clang-format check to use a single job to execute it and uses clang-format-20 from conda-forge.