### PR TITLE
set CONDA_PLUGINS_AUTO_ACCEPT_TOS to manylinux env setup script

### DIFF
--- a/buildscripts/manylinux/prepare_miniconda.sh
+++ b/buildscripts/manylinux/prepare_miniconda.sh
@@ -5,5 +5,6 @@ curl -L -o mini3.sh $1
 bash mini3.sh -b -f -p /root/miniconda3
 echo "Miniconda installed"
 source /root/miniconda3/bin/activate base
+export CONDA_PLUGINS_AUTO_ACCEPT_TOS=true
 echo "Env activated"
 cd -


### PR DESCRIPTION
This PR adds CONDA_PLUGINS_AUTO_ACCEPT_TOS=1 to -
- GHA workflows that use conda environment and 
- scripts used to setup conda env for azure pipelines and on manylinux containers