### PR TITLE
gha/llvmlite wheel workflow fixes

### DIFF
--- a/.github/workflows/llvmlite_linux-64_wheel_builder.yml
+++ b/.github/workflows/llvmlite_linux-64_wheel_builder.yml
@@ -10,6 +10,11 @@ on:
         description: 'llvmdev workflow run ID (optional)'
         required: false
         type: string
+      upload_wheel_to_anaconda:
+        description: 'Upload wheel to Anaconda Cloud - numba channel'
+        required: false
+        type: boolean
+        default: false
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
@@ -200,7 +205,7 @@ jobs:
   linux-64-upload:
     name: upload-py${{ matrix.python-version }}
     needs: [linux-64-test, linux-64-validate]
-    if: github.event_name == 'workflow_dispatch'
+    if: github.event_name == 'workflow_dispatch' && inputs.upload_wheel_to_anaconda
     runs-on: ubuntu-latest
     defaults:
       run:

--- a/.github/workflows/llvmlite_linux-64_wheel_builder.yml
+++ b/.github/workflows/llvmlite_linux-64_wheel_builder.yml
@@ -110,6 +110,9 @@ jobs:
           retention-days: ${{ env.ARTIFACT_RETENTION_DAYS }}
           if-no-files-found: error
 
+      - name: Show Workflow Run ID
+        run: "echo \"Workflow Run ID: ${{ github.run_id }}\""
+
   linux-64-validate:
     name: validate-py${{ matrix.python-version }}
     needs: linux-64-build

--- a/.github/workflows/llvmlite_linux-aarch64_wheel_builder.yml
+++ b/.github/workflows/llvmlite_linux-aarch64_wheel_builder.yml
@@ -1,9 +1,9 @@
-name: llvmlite_linux-arm64_wheel_builder
+name: llvmlite_linux-aarch64_wheel_builder
 
 on:
   pull_request:
     paths:
-      - .github/workflows/llvmlite_linux-arm64_wheel_builder.yml
+      - .github/workflows/llvmlite_linux-aarch64_wheel_builder.yml
   workflow_dispatch:
     inputs:
       llvmdev_run_id:
@@ -28,8 +28,8 @@ env:
   MANYLINUX_IMAGE: "manylinux_2_28_aarch64"
 
 jobs:
-  linux-arm64-build:
-    name: linux-arm64-build-py${{ matrix.python-version }}
+  linux-aarch64-build:
+    name: linux-aarch64-build-py${{ matrix.python-version }}
     runs-on: ubuntu-24.04-arm
     defaults:
       run:
@@ -49,7 +49,7 @@ jobs:
         if: ${{ inputs.llvmdev_run_id != '' }}
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
-          name: llvmdev_for_wheel_linux-arm64
+          name: llvmdev_for_wheel_linux-aarch64
           path: llvmdev_conda_packages
           run-id: ${{ inputs.llvmdev_run_id }}
           repository: ${{ github.repository }}
