### PR TITLE
azure-pipelines/win-2019 to 2025

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -89,7 +89,7 @@ jobs:
 - template: buildscripts/azure/azure-windows.yml
   parameters:
     name: Windows
-    vmImage: windows-2019
+    vmImage: windows-2025
 
 - job: check_formatting
   pool:

--- a/buildscripts/azure/azure-windows.yml
+++ b/buildscripts/azure/azure-windows.yml
@@ -36,6 +36,9 @@ jobs:
 
     - powershell: |
         $wc = New-Object net.webclient
+        # Add User-Agent header to prevent 403 Forbidden error when downloading Miniconda
+        # Some servers block requests without proper User-Agent headers
+        $wc.Headers.Add("User-Agent", "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.110 Safari/537.36")
         $wc.Downloadfile("https://repo.anaconda.com/miniconda/Miniconda3-latest-Windows-x86_64.exe", "Miniconda3-latest-Windows-x86_64.exe")
         Start-Process "Miniconda3-latest-Windows-x86_64.exe" "/S /D=C:\Miniconda3" -Wait
       displayName: 'Install miniconda'

--- a/buildscripts/incremental/build.cmd
+++ b/buildscripts/incremental/build.cmd
@@ -16,7 +16,7 @@ call activate %CONDA_ENV%
 @rem - https://github.com/conda-forge/llvmdev-feedstock/pull/223
 @rem - https://github.com/MicrosoftDocs/visualstudio-docs/issues/7774
 if "%LLVM%"=="16" (
-  call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\Common7\Tools\VsDevCmd.bat"
+  call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\Common7\Tools\VsDevCmd.bat"
   if %errorlevel% neq 0 exit /b %errorlevel%
 )
 

--- a/ffi/build.py
+++ b/ffi/build.py
@@ -79,7 +79,9 @@ def find_windows_generator():
         )
 
     generators.extend([
-        # use VS2019 to match how llvmdev is built
+        # use VS2022 first
+        ('Visual Studio 17 2022', ('x64' if is_64bit else 'Win32'), 'v143'),
+        # try VS2019 next
         ('Visual Studio 16 2019', ('x64' if is_64bit else 'Win32'), 'v142'),
         # # This is the generator configuration for VS2017
         # ('Visual Studio 15 2017' + (' Win64' if is_64bit else ''), None, None)


### PR DESCRIPTION
To ensure CI functions without disruption, we need to migrate to newer Windows runner image - `windows-2025` from existing `windows-2019` .

This PR updates runner image for azure-pipelines.