### PR TITLE
fix/revert gha recipe changes

### DIFF
--- a/.github/workflows/llvmlite_osx-64_conda_builder.yml
+++ b/.github/workflows/llvmlite_osx-64_conda_builder.yml
@@ -59,6 +59,8 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build llvmlite conda package
+        env:
+          CONDA_BUILD_SYSROOT: /opt/MacOSX10.10.sdk
         run: |
           if [ "${{ inputs.llvmdev_run_id }}" != "" ]; then
               LLVMDEV_CHANNEL="file://$PWD/llvmdev_conda_packages"

--- a/.github/workflows/llvmlite_osx-64_conda_builder.yml
+++ b/.github/workflows/llvmlite_osx-64_conda_builder.yml
@@ -102,7 +102,7 @@ jobs:
         with:
           name: llvmlite-osx-64-py${{ matrix.python-version }}
 
-      - name: Install conda-build and llvmlite
+      - name: Install conda-build
         run: |
           conda install conda-build
 

--- a/.github/workflows/llvmlite_osx-64_conda_builder.yml
+++ b/.github/workflows/llvmlite_osx-64_conda_builder.yml
@@ -59,8 +59,6 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build llvmlite conda package
-        env:
-          CONDA_BUILD_SYSROOT: /opt/MacOSX10.10.sdk
         run: |
           if [ "${{ inputs.llvmdev_run_id }}" != "" ]; then
               LLVMDEV_CHANNEL="file://$PWD/llvmdev_conda_packages"
@@ -69,7 +67,7 @@ jobs:
           fi
           CONDA_CHANNEL_DIR="conda_channel_dir"
           mkdir $CONDA_CHANNEL_DIR
-          conda build --debug -c "$LLVMDEV_CHANNEL" -c defaults --python=${{ matrix.python-version }} conda-recipes/llvmlite --output-folder=$CONDA_CHANNEL_DIR --no-test
+          conda build --debug -c "$LLVMDEV_CHANNEL" -c defaults --python=${{ matrix.python-version }} conda-recipes/llvmlite --output-folder=$CONDA_CHANNEL_DIR --no-test --variants '{"CONDA_BUILD_SYSROOT": "/opt/MacOSX10.10.sdk"}'
 
       - name: Upload llvmlite conda package
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2

--- a/buildscripts/manylinux/build_llvmlite.sh
+++ b/buildscripts/manylinux/build_llvmlite.sh
@@ -51,3 +51,8 @@ auditwheel --verbose repair *.whl
 
 cd wheelhouse
 ls
+
+
+# Verify & Test
+pip install *.whl
+python -m llvmlite.tests -vb

--- a/buildscripts/manylinux/build_llvmlite.sh
+++ b/buildscripts/manylinux/build_llvmlite.sh
@@ -51,8 +51,3 @@ auditwheel --verbose repair *.whl
 
 cd wheelhouse
 ls
-
-
-# Verify & Test
-pip install *.whl
-python -m llvmlite.tests -vb

--- a/conda-recipes/llvmdev/conda_build_config.yaml
+++ b/conda-recipes/llvmdev/conda_build_config.yaml
@@ -15,6 +15,3 @@ c_compiler:              # [win]
   - vs2019               # [win]
 cxx_compiler:            # [win]
   - vs2019               # [win]
-
-CONDA_BUILD_SYSROOT:
-  - /opt/MacOSX10.10.sdk        # [osx and x86_64]

--- a/conda-recipes/llvmdev/conda_build_config.yaml
+++ b/conda-recipes/llvmdev/conda_build_config.yaml
@@ -15,3 +15,6 @@ c_compiler:              # [win]
   - vs2019               # [win]
 cxx_compiler:            # [win]
   - vs2019               # [win]
+
+MACOSX_SDK_VERSION:    # [osx and x86_64]
+  - 10.12              # [osx and x86_64]

--- a/conda-recipes/llvmdev_for_wheel/conda_build_config.yaml
+++ b/conda-recipes/llvmdev_for_wheel/conda_build_config.yaml
@@ -15,6 +15,3 @@ c_compiler:              # [win]
   - vs2019               # [win]
 cxx_compiler:            # [win]
   - vs2019               # [win]
-
-CONDA_BUILD_SYSROOT:
-  - /opt/MacOSX10.10.sdk        # [osx and x86_64]

--- a/conda-recipes/llvmdev_for_wheel/conda_build_config.yaml
+++ b/conda-recipes/llvmdev_for_wheel/conda_build_config.yaml
@@ -15,3 +15,6 @@ c_compiler:              # [win]
   - vs2019               # [win]
 cxx_compiler:            # [win]
   - vs2019               # [win]
+
+MACOSX_SDK_VERSION:    # [osx and x86_64]
+  - 10.12              # [osx and x86_64]

--- a/conda-recipes/llvmlite/conda_build_config.yaml
+++ b/conda-recipes/llvmlite/conda_build_config.yaml
@@ -15,6 +15,3 @@ c_compiler:              # [win]
   - vs2019               # [win]
 cxx_compiler:            # [win]
   - vs2019               # [win]
-
-CONDA_BUILD_SYSROOT:
-  - /opt/MacOSX10.10.sdk        # [osx and x86_64]


### PR DESCRIPTION
This PR reverts all changes that were made to recipe, buildscript for GHA workflows.
- CONDA_BUILD_SYSROOT now moved to osx-64 workflow as env variable.
- reverted testing steps on linux buildscript.