@@ -101,7 +101,7 @@ jobs:
       - name: Upload wheel
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
-          name: llvmlite-linux-arm64-py${{ matrix.python-version }}
+          name: llvmlite-linux-aarch64-py${{ matrix.python-version }}
           path: wheelhouse/*.whl
           compression-level: 0
           retention-days: ${{ env.ARTIFACT_RETENTION_DAYS }}
@@ -110,9 +110,9 @@ jobs:
       - name: Show Workflow Run ID
         run: "echo \"Workflow Run ID: ${{ github.run_id }}\""
 
-  linux-arm64-validate:
+  linux-aarch64-validate:
     name: validate-py${{ matrix.python-version }}
-    needs: linux-arm64-build
+    needs: linux-aarch64-build
     runs-on: ubuntu-24.04-arm
     defaults:
       run:
@@ -139,7 +139,7 @@ jobs:
       - name: Download llvmlite wheels
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
-          name: llvmlite-linux-arm64-py${{ matrix.python-version }}
+          name: llvmlite-linux-aarch64-py${{ matrix.python-version }}
           path: dist
 
       - name: Validate wheels
@@ -151,9 +151,9 @@ jobs:
             twine check "$WHL_FILE"
           done
 
-  linux-arm64-test:
+  linux-aarch64-test:
     name: test-py${{ matrix.python-version }}
-    needs: linux-arm64-build
+    needs: linux-aarch64-build
     runs-on: ubuntu-24.04-arm
     defaults:
       run:
@@ -172,7 +172,7 @@ jobs:
       - name: Download llvmlite wheel
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
-          name: llvmlite-linux-arm64-py${{ matrix.python-version }}
+          name: llvmlite-linux-aarch64-py${{ matrix.python-version }}
           path: dist
 
       - name: Install and test
@@ -202,9 +202,9 @@ jobs:
           # Run tests
           "${PYTHON_PATH}" -m llvmlite.tests
 
-  linux-arm64-upload:
+  linux-aarch64-upload:
     name: upload-py${{ matrix.python-version }}
-    needs: [linux-arm64-test, linux-arm64-validate]
+    needs: [linux-aarch64-test, linux-aarch64-validate]
     if: github.event_name == 'workflow_dispatch' && inputs.upload_wheel_to_anaconda
     runs-on: ubuntu-24.04-arm
     defaults:
@@ -229,7 +229,7 @@ jobs:
       - name: Download llvmlite wheel
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
-          name: llvmlite-linux-arm64-py${{ matrix.python-version }}
+          name: llvmlite-linux-aarch64-py${{ matrix.python-version }}
           path: dist
 
       - name: Upload wheel to Anaconda Cloud

--- a/.github/workflows/llvmlite_linux-arm64_wheel_builder.yml
+++ b/.github/workflows/llvmlite_linux-arm64_wheel_builder.yml
@@ -107,6 +107,9 @@ jobs:
           retention-days: ${{ env.ARTIFACT_RETENTION_DAYS }}
           if-no-files-found: error
 
+      - name: Show Workflow Run ID
+        run: "echo \"Workflow Run ID: ${{ github.run_id }}\""
+
   linux-arm64-validate:
     name: validate-py${{ matrix.python-version }}
     needs: linux-arm64-build

--- a/.github/workflows/llvmlite_linux-arm64_wheel_builder.yml
+++ b/.github/workflows/llvmlite_linux-arm64_wheel_builder.yml
@@ -10,6 +10,11 @@ on:
         description: 'llvmdev workflow run ID (optional)'
         required: false
         type: string
+      upload_wheel_to_anaconda:
+        description: 'Upload wheel to Anaconda Cloud - numba channel'
+        required: false
+        type: boolean
+        default: false
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
@@ -197,7 +202,7 @@ jobs:
   linux-arm64-upload:
     name: upload-py${{ matrix.python-version }}
     needs: [linux-arm64-test, linux-arm64-validate]
-    if: github.event_name == 'workflow_dispatch'
+    if: github.event_name == 'workflow_dispatch' && inputs.upload_wheel_to_anaconda
     runs-on: ubuntu-24.04-arm
     defaults:
       run:

--- a/.github/workflows/llvmlite_osx-64_wheel_builder.yml
+++ b/.github/workflows/llvmlite_osx-64_wheel_builder.yml
@@ -10,6 +10,11 @@ on:
         description: 'llvmdev workflow run ID (optional)'
         required: false
         type: string
+      upload_wheel_to_anaconda:
+        description: 'Upload wheel to Anaconda Cloud - numba channel'
+        required: false
+        type: boolean
+        default: false
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
@@ -182,7 +187,7 @@ jobs:
   osx-64-upload:
     name: osx-64-upload
     needs: osx-64-test
-    if: github.event_name == 'workflow_dispatch'
+    if: github.event_name == 'workflow_dispatch' && inputs.upload_wheel_to_anaconda
     runs-on: macos-13
     defaults:
       run:

--- a/.github/workflows/llvmlite_osx-arm64_wheel_builder.yml
+++ b/.github/workflows/llvmlite_osx-arm64_wheel_builder.yml
@@ -10,6 +10,11 @@ on:
         description: 'llvmdev workflow run ID (optional)'
         required: false
         type: string
+      upload_wheel_to_anaconda:
+        description: 'Upload wheel to Anaconda Cloud - numba channel'
+        required: false
+        type: boolean
+        default: false
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
@@ -167,7 +172,7 @@ jobs:
   osx-arm64-upload:
     name: osx-arm64-upload
     needs: osx-arm64-test
-    if: github.event_name == 'workflow_dispatch'
+    if: github.event_name == 'workflow_dispatch' && inputs.upload_wheel_to_anaconda
     runs-on: macos-14
     defaults:
       run:

--- a/.github/workflows/llvmlite_win-64_wheel_builder.yml
+++ b/.github/workflows/llvmlite_win-64_wheel_builder.yml
@@ -10,6 +10,11 @@ on:
         description: 'llvmdev workflow run ID (optional)'
         required: false
         type: string
+      upload_wheel_to_anaconda:
+        description: 'Upload wheel to Anaconda Cloud - numba channel'
+        required: false
+        type: boolean
+        default: false
 
 # Add concurrency control
 concurrency:
@@ -165,7 +170,7 @@ jobs:
   win-64-upload:
     name: win-64-upload
     needs: win-64-test
-    if: github.event_name == 'workflow_dispatch'
+    if: github.event_name == 'workflow_dispatch' && inputs.upload_wheel_to_anaconda
     runs-on: windows-2025
     defaults:
       run:


### PR DESCRIPTION
This PR contains following changes applicable to llvmlite wheel GHA workflows -
- [critical] standardizes identifier for arm system to 'linux-aarch64' in line with llvmdev workflows.
- adds user input choice for 'upload wheel to anaconda' step. this is false by default and only uploads when manually set to true before running workflow. This avoids uploading every time, when not required.
- adds 'show workflow id' step on linux workflows as on other workflows. 