### PR TITLE
gha/fix artifact usage manylinux wheels

### DIFF
--- a/.github/workflows/llvmlite_linux-64_wheel_builder.yml
+++ b/.github/workflows/llvmlite_linux-64_wheel_builder.yml
@@ -78,11 +78,13 @@ jobs:
 
       - name: Build wheel in manylinux container
         run: |
+          LLVMDEV_ARTIFACT_PATH="/root/llvmlite/llvmdev_conda_packages"
+
           # Run the build script in manylinux container using the existing script
           docker run --rm \
             -v "$(pwd):/root/llvmlite" \
             quay.io/pypa/${{ env.MANYLINUX_IMAGE }} \
-            bash -c "git config --global --add safe.directory /root/llvmlite && /root/llvmlite/buildscripts/manylinux/build_llvmlite.sh ${{ env.MINICONDA_FILE }} ${{ env.PYTHON_PATH }}"
+            bash -c "git config --global --add safe.directory /root/llvmlite && /root/llvmlite/buildscripts/manylinux/build_llvmlite.sh ${{ env.MINICONDA_FILE }} ${{ env.PYTHON_PATH }} $LLVMDEV_ARTIFACT_PATH"
 
           # Create wheelhouse directory for artifact upload
           mkdir -p wheelhouse

--- a/.github/workflows/llvmlite_linux-aarch64_wheel_builder.yml
+++ b/.github/workflows/llvmlite_linux-aarch64_wheel_builder.yml
@@ -78,11 +78,13 @@ jobs:
 
       - name: Build wheel in manylinux container
         run: |
+          LLVMDEV_ARTIFACT_PATH="/root/llvmlite/llvmdev_conda_packages"
+
           # Run the build script in manylinux container using the existing script
           docker run --rm \
             -v "$(pwd):/root/llvmlite" \
             quay.io/pypa/${{ env.MANYLINUX_IMAGE }} \
-            bash -c "git config --global --add safe.directory /root/llvmlite && /root/llvmlite/buildscripts/manylinux/build_llvmlite.sh ${{ env.MINICONDA_FILE }} ${{ env.PYTHON_PATH }}"
+            bash -c "git config --global --add safe.directory /root/llvmlite && /root/llvmlite/buildscripts/manylinux/build_llvmlite.sh ${{ env.MINICONDA_FILE }} ${{ env.PYTHON_PATH }} $LLVMDEV_ARTIFACT_PATH"
 
           # Create wheelhouse directory for artifact upload
           mkdir -p wheelhouse

--- a/buildscripts/manylinux/build_llvmlite.sh
+++ b/buildscripts/manylinux/build_llvmlite.sh
@@ -13,20 +13,25 @@ sourceroot=$(pwd)
 pyver=$2
 envname="llvmbase"
 outputdir="/root/llvmlite/docker_output"
+LLVMDEV_PKG_PATH=${3:-""}
 
 ls -l /opt/python/$pyver/bin
 
-conda create -y -n $envname 
+conda create -y -n $envname
 conda activate $envname
 # Install llvmdev
 
-if [[ $(uname -m) == "aarch64" ]] ; then
-    conda install -y numba/label/manylinux_2_28::llvmdev --no-deps
-elif [[ $(uname -m) == "x86_64" ]] ; then
-    conda install -y numba/label/manylinux_2_17::llvmdev --no-deps
+if [ -n "$LLVMDEV_PKG_PATH" ] && [ -d "$LLVMDEV_PKG_PATH" ]; then
+    conda install -y -c "file://$LLVMDEV_PKG_PATH" llvmdev --no-deps
 else
-    echo "Error: Unsupported architecture: $(uname -m)"
-    exit 1
+    if [[ $(uname -m) == "aarch64" ]] ; then
+        conda install -y numba/label/manylinux_2_28::llvmdev --no-deps
+    elif [[ $(uname -m) == "x86_64" ]] ; then
+        conda install -y numba/label/manylinux_2_17::llvmdev --no-deps
+    else
+        echo "Error: Unsupported architecture: $(uname -m)"
+        exit 1
+    fi
 fi
 
 # Prepend builtin Python Path

--- a/buildscripts/manylinux/build_llvmlite.sh
+++ b/buildscripts/manylinux/build_llvmlite.sh
@@ -22,7 +22,7 @@ conda activate $envname
 # Install llvmdev
 
 if [ -n "$LLVMDEV_ARTIFACT_PATH" ] && [ -d "$LLVMDEV_ARTIFACT_PATH" ]; then
-    conda install -y "$LLVMDEV_ARTIFACT_PATH"/*.conda --no-deps
+    conda install -y "$LLVMDEV_ARTIFACT_PATH"/llvmdev-*.conda --no-deps
 else
     if [[ $(uname -m) == "aarch64" ]] ; then
         conda install -y numba/label/manylinux_2_28::llvmdev --no-deps

--- a/buildscripts/manylinux/build_llvmlite.sh
+++ b/buildscripts/manylinux/build_llvmlite.sh
@@ -13,7 +13,7 @@ sourceroot=$(pwd)
 pyver=$2
 envname="llvmbase"
 outputdir="/root/llvmlite/docker_output"
-LLVMDEV_PKG_PATH=${3:-""}
+LLVMDEV_ARTIFACT_PATH=${3:-""}
 
 ls -l /opt/python/$pyver/bin
 
@@ -21,8 +21,8 @@ conda create -y -n $envname
 conda activate $envname
 # Install llvmdev
 
-if [ -n "$LLVMDEV_PKG_PATH" ] && [ -d "$LLVMDEV_PKG_PATH" ]; then
-    conda install -y "$LLVMDEV_PKG_PATH"/*.conda --no-deps
+if [ -n "$LLVMDEV_ARTIFACT_PATH" ] && [ -d "$LLVMDEV_ARTIFACT_PATH" ]; then
+    conda install -y "$LLVMDEV_ARTIFACT_PATH"/*.conda --no-deps
 else
     if [[ $(uname -m) == "aarch64" ]] ; then
         conda install -y numba/label/manylinux_2_28::llvmdev --no-deps

--- a/buildscripts/manylinux/build_llvmlite.sh
+++ b/buildscripts/manylinux/build_llvmlite.sh
@@ -22,7 +22,7 @@ conda activate $envname
 # Install llvmdev
 
 if [ -n "$LLVMDEV_PKG_PATH" ] && [ -d "$LLVMDEV_PKG_PATH" ]; then
-    conda install -y -c "file://$LLVMDEV_PKG_PATH" llvmdev --no-deps
+    conda install -y "$LLVMDEV_PKG_PATH"/*.conda --no-deps
 else
     if [[ $(uname -m) == "aarch64" ]] ; then
         conda install -y numba/label/manylinux_2_28::llvmdev --no-deps


### PR DESCRIPTION
The `llvmlite_linux-64_wheel_builder `and `llvmlite_linux-aarch64_wheel_builder` workflows have an `llvmdev_run_id` input parameter that allows users to specify a custom llvmdev build from a previous workflow run.
The build script always fell back to installing llvmdev from conda channels. 
This PR adds (optional) `llvmdev artifact path` as a 3rd parameter to the build script, with fallback to llvmdev from numba conda channel when the parameter is absent..