### PR TITLE
gha/llvmlite upgrade win-2019 to 2025

### DIFF
--- a/.github/workflows/llvmlite_win-64_conda_builder.yml
+++ b/.github/workflows/llvmlite_win-64_conda_builder.yml
@@ -20,7 +20,7 @@ concurrency:
 jobs:
   win-64-build:
     name: win-64-build
-    runs-on: windows-2019
+    runs-on: windows-2025
     defaults:
       run:
         shell: bash -elx {0}
@@ -58,7 +58,7 @@ jobs:
       - name: Build llvmlite conda package
         run: |
           if [ "${{ inputs.llvmdev_run_id }}" != "" ]; then
-              LLVMDEV_CHANNEL="file://${{ github.workspace }}/llvmdev_conda_packages"
+              LLVMDEV_CHANNEL="file:///${{ github.workspace }}/llvmdev_conda_packages"
           else
               LLVMDEV_CHANNEL="numba"
           fi
@@ -81,7 +81,7 @@ jobs:
   win-64-test:
     name: win-64-test
     needs: win-64-build
-    runs-on: windows-2019
+    runs-on: windows-2025
     defaults:
       run:
         shell: bash -elx {0}

--- a/.github/workflows/llvmlite_win-64_wheel_builder.yml
+++ b/.github/workflows/llvmlite_win-64_wheel_builder.yml
@@ -25,7 +25,7 @@ env:
 jobs:
   win-64-build:
     name: win-64-build
-    runs-on: windows-2019
+    runs-on: windows-2025
     defaults:
       run:
         shell: bash -elx {0}
@@ -61,7 +61,7 @@ jobs:
       - name: Install build dependencies
         run: |
           if [ "${{ inputs.llvmdev_run_id }}" != "" ]; then
-              CHAN="file://${{ github.workspace }}/llvmdev_conda_packages"
+              CHAN="file:///${{ github.workspace }}/llvmdev_conda_packages"
           else
               CHAN="${{ env.CONDA_CHANNEL_NUMBA }}"
           fi
@@ -85,7 +85,7 @@ jobs:
   win-64-validate:
     name: win-64-validate
     needs: win-64-build
-    runs-on: windows-2019
+    runs-on: windows-2025
     defaults:
       run:
         shell: bash -elx {0}
@@ -126,7 +126,7 @@ jobs:
   win-64-test:
     name: win-64-test
     needs: win-64-validate
-    runs-on: windows-2019
+    runs-on: windows-2025
     defaults:
       run:
         shell: bash -elx {0}
@@ -166,7 +166,7 @@ jobs:
     name: win-64-upload
     needs: win-64-test
     if: github.event_name == 'workflow_dispatch'
-    runs-on: windows-2019
+    runs-on: windows-2025
     defaults:
       run:
         shell: bash -elx {0}

--- a/conda-recipes/llvmlite/bld.bat
+++ b/conda-recipes/llvmlite/bld.bat
@@ -2,18 +2,18 @@
 @rem Let CMake know about the LLVM install path, for find_package()
 set CMAKE_PREFIX_PATH=%LIBRARY_PREFIX%
 
-@rem VS2019 uses a different naming convention for platforms than older version
+@rem VS2022 uses a different naming convention for platforms than older version
 if "%ARCH%"=="32" (
-    @rem VS2017:
+    @rem VS2022:
     @rem set CMAKE_GENERATOR_ARCH=
     set CMAKE_GENERATOR_ARCH=Win32
 ) else (
-    @rem VS2017
+    @rem VS2022
     @rem set CMAKE_GENERATOR_ARCH=Win64
     set CMAKE_GENERATOR_ARCH=x64
 )
-set CMAKE_GENERATOR=Visual Studio 16 2019
-set CMAKE_GENERATOR_TOOLKIT=v142
+set CMAKE_GENERATOR=Visual Studio 17 2022
+set CMAKE_GENERATOR_TOOLKIT=v143
 
 @rem Ensure there are no build leftovers (CMake can complain)
 if exist ffi\build rmdir /S /Q ffi\build

--- a/conda-recipes/llvmlite/conda_build_config.yaml
+++ b/conda-recipes/llvmlite/conda_build_config.yaml
@@ -12,6 +12,6 @@ fortran_compiler_version:   # [linux]
   - 11                      # [linux and aarch64]
 
 c_compiler:              # [win]
-  - vs2019               # [win]
+  - vs2022               # [win]
 cxx_compiler:            # [win]
-  - vs2019               # [win]
+  - vs2022               # [win]

--- a/conda-recipes/llvmlite/meta.yaml
+++ b/conda-recipes/llvmlite/meta.yaml
@@ -23,7 +23,7 @@ requirements:
     # build.sh deals with it!
     - {{ compiler('c') }}  # [not osx]
     - {{ compiler('cxx') }}  # [not osx]
-    - vs2015_{{ target_platform  }}    # [win]
+    - vs2022_{{ target_platform  }}    # [win]
     # The DLL build uses cmake on Windows
     - cmake          # [win]
     - make           # [unix]
@@ -42,8 +42,8 @@ requirements:
     - vs2015_runtime # [win]
     # osx has dynamically linked libstdc++
     - libcxx >=4.0.1 # [osx]
-    - zlib 
-    - zstd 
+    - zlib
+    - zstd
 
 test:
   imports:

--- a/ffi/build.py
+++ b/ffi/build.py
@@ -79,8 +79,10 @@ def find_windows_generator():
         )
 
     generators.extend([
+        # use VS2022
+        ('Visual Studio 17 2022', ('x64' if is_64bit else 'Win32'), 'v143'),
         # use VS2019 to match how llvmdev is built
-        ('Visual Studio 16 2019', ('x64' if is_64bit else 'Win32'), 'v142'),
+        # ('Visual Studio 16 2019', ('x64' if is_64bit else 'Win32'), 'v142'),
         # # This is the generator configuration for VS2017
         # ('Visual Studio 15 2017' + (' Win64' if is_64bit else ''), None, None)
     ])


### PR DESCRIPTION
Addressing -
https://github.com/numba/llvmlite/issues/1214
https://github.com/actions/runner-images/issues/12045

GitHub is retiring Windows Server 2019 hosted runners on June 30, 2025 as part of their N-1 OS support policy.
To ensure CI functions without disruption, we need to migrate to newer Windows runner images.

This PR makes needed changes to llvmlite recipe and build scripts.