### PR TITLE
gha/restructure llvmdev ci

### DIFF
--- a/.github/workflows/llvmdev_build.yml
+++ b/.github/workflows/llvmdev_build.yml
@@ -11,21 +11,23 @@ on:
     inputs:
       platform:
         description: Conda Platform
-        default: linux-64
+        default: all
         required: true
         type: choice
         options:
+          - all
           - linux-64
-          - linux-aarch64
+          - linux-arm64
           - osx-64
           - osx-arm64
           - win-64
       recipe:
         description: Recipe to build
-        default: llvmdev
+        default: all
         required: true
         type: choice
         options:
+          - all
           - llvmdev
           - llvmdev_for_wheel
 
@@ -42,6 +44,9 @@ concurrency:
       || github.event.label.name
       || github.sha }}
   cancel-in-progress: true
+
+env:
+  ARTIFACT_RETENTION_DAYS: 7
 
 jobs:
 
@@ -92,14 +97,49 @@ jobs:
 
       - name: Install conda-build
         run: |
-          conda install conda-build
+          if [[ "${{ matrix.platform }}" == "linux-arm64" ]]; then
+            conda install -c defaults conda-build "py-lief<0.16"
+          else
+            conda install -c defaults conda-build
+          fi
 
-      - name: Build conda package
+      - name: Build and test conda package in manylinux - linux platforms
+        if: (matrix.platform == 'linux-64' || matrix.platform == 'linux-arm64') && matrix.recipe == 'llvmdev_for_wheel'
         env:
           CONDA_CHANNEL_DIR: conda_channel_dir
         run: |
           set -x
