### PR TITLE
gha/add pr comment triggers

### DIFF
--- a/.github/workflows/llvmdev_build.yml
+++ b/.github/workflows/llvmdev_build.yml
@@ -1,6 +1,8 @@
 name: llvmdev
 
 on:
+  issue_comment:
+    types: [created, edited]
   pull_request:
     paths:
       - .github/workflows/llvmdev_build.yml
@@ -54,22 +56,78 @@ jobs:
     runs-on: ubuntu-24.04
     outputs:
       matrix: ${{ steps.evaluate.outputs.matrix }}
+      pr_comment_trigger_ref: ${{ steps.cmd.outputs.ref }}
+      pr_comment_trigger_status: ${{ steps.validator.outputs.should_run }}
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: '3.13'
+
+      - name: PR Comment Command Check
+        uses: github/command@v1
+        id: cmd
+        if: ${{ github.event_name == 'issue_comment' }}
+        with:
+          command: "/gha llvmdev"
+          reaction: "rocket"
+          allowed_contexts: pull_request
+          allow_forks: true
+          param_separator: " "
+
+      - name: Validate command
+        id: validator
+        if: ${{ github.event_name == 'issue_comment' && steps.cmd.outputs.continue == 'true' }}
+        run: |
+          SHOULD_RUN="true"
+          PARAMS_JSON="{}"
+          # Default values
+          PLATFORM="all"
+          RECIPE="all"
+
+          PARAMS=(${{ steps.cmd.outputs.params }})
+          echo "PARAMS: ${PARAMS[*]}"
+          for param in "${PARAMS[@]}"; do
+            case "$param" in
+              platform=*) PLATFORM="${param#*=}" ;;
+              recipe=*) RECIPE="${param#*=}" ;;
+            esac
+          done
+          PARAMS_JSON=$(printf '{"platform": "%s", "recipe": "%s"}' "$PLATFORM" "$RECIPE")
+          echo "should_run=$SHOULD_RUN" >> "$GITHUB_OUTPUT"
+          echo "command_params_json=$PARAMS_JSON" >> "$GITHUB_OUTPUT"
+
+      - name: Post Success Comment for PR Comment Trigger
+        if: ${{ github.event_name == 'issue_comment' && steps.validator.outputs.should_run == 'true' }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          RUN_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          BODY="llvmdev workflow triggered<br><br><pre>workflow id: ${{ github.run_id }}<br>details: $RUN_URL</pre>"
+          gh pr comment ${{ steps.cmd.outputs.issue_number }} --body "$BODY"
+
+      - name: Post Failure Comment for PR Comment Trigger
+        if: ${{ github.event_name == 'issue_comment' && steps.cmd.outputs.continue == 'true' && steps.validator.outputs.should_run != 'true' }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          RUN_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          BODY="llvmdev workflow failed<br><br><pre>workflow id: ${{ github.run_id }}<br>details: $RUN_URL</pre>"
+          gh pr comment ${{ steps.cmd.outputs.issue_number }} --body "$BODY"
+
       - name: Evaluate
+        if: ${{ github.event_name != 'issue_comment' || steps.validator.outputs.should_run == 'true' }}
         id: evaluate
         env:
           GITHUB_EVENT_NAME: ${{ github.event_name }}
           GITHUB_LABEL_NAME: ${{ github.event.label.name }}
-          GITHUB_WORKFLOW_INPUT: ${{ toJson(github.event.inputs) }}
+          GITHUB_WORKFLOW_INPUT: ${{ (github.event_name == 'issue_comment' && steps.validator.outputs.command_params_json) || toJson(github.event.inputs) }}
         run: |
           ./buildscripts/github/llvmdev_evaluate.py
 
   build:
     needs: check
+    if: ${{ (github.event_name == 'issue_comment' && needs.check.outputs.pr_comment_trigger_status == 'true') || github.event_name != 'issue_comment' }}
     name: ${{ matrix.recipe }}-${{ matrix.platform }}
     runs-on: ${{ matrix.runner }}
     defaults:
@@ -82,6 +140,8 @@ jobs:
     steps:
       - name: Clone repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          ref: ${{ github.event_name == 'issue_comment' && needs.check.outputs.pr_comment_trigger_ref || github.ref }}
 
       - name: Setup platform-specific requirements
         run: |

--- a/.github/workflows/llvmdev_build.yml
+++ b/.github/workflows/llvmdev_build.yml
@@ -57,14 +57,18 @@ jobs:
     outputs:
       matrix: ${{ steps.evaluate.outputs.matrix }}
       pr_comment_trigger_ref: ${{ steps.cmd.outputs.ref }}
-      pr_comment_trigger_status: ${{ steps.validator.outputs.should_run }}
+      pr_comment_trigger_status: ${{ steps.parsed_command.outputs.should_run }}
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: '3.13'
 
-      - name: PR Comment Command Check
+      - name: 'PR Comment - Command Check (1/2)'
+        # This step verifies and validates the trigger command. It checks if the
+        # command is correct and if the issuer has the necessary permissions.
+        # for more details see https://github.com/github/command
+        # The workflow proceeds only if `steps.cmd.outputs.continue == 'true'`.
         uses: github/command@v1
         id: cmd
         if: ${{ github.event_name == 'issue_comment' }}
@@ -75,8 +79,13 @@ jobs:
           allow_forks: true
           param_separator: " "
 
-      - name: Validate command
-        id: validator
+      - name: 'PR Comment - Parse Parameters (2/2)'
+        # This step parses the parameters from the PR comment command.
+        # The parsed parameters are then converted to a JSON string to mimic
+        # the structure of the `workflow_dispatch` event's `inputs`.
+        # The workflow proceeds only if
+        # `steps.parsed_command.outputs.should_run == 'true'`.
+        id: parsed_command
         if: ${{ github.event_name == 'issue_comment' && steps.cmd.outputs.continue == 'true' }}
         run: |
           SHOULD_RUN="true"
@@ -97,31 +106,29 @@ jobs:
           echo "should_run=$SHOULD_RUN" >> "$GITHUB_OUTPUT"
           echo "command_params_json=$PARAMS_JSON" >> "$GITHUB_OUTPUT"
 
-      - name: Post Success Comment for PR Comment Trigger
-        if: ${{ github.event_name == 'issue_comment' && steps.validator.outputs.should_run == 'true' }}
+      - name: Post Workflow Trigger Comment
+        # This step posts a comment on the PR to indicate the status of the
+        # workflow trigger. It includes a link to the workflow run for easy
+        # access to the logs.
+        if: ${{ github.event_name == 'issue_comment' && steps.cmd.outputs.continue == 'true' }}
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
           RUN_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-          BODY="llvmdev workflow triggered<br><br><pre>workflow id: ${{ github.run_id }}<br>details: $RUN_URL</pre>"
-          gh pr comment ${{ steps.cmd.outputs.issue_number }} --body "$BODY"
-
-      - name: Post Failure Comment for PR Comment Trigger
-        if: ${{ github.event_name == 'issue_comment' && steps.cmd.outputs.continue == 'true' && steps.validator.outputs.should_run != 'true' }}
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          RUN_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-          BODY="llvmdev workflow failed<br><br><pre>workflow id: ${{ github.run_id }}<br>details: $RUN_URL</pre>"
+          if [[ "${{ steps.parsed_command.outputs.should_run }}" == "true" ]]; then
+            BODY="**llvmlite workflow triggered**<br><br>Successfully triggered<br><br><pre>workflow id: ${{ github.run_id }}<br>details: $RUN_URL</pre>"
+          else
+            BODY="**llvmlite workflow failed**<br><br>Failed to trigger<br><br><pre>workflow id: ${{ github.run_id }}<br>details: $RUN_URL</pre>"
+          fi
           gh pr comment ${{ steps.cmd.outputs.issue_number }} --body "$BODY"
 
       - name: Evaluate
-        if: ${{ github.event_name != 'issue_comment' || steps.validator.outputs.should_run == 'true' }}
+        if: ${{ github.event_name != 'issue_comment' || steps.parsed_command.outputs.should_run == 'true' }}
         id: evaluate
         env:
           GITHUB_EVENT_NAME: ${{ github.event_name }}
           GITHUB_LABEL_NAME: ${{ github.event.label.name }}
-          GITHUB_WORKFLOW_INPUT: ${{ (github.event_name == 'issue_comment' && steps.validator.outputs.command_params_json) || toJson(github.event.inputs) }}
+          GITHUB_WORKFLOW_INPUT: ${{ (github.event_name == 'issue_comment' && steps.parsed_command.outputs.command_params_json) || toJson(github.event.inputs) }}
         run: |
           ./buildscripts/github/llvmdev_evaluate.py
 

--- a/.github/workflows/llvmdev_build.yml
+++ b/.github/workflows/llvmdev_build.yml
@@ -69,7 +69,7 @@ jobs:
         # command is correct and if the issuer has the necessary permissions.
         # for more details see https://github.com/github/command
         # The workflow proceeds only if `steps.cmd.outputs.continue == 'true'`.
-        uses: github/command@v1
+        uses: github/command@v2
         id: cmd
         if: ${{ github.event_name == 'issue_comment' }}
         with:

--- a/.github/workflows/llvmlite_conda_builder.yml
+++ b/.github/workflows/llvmlite_conda_builder.yml
@@ -1,6 +1,8 @@
 name: llvmlite_conda_builder
 
 on:
+  issue_comment:
+    types: [created, edited]
   push:
     branches:
       - main
@@ -27,6 +29,11 @@ on:
           - osx-arm64
           - win-64
 
+# permissions for issue_comment events to read workflow runs and write comments on PRs
+permissions:
+  contents: read
+  pull-requests: write
+
 # Add concurrency control
 concurrency:
   group: >-
@@ -45,27 +52,89 @@ jobs:
     runs-on: ubuntu-24.04
     outputs:
       matrix: ${{ steps.evaluate.outputs.matrix }}
+      pr_comment_trigger_ref: ${{ steps.cmd.outputs.ref }}
+      pr_comment_trigger_status: ${{ steps.validator.outputs.should_run }}
+      pr_comment_llvmdev_runid: ${{ steps.validator.outputs.llvmdev_runid }}
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: '3.13'
+
+      - name: PR Comment Command Check
+        uses: github/command@v1
+        id: cmd
+        if: ${{ github.event_name == 'issue_comment' }}
+        with:
+          command: "/gha llvmlite"
+          reaction: "rocket"
+          allowed_contexts: pull_request
+          allow_forks: true
+          param_separator: " "
+
+      - name: Validate command
+        id: validator
+        if: ${{ github.event_name == 'issue_comment' && steps.cmd.outputs.continue == 'true' }}
+        run: |
+          SHOULD_RUN="true"
+          PARAMS_JSON="{}"
+          LLVMDEV_RUN_ID=""
+          # Default values
+          PLATFORM="all"
+
+          PARAMS=(${{ steps.cmd.outputs.params }})
+          echo "PARAMS: ${PARAMS[*]}"
+          for param in "${PARAMS[@]}"; do
+            case "$param" in
+              platform=*) PLATFORM="${param#*=}" ;;
+              llvmdev_run_id=*) LLVMDEV_RUN_ID="${param#*=}" ;;
+            esac
+          done
+          PARAMS_JSON=$(printf '{"platform": "%s", "llvmdev_run_id": "%s"}' "$PLATFORM" "$LLVMDEV_RUN_ID")
+          {
+            echo "should_run=$SHOULD_RUN"
+            echo "command_params_json=$PARAMS_JSON"
+            echo "llvmdev_runid=$LLVMDEV_RUN_ID"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Post Success Comment for PR Comment Trigger
+        if: ${{ github.event_name == 'issue_comment' && steps.validator.outputs.should_run == 'true' }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          RUN_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          BODY="llvmlite workflow triggered<br><br><pre>workflow id: ${{ github.run_id }}<br>details: $RUN_URL</pre>"
+          gh pr comment ${{ steps.cmd.outputs.issue_number }} --body "$BODY"
+
+
+      - name: Post Failure Comment for PR Comment Trigger
+        if: ${{ github.event_name == 'issue_comment' && steps.cmd.outputs.continue == 'true' && steps.validator.outputs.should_run != 'true' }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          RUN_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          BODY="llvmlite workflow failed<br><br><pre>workflow id: ${{ github.run_id }}<br>details: $RUN_URL</pre>"
+          gh pr comment ${{ steps.cmd.outputs.issue_number }} --body "$BODY"
+
       - name: Evaluate
+        if: ${{ github.event_name != 'issue_comment' || steps.validator.outputs.should_run == 'true' }}
         id: evaluate
         env:
           GITHUB_EVENT_NAME: ${{ github.event_name }}
-          GITHUB_WORKFLOW_INPUT: ${{ toJson(github.event.inputs) }}
+          GITHUB_WORKFLOW_INPUT: ${{ (github.event_name == 'issue_comment' && steps.validator.outputs.command_params_json) || toJson(github.event.inputs) }}
         run: |
           set -ex
           echo "=== Environment ==="
           echo "Event: $GITHUB_EVENT_NAME"
           echo "Inputs: $GITHUB_WORKFLOW_INPUT"
+          echo "Command Params JSON: ${{ steps.validator.outputs.command_params_json }}"
           echo "=== Running evaluation script ==="
           ./buildscripts/github/llvmlite_evaluate.py
           echo "=== Evaluation completed ==="
 
   build:
     needs: check
+    if: ${{ (github.event_name == 'issue_comment' && needs.check.outputs.pr_comment_trigger_status == 'true') || github.event_name != 'issue_comment' }}
     name: ${{ matrix.platform }}-py${{ matrix.python-version }}-build
     runs-on: ${{ matrix.runner }}
     defaults:
@@ -80,6 +149,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
+          ref: ${{ github.event_name == 'issue_comment' && needs.check.outputs.pr_comment_trigger_ref || github.ref }}
 
       - name: Setup platform-specific requirements
         if: matrix.platform == 'osx-64'
@@ -97,12 +167,12 @@ jobs:
         run: conda install conda-build
 
       - name: Download llvmdev Artifact
-        if: ${{ inputs.llvmdev_run_id != '' }}
+        if: ${{ inputs.llvmdev_run_id != '' || needs.check.outputs.pr_comment_llvmdev_runid != '' }}
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           name: llvmdev_${{ matrix.platform }}
           path: llvmdev_conda_packages
-          run-id: ${{ inputs.llvmdev_run_id }}
+          run-id: ${{ github.event_name == 'workflow_dispatch' && inputs.llvmdev_run_id || (github.event_name == 'issue_comment' && needs.check.outputs.pr_comment_llvmdev_runid) || '' }}
           repository: ${{ github.repository }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
@@ -132,6 +202,7 @@ jobs:
   test:
     name: ${{ matrix.platform }}-py${{ matrix.python-version }}-test
     needs: [check, build]
+    if: ${{ (github.event_name == 'issue_comment' && needs.check.outputs.pr_comment_trigger_status == 'true') || github.event_name != 'issue_comment' }}
     runs-on: ${{ matrix.runner }}
     defaults:
       run:

--- a/.github/workflows/llvmlite_conda_builder.yml
+++ b/.github/workflows/llvmlite_conda_builder.yml
@@ -53,15 +53,18 @@ jobs:
     outputs:
       matrix: ${{ steps.evaluate.outputs.matrix }}
       pr_comment_trigger_ref: ${{ steps.cmd.outputs.ref }}
-      pr_comment_trigger_status: ${{ steps.validator.outputs.should_run }}
-      pr_comment_llvmdev_runid: ${{ steps.validator.outputs.llvmdev_runid }}
+      pr_comment_trigger_status: ${{ steps.parsed_command.outputs.should_run }}
+      pr_comment_llvmdev_runid: ${{ steps.parsed_command.outputs.llvmdev_runid }}
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: '3.13'
 
-      - name: PR Comment Command Check
+      - name: 'PR Comment - Command Check (1/2)'
+        # This step verifies and validates the trigger command. It checks if the
+        # command is correct and if the issuer has the necessary permissions.
+        # The workflow proceeds only if `steps.cmd.outputs.continue == 'true'`.
         uses: github/command@v1
         id: cmd
         if: ${{ github.event_name == 'issue_comment' }}
@@ -72,8 +75,13 @@ jobs:
           allow_forks: true
           param_separator: " "
 
-      - name: Validate command
-        id: validator
+      - name: 'PR Comment - Parse Parameters (2/2)'
+        # This step parses the parameters from the PR comment command.
+        # The parsed parameters are then converted to a JSON string to mimic
+        # the structure of the `workflow_dispatch` event's `inputs`.
+        # The workflow proceeds only if
+        # `steps.parsed_command.outputs.should_run == 'true'`.
+        id: parsed_command
         if: ${{ github.event_name == 'issue_comment' && steps.cmd.outputs.continue == 'true' }}
         run: |
           SHOULD_RUN="true"
@@ -97,37 +105,33 @@ jobs:
             echo "llvmdev_runid=$LLVMDEV_RUN_ID"
           } >> "$GITHUB_OUTPUT"
 
-      - name: Post Success Comment for PR Comment Trigger
-        if: ${{ github.event_name == 'issue_comment' && steps.validator.outputs.should_run == 'true' }}
+      - name: Post Workflow Trigger Comment
+        # This step posts a comment on the PR to indicate the status of the
+        # workflow trigger. It includes a link to the workflow run for easy
+        # access to the logs.
+        if: ${{ github.event_name == 'issue_comment' && steps.cmd.outputs.continue == 'true' }}
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
           RUN_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-          BODY="llvmlite workflow triggered<br><br><pre>workflow id: ${{ github.run_id }}<br>details: $RUN_URL</pre>"
-          gh pr comment ${{ steps.cmd.outputs.issue_number }} --body "$BODY"
-
-
-      - name: Post Failure Comment for PR Comment Trigger
-        if: ${{ github.event_name == 'issue_comment' && steps.cmd.outputs.continue == 'true' && steps.validator.outputs.should_run != 'true' }}
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          RUN_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-          BODY="llvmlite workflow failed<br><br><pre>workflow id: ${{ github.run_id }}<br>details: $RUN_URL</pre>"
+          if [[ "${{ steps.parsed_command.outputs.should_run }}" == "true" ]]; then
+            BODY="**llvmlite workflow triggered**<br><br>Successfully triggered<br><br><pre>workflow id: ${{ github.run_id }}<br>details: $RUN_URL</pre>"
+          else
+            BODY="**llvmlite workflow failed**<br><br>Failed to trigger<br><br><pre>workflow id: ${{ github.run_id }}<br>details: $RUN_URL</pre>"
+          fi
           gh pr comment ${{ steps.cmd.outputs.issue_number }} --body "$BODY"
 
       - name: Evaluate
-        if: ${{ github.event_name != 'issue_comment' || steps.validator.outputs.should_run == 'true' }}
+        if: ${{ github.event_name != 'issue_comment' || steps.parsed_command.outputs.should_run == 'true' }}
         id: evaluate
         env:
           GITHUB_EVENT_NAME: ${{ github.event_name }}
-          GITHUB_WORKFLOW_INPUT: ${{ (github.event_name == 'issue_comment' && steps.validator.outputs.command_params_json) || toJson(github.event.inputs) }}
+          GITHUB_WORKFLOW_INPUT: ${{ (github.event_name == 'issue_comment' && steps.parsed_command.outputs.command_params_json) || toJson(github.event.inputs) }}
         run: |
           set -ex
           echo "=== Environment ==="
           echo "Event: $GITHUB_EVENT_NAME"
           echo "Inputs: $GITHUB_WORKFLOW_INPUT"
-          echo "Command Params JSON: ${{ steps.validator.outputs.command_params_json }}"
           echo "=== Running evaluation script ==="
           ./buildscripts/github/llvmlite_evaluate.py
           echo "=== Evaluation completed ==="

--- a/.github/workflows/llvmlite_conda_builder.yml
+++ b/.github/workflows/llvmlite_conda_builder.yml
@@ -65,7 +65,7 @@ jobs:
         # This step verifies and validates the trigger command. It checks if the
         # command is correct and if the issuer has the necessary permissions.
         # The workflow proceeds only if `steps.cmd.outputs.continue == 'true'`.
-        uses: github/command@v1
+        uses: github/command@v2
         id: cmd
         if: ${{ github.event_name == 'issue_comment' }}
         with:

--- a/buildscripts/github/llvmdev_evaluate.py
+++ b/buildscripts/github/llvmdev_evaluate.py
@@ -85,8 +85,8 @@ if event == "pull_request":
 elif event == "label" and label == "build_on_gha":
     print("build label detected")
     include = default_include
-elif event == "workflow_dispatch":
-    print("workflow_dispatch detected")
+elif event in ("issue_comment", "workflow_dispatch"):
+    print(f"{event} detected")
     params = json.loads(inputs)
     platform = params.get("platform", "all")
     recipe = params.get("recipe", "all")

--- a/buildscripts/github/llvmlite_evaluate.py
+++ b/buildscripts/github/llvmlite_evaluate.py
@@ -42,8 +42,8 @@ if event in ("pull_request", "push"):
 elif event == "label" and label == "build_llvmlite_on_gha":
     print("build label detected")
     include = default_include
-elif event == "workflow_dispatch":
-    print("workflow_dispatch detected")
+elif event in ("issue_comment", "workflow_dispatch"):
+    print(f"{event} detected")
     params = json.loads(inputs)
     platform = params.get("platform", "all")
 

--- a/buildscripts/manylinux/prepare_miniconda.sh
+++ b/buildscripts/manylinux/prepare_miniconda.sh
@@ -5,5 +5,6 @@ curl -L -o mini3.sh $1
 bash mini3.sh -b -f -p /root/miniconda3
 echo "Miniconda installed"
 source /root/miniconda3/bin/activate base
+export CONDA_PLUGINS_AUTO_ACCEPT_TOS=1
 echo "Env activated"
 cd -


### PR DESCRIPTION
Currently, the GitHub Action workflows for building and testing llvmdev and llvmlite conda packages can only be triggered manually through the GitHub web interface using the `workflow_dispatch` event. This involves navigating to:

Actions tab → 'Run workflow' dropdown → Select branch and user inputs → Click 'Run'.:

Additionally, pull request triggers activate only when workflow files themselves change.
However, these triggers are inadequate for fully testing pull requests from forks, particularly when verifying the complete build chain (llvmdev → llvmlite).

To resolve this, the current PR introduces issue-comment event triggers using the [github/command](https://github.com/github/command) action. This setup enables maintainers with sufficient permissions (Numba developers) to invoke GitHub Action workflows directly through PR comments.

security and permissions:
- Only maintainers or contributors with write permissions can trigger workflows using the /gha llvmdev command in PR comments.
- The github/command action explicitly permits triggering workflows from forked repositories (`allow_forks: true`). 
- Commands are strictly parsed and validated within the workflow to prevent unauthorized or unintended execution.

references:
- https://docs.github.com/en/actions/reference/events-that-trigger-workflows#issue_comment
- https://github.com/marketplace/actions/command-action

To achieve this, this PR adds `issue-event` triggers using `github/command` action. ([github/command](https://github.com/github/command))
```
usage: 
[command] [keyword-args optional]
/gha llvmdev [platform='all', recipe='all']
/gha llvmlite [platform='all', llvmdev_run_id=''] 
```
llvmdev_run_id: Workflow ID obtained from the llvmdev run, required to retrieve artifacts.