### PR TITLE
[WIP] LLVM 20 llvmdev recipe

### DIFF
--- a/conda-recipes/llvmdev/build.sh
+++ b/conda-recipes/llvmdev/build.sh
@@ -13,7 +13,7 @@ cd build
 
 export CPU_COUNT=4
 
-CMAKE_ARGS="${CMAKE_ARGS} -DLLVM_ENABLE_PROJECTS=lld;libunwind;compiler-rt"
+CMAKE_ARGS="${CMAKE_ARGS} -DLLVM_ENABLE_PROJECTS=lld -DLLVM_ENABLE_RUNTIMES=libunwind;compiler-rt"
 
 if [[ "$target_platform" == "linux-64" ]]; then
   CMAKE_ARGS="${CMAKE_ARGS} -DLLVM_USE_INTEL_JITEVENTS=ON"

--- a/conda-recipes/llvmdev/build.sh
+++ b/conda-recipes/llvmdev/build.sh
@@ -13,7 +13,7 @@ cd build
 
 export CPU_COUNT=4
 
-CMAKE_ARGS="${CMAKE_ARGS} -DLLVM_ENABLE_PROJECTS=lld -DLLVM_ENABLE_RUNTIMES=libunwind;compiler-rt"
+CMAKE_ARGS="${CMAKE_ARGS} -DLLVM_ENABLE_PROJECTS=lld;compiler-rt -DLLVM_ENABLE_RUNTIMES=libunwind"
 
 if [[ "$target_platform" == "linux-64" ]]; then
   CMAKE_ARGS="${CMAKE_ARGS} -DLLVM_USE_INTEL_JITEVENTS=ON"

--- a/conda-recipes/llvmdev/meta.yaml
+++ b/conda-recipes/llvmdev/meta.yaml
@@ -1,7 +1,7 @@
-{% set shortversion = "15.0" %}
-{% set version = "15.0.7" %}
-{% set sha256_llvm = "8b5fcb24b4128cf04df1b0b9410ce8b1a729cb3c544e6da885d234280dedeac6" %}
-{% set build_number = "2" %}
+{% set shortversion = "19.1" %}
+{% set version = "19.1.7" %}
+{% set sha256_llvm = "82401fea7b79d0078043f7598b835284d6650a75b93e64b6f761ea7b63097501" %}
+{% set build_number = "0" %}
 
 package:
   name: llvmdev
@@ -11,17 +11,16 @@ source:
   - url: https://github.com/llvm/llvm-project/releases/download/llvmorg-{{ version.replace(".rc", "-rc") }}/llvm-project-{{ version.replace(".rc", "rc") }}.src.tar.xz
     sha256: {{ sha256_llvm }}
     patches:
-    - ../llvm15-clear-gotoffsetmap.patch
-    - ../llvm15-remove-use-of-clonefile.patch
-    - ../llvm15-svml.patch
-    - ../compiler-rt-cfi-startproc-war.patch
-    - ../compiler-rt-macos-build.patch
+    # - ../llvm15-remove-use-of-clonefile.patch
+    # - ../llvm15-svml.patch
+    # - ../compiler-rt-cfi-startproc-war.patch
+    # - ../compiler-rt-macos-build.patch
 
     # Patches from conda-forge needed for windows to build
     # backport of zlib patches, can be dropped for vs15.0.3, see
     # https://reviews.llvm.org/D135457 & https://reviews.llvm.org/D136065
-    - patches/0002-CMake-Fix-Findzstd-module-for-shared-DLL-on-Windows.patch
-    - patches/no-windows-symlinks.patch
+    # - patches/0002-CMake-Fix-Findzstd-module-for-shared-DLL-on-Windows.patch
+    # - patches/no-windows-symlinks.patch
 
 build:
   number: {{ build_number }}

--- a/conda-recipes/llvmdev/meta.yaml
+++ b/conda-recipes/llvmdev/meta.yaml
@@ -1,6 +1,6 @@
-{% set shortversion = "19.1" %}
-{% set version = "19.1.7" %}
-{% set sha256_llvm = "82401fea7b79d0078043f7598b835284d6650a75b93e64b6f761ea7b63097501" %}
+{% set shortversion = "20.1" %}
+{% set version = "20.1.5" %}
+{% set sha256_llvm = "a069565cd1c6aee48ee0f36de300635b5781f355d7b3c96a28062d50d575fa3e" %}
 {% set build_number = "0" %}
 
 package:


### PR DESCRIPTION
Using this PR for development / notes.

## Build / installation

I built for linux-64 with the GHA builder (https://github.com/numba/llvmlite/actions/runs/15325329108)

Installation requires:

```
  + liblzma-devel    5.8.1  hb9d3cd8_1          conda-forge                             442kB
  + xz-gpl-tools     5.8.1  hbcc6ac9_1          conda-forge                              34kB
  + xz-tools         5.8.1  hb9d3cd8_1          conda-forge                              96kB
  + libstdcxx-ng    15.1.0  h4852527_2          conda-forge                            Cached
  + zlib            1.2.13  h4ab18f5_6          conda-forge                            Cached
  + xz               5.8.1  hbcc6ac9_1          conda-forge                              24kB
  + zstd             1.5.6  ha6fb4c9_0          conda-forge                            Cached
  + llvmdev         20.1.5  hfc4b9b4_0          /home/gmarkall/numbadev/llvmdev-20      684MB
```

Are the zlib and zstd dependencies a problem?