-          mkdir "${CONDA_CHANNEL_DIR}"
+          # Set manylinux-specific variables
+          MANYLINUX_IMAGE=""
+          MINICONDA_FILE=""
+          if [[ "${{ matrix.platform }}" == "linux-64" ]]; then
+            MANYLINUX_IMAGE="quay.io/pypa/manylinux2014_x86_64"
+            MINICONDA_FILE="https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh"
+          elif [[ "${{ matrix.platform }}" == "linux-arm64" ]]; then
+            MANYLINUX_IMAGE="quay.io/pypa/manylinux_2_28_aarch64"
+            MINICONDA_FILE="https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-aarch64.sh"
+          fi
+
+          echo "Building in manylinux container for ${{ matrix.platform }}"
+          mkdir -p docker_output
+          docker run --rm \
+            -v "$(pwd):/root/llvmlite" \
+            "$MANYLINUX_IMAGE" \
+            bash -c "git config --global --add safe.directory /root/llvmlite && /root/llvmlite/buildscripts/manylinux/build_llvmdev.sh $MINICONDA_FILE"
+
+          # The script outputs to docker_output/<platform>/*.conda
+          # Move the package to the upload directory.
+          mkdir -p "${CONDA_CHANNEL_DIR}"
+          mv docker_output/*/*.conda "${CONDA_CHANNEL_DIR}/"
+          ls -lah "${CONDA_CHANNEL_DIR}"
+
+      - name: Build and test conda package - non-linux platforms
+        if: (matrix.platform != 'linux-64' && matrix.platform != 'linux-arm64') || matrix.recipe != 'llvmdev_for_wheel'
+        env:
+          CONDA_CHANNEL_DIR: conda_channel_dir
+        run: |
+          set -x
+          mkdir -p "${CONDA_CHANNEL_DIR}"
           EXTRA_ARGS=()
           if [[ "${{ matrix.platform }}" == "osx-64" ]]; then
             EXTRA_ARGS=(--variants '{"CONDA_BUILD_SYSROOT": "/opt/MacOSX10.10.sdk"}')
@@ -113,7 +153,7 @@ jobs:
           name: ${{ matrix.recipe }}_${{ matrix.platform }}
           path: conda_channel_dir
           compression-level: 0
-          retention-days: 7
+          retention-days: ${{ env.ARTIFACT_RETENTION_DAYS }}
           if-no-files-found: error
 
       - name: Get Workflow Run ID

--- a/buildscripts/github/llvmdev_evaluate.py
+++ b/buildscripts/github/llvmdev_evaluate.py
@@ -11,28 +11,36 @@ inputs = os.environ.get("GITHUB_WORKFLOW_INPUT", "{}")
 
 runner_mapping = {
     "linux-64": "ubuntu-24.04",
-    "linux-aarch64": "ubuntu-24.04-arm",
+    "linux-arm64": "ubuntu-24.04-arm",
     "osx-64": "macos-13",
     "osx-arm64": "macos-14",
     "win-64": "windows-2025",
 }
 
 default_include = [
+    # linux-64
     {
         "runner": runner_mapping["linux-64"],
         "platform": "linux-64",
         "recipe": "llvmdev",
     },
     {
-        "runner": runner_mapping["win-64"],
-        "platform": "win-64",
-        "recipe": "llvmdev",
-    },
-    {
-        "runner": runner_mapping["win-64"],
-        "platform": "win-64",
+        "runner": runner_mapping["linux-64"],
+        "platform": "linux-64",
         "recipe": "llvmdev_for_wheel",
     },
+    # linux-arm64
+    {
+        "runner": runner_mapping["linux-arm64"],
+        "platform": "linux-arm64",
+        "recipe": "llvmdev",
+    },
+    {
+        "runner": runner_mapping["linux-arm64"],
+        "platform": "linux-arm64",
+        "recipe": "llvmdev_for_wheel",
+    },
+    # osx-64
     {
         "runner": runner_mapping["osx-64"],
         "platform": "osx-64",
@@ -41,6 +49,28 @@ default_include = [
     {
         "runner": runner_mapping["osx-64"],
         "platform": "osx-64",
+        "recipe": "llvmdev_for_wheel",
+    },
+    # osx-arm64
+    {
+        "runner": runner_mapping["osx-arm64"],
+        "platform": "osx-arm64",
+        "recipe": "llvmdev",
+    },
+    {
+        "runner": runner_mapping["osx-arm64"],
+        "platform": "osx-arm64",
+        "recipe": "llvmdev_for_wheel",
+    },
+    # win-64
+    {
+        "runner": runner_mapping["win-64"],
+        "platform": "win-64",
+        "recipe": "llvmdev",
+    },
+    {
+        "runner": runner_mapping["win-64"],
+        "platform": "win-64",
         "recipe": "llvmdev_for_wheel",
     },
 ]
@@ -58,13 +88,25 @@ elif event == "label" and label == "build_on_gha":
 elif event == "workflow_dispatch":
     print("workflow_dispatch detected")
     params = json.loads(inputs)
-    include = [
-        {
-            "runner": runner_mapping[params.get("platform", "linux-64")],
-            "platform": params.get("platform", "linux-64"),
-            "recipe": params.get("recipe", "llvmdev"),
-        }
-    ]
+    platform = params.get("platform", "all")
+    recipe = params.get("recipe", "all")
+
+    # Start with the full matrix
+    filtered_matrix = default_include
+
+    # Filter by platform if a specific one is chosen
+    if platform != "all":
+        filtered_matrix = [
+            item for item in filtered_matrix if item["platform"] == platform
+        ]
+
+    # Filter by recipe if a specific one is chosen
+    if recipe != "all":
+        filtered_matrix = [
+            item for item in filtered_matrix if item["recipe"] == recipe
+        ]
+
+    include = filtered_matrix
 else:
     include = {}
 

--- a/buildscripts/github/setup_platform.sh
+++ b/buildscripts/github/setup_platform.sh
@@ -31,4 +31,4 @@ case "${PLATFORM}" in
         ;;
 esac
 
-echo "Platform setup complete for ${PLATFORM}" 
+echo "Platform setup complete for ${PLATFORM}"

--- a/conda-recipes/llvmdev/conda_build_config.yaml
+++ b/conda-recipes/llvmdev/conda_build_config.yaml
@@ -16,5 +16,11 @@ c_compiler:              # [win]
 cxx_compiler:            # [win]
   - vs2022               # [win]
 
+c_compiler_version:      # [osx and x86_64]
+  - 14                   # [osx and x86_64]
+
+cxx_compiler_version:    # [osx and x86_64]
+  - 14                   # [osx and x86_64]
+
 MACOSX_SDK_VERSION:    # [osx and x86_64]
   - 10.12              # [osx and x86_64]

--- a/conda-recipes/llvmdev_for_wheel/conda_build_config.yaml
+++ b/conda-recipes/llvmdev_for_wheel/conda_build_config.yaml
@@ -16,5 +16,11 @@ c_compiler:              # [win]
 cxx_compiler:            # [win]
   - vs2022              # [win]
 
+c_compiler_version:      # [osx and x86_64]
+  - 14                   # [osx and x86_64]
+
+cxx_compiler_version:    # [osx and x86_64]
+  - 14                   # [osx and x86_64]
+
 MACOSX_SDK_VERSION:    # [osx and x86_64]
   - 10.12              # [osx and x86_64]


### PR DESCRIPTION
This PR introduces several key fixes to the llvmdev GHA build process.
- builds llvmdev_for_wheel inside manylinux containers for `linux-64` and `linux-arm64` to ensure wheel compatibility.
- pins the `osx-64` compiler to version 14 to avoid conda selecting 17.x compilers.
- fixes `linux-arm64` builds by pinning `py-lief` to a version older than 0.16.
- standardizes the use of `linux-arm64` as the platform identifier.