### PR TITLE
[WIP] LLVM 19 llvmdev recipe

### DIFF
--- a/conda-recipes/llvmdev/build.sh
+++ b/conda-recipes/llvmdev/build.sh
@@ -13,7 +13,7 @@ cd build
 
 export CPU_COUNT=4
 
-CMAKE_ARGS="${CMAKE_ARGS} -DLLVM_ENABLE_PROJECTS=lld;libunwind;compiler-rt"
+CMAKE_ARGS="${CMAKE_ARGS} -DLLVM_ENABLE_PROJECTS=lld -DLLVM_ENABLE_RUNTIMES=libunwind;compiler-rt"
 
 if [[ "$target_platform" == "linux-64" ]]; then
   CMAKE_ARGS="${CMAKE_ARGS} -DLLVM_USE_INTEL_JITEVENTS=ON"

--- a/conda-recipes/llvmdev/build.sh
+++ b/conda-recipes/llvmdev/build.sh
@@ -13,7 +13,7 @@ cd build
 
 export CPU_COUNT=4
 
-CMAKE_ARGS="${CMAKE_ARGS} -DLLVM_ENABLE_PROJECTS=lld -DLLVM_ENABLE_RUNTIMES=libunwind;compiler-rt"
+CMAKE_ARGS="${CMAKE_ARGS} -DLLVM_ENABLE_PROJECTS=lld;compiler-rt -DLLVM_ENABLE_RUNTIMES=libunwind"
 
 if [[ "$target_platform" == "linux-64" ]]; then
   CMAKE_ARGS="${CMAKE_ARGS} -DLLVM_USE_INTEL_JITEVENTS=ON"

--- a/conda-recipes/llvmdev/meta.yaml
+++ b/conda-recipes/llvmdev/meta.yaml
@@ -1,7 +1,7 @@
-{% set shortversion = "15.0" %}
-{% set version = "15.0.7" %}
-{% set sha256_llvm = "8b5fcb24b4128cf04df1b0b9410ce8b1a729cb3c544e6da885d234280dedeac6" %}
-{% set build_number = "2" %}
+{% set shortversion = "19.1" %}
+{% set version = "19.1.7" %}
+{% set sha256_llvm = "82401fea7b79d0078043f7598b835284d6650a75b93e64b6f761ea7b63097501" %}
+{% set build_number = "0" %}
 
 package:
   name: llvmdev
@@ -11,17 +11,16 @@ source:
   - url: https://github.com/llvm/llvm-project/releases/download/llvmorg-{{ version.replace(".rc", "-rc") }}/llvm-project-{{ version.replace(".rc", "rc") }}.src.tar.xz
     sha256: {{ sha256_llvm }}
     patches:
-    - ../llvm15-clear-gotoffsetmap.patch
-    - ../llvm15-remove-use-of-clonefile.patch
-    - ../llvm15-svml.patch
-    - ../compiler-rt-cfi-startproc-war.patch
-    - ../compiler-rt-macos-build.patch
+    # - ../llvm15-remove-use-of-clonefile.patch
+    # - ../llvm15-svml.patch
+    # - ../compiler-rt-cfi-startproc-war.patch
+    # - ../compiler-rt-macos-build.patch
 
     # Patches from conda-forge needed for windows to build
     # backport of zlib patches, can be dropped for vs15.0.3, see
     # https://reviews.llvm.org/D135457 & https://reviews.llvm.org/D136065
-    - patches/0002-CMake-Fix-Findzstd-module-for-shared-DLL-on-Windows.patch
-    - patches/no-windows-symlinks.patch
+    # - patches/0002-CMake-Fix-Findzstd-module-for-shared-DLL-on-Windows.patch
+    # - patches/no-windows-symlinks.patch
 
 build:
   number: {{ build_number }}


### PR DESCRIPTION
Steps taken so far:

  - Update recipe versions and checksums
  - Build with no patches to see what happens - which are necessary now?
  - Build libunwind as a runtime - it seems it is no longer built as a project

I'd like to see if this can be run on GHA to see whether it works there (using this PR to try to experiment with that)

To do:

- Update bld.bat for Windows
- Fix the assertions issue in the build: #1194