### PR TITLE
fix llvmdev_build.yml to resolve toolchain incompatibility on osx-64

### DIFF
--- a/.github/workflows/llvmdev_build.yml
+++ b/.github/workflows/llvmdev_build.yml
@@ -100,7 +100,11 @@ jobs:
         run: |
           set -x
           mkdir "${CONDA_CHANNEL_DIR}"
-          conda build "./conda-recipes/${{ matrix.recipe }}" "--output-folder=${CONDA_CHANNEL_DIR}"
+          VARIANTS_ARG=""
+          if [[ "${{ matrix.platform }}" == "osx-64" ]]; then
+            VARIANTS_ARG="--variants '{\"CONDA_BUILD_SYSROOT\": \"/opt/MacOSX10.10.sdk\"}'"
+          fi
+          conda build "./conda-recipes/${{ matrix.recipe }}" "--output-folder=${CONDA_CHANNEL_DIR}" ${VARIANTS_ARG}
           ls -lah "${CONDA_CHANNEL_DIR}"
 
       - name: Upload conda package

--- a/.github/workflows/llvmdev_build.yml
+++ b/.github/workflows/llvmdev_build.yml
@@ -104,7 +104,7 @@ jobs:
           if [[ "${{ matrix.platform }}" == "osx-64" ]]; then
             VARIANTS_ARG='--variants {"CONDA_BUILD_SYSROOT": "/opt/MacOSX10.10.sdk"}'
           fi
-          conda build "./conda-recipes/${{ matrix.recipe }}" "--output-folder=${CONDA_CHANNEL_DIR}" ${VARIANTS_ARG}
+          conda build "./conda-recipes/${{ matrix.recipe }}" "--output-folder=${CONDA_CHANNEL_DIR}" "${VARIANTS_ARG}"
           ls -lah "${CONDA_CHANNEL_DIR}"
 
       - name: Upload conda package

--- a/.github/workflows/llvmdev_build.yml
+++ b/.github/workflows/llvmdev_build.yml
@@ -100,11 +100,11 @@ jobs:
         run: |
           set -x
           mkdir "${CONDA_CHANNEL_DIR}"
-          VARIANTS_ARG=""
+          EXTRA_ARGS=()
           if [[ "${{ matrix.platform }}" == "osx-64" ]]; then
-            VARIANTS_ARG='--variants {"CONDA_BUILD_SYSROOT": "/opt/MacOSX10.10.sdk"}'
+            EXTRA_ARGS=(--variants '{"CONDA_BUILD_SYSROOT": "/opt/MacOSX10.10.sdk"}')
           fi
-          conda build "./conda-recipes/${{ matrix.recipe }}" "--output-folder=${CONDA_CHANNEL_DIR}" "${VARIANTS_ARG}"
+          conda build "./conda-recipes/${{ matrix.recipe }}" "--output-folder=${CONDA_CHANNEL_DIR}" "${EXTRA_ARGS[@]}"
           ls -lah "${CONDA_CHANNEL_DIR}"
 
       - name: Upload conda package

--- a/.github/workflows/llvmdev_build.yml
+++ b/.github/workflows/llvmdev_build.yml
@@ -102,7 +102,7 @@ jobs:
           mkdir "${CONDA_CHANNEL_DIR}"
           VARIANTS_ARG=""
           if [[ "${{ matrix.platform }}" == "osx-64" ]]; then
-            VARIANTS_ARG="--variants '{\"CONDA_BUILD_SYSROOT\": \"/opt/MacOSX10.10.sdk\"}'"
+            VARIANTS_ARG='--variants {"CONDA_BUILD_SYSROOT": "/opt/MacOSX10.10.sdk"}'
           fi
           conda build "./conda-recipes/${{ matrix.recipe }}" "--output-folder=${CONDA_CHANNEL_DIR}" ${VARIANTS_ARG}
           ls -lah "${CONDA_CHANNEL_DIR}"


### PR DESCRIPTION
```
ld: unsupported tapi file type '!tapi-tbd' in YAML file '/Applications/Xcode_15.2.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/lib/libSystem.tbd' for architecture x86_64
    clang-14: error: linker command failed with exit code 1 (use -v to see invocation)
    ninja: build stopped: subcommand failed.
```

The above error is mostly caused when using conda build under conda env on (intel-based) osx-64 systems.
It's because the newer toolchains are incompatible with conda build. 
To make this work, we download older toolchain and have conda build point to it using CONDA_BUILD_SYSROOT var.
```
--variants '{"CONDA_BUILD_SYSROOT": "/opt/MacOSX10.10.sdk"}'
```

Reference:
- [conda build doc](https://docs.conda.io/projects/conda-build/en/stable/resources/compiler-tools.html#macos-sdk)