### PR TITLE
llvmdev-20 recipe fixes

### DIFF
--- a/conda-recipes/llvmdev/conda_build_config.yaml
+++ b/conda-recipes/llvmdev/conda_build_config.yaml
@@ -1,11 +1,11 @@
 # Numba/llvmlite stack needs an older compiler for backwards compatability.
 c_compiler_version:         # [linux or osx]
   - 11                      # [linux]
-  - 14                      # [osx]
+  - 19                      # [osx]
 
 cxx_compiler_version:       # [linux or osx]
   - 11                      # [linux]
-  - 14                      # [osx]
+  - 19                      # [osx]
 
 fortran_compiler_version:   # [linux]
   - 11                      # [linux]

--- a/conda-recipes/llvmdev_for_wheel/build.sh
+++ b/conda-recipes/llvmdev_for_wheel/build.sh
@@ -16,7 +16,7 @@ cd build
 
 export CPU_COUNT=4
 
-CMAKE_ARGS="${CMAKE_ARGS} -DLLVM_ENABLE_PROJECTS=lld;libunwind;compiler-rt"
+CMAKE_ARGS="${CMAKE_ARGS} -DLLVM_ENABLE_PROJECTS=lld;compiler-rt"
 
 if [[ "$target_platform" == "linux-64" ]]; then
   CMAKE_ARGS="${CMAKE_ARGS} -DLLVM_USE_INTEL_JITEVENTS=ON"

--- a/conda-recipes/llvmdev_for_wheel/conda_build_config.yaml
+++ b/conda-recipes/llvmdev_for_wheel/conda_build_config.yaml
@@ -17,10 +17,10 @@ cxx_compiler:            # [win]
   - vs2022              # [win]
 
 c_compiler_version:         # [osx]
-  - 14                      # [osx]
+  - 19                      # [osx]
 
 cxx_compiler_version:       # [osx]
-  - 14                      # [osx]
+  - 19                      # [osx]
 
 MACOSX_SDK_VERSION:    # [osx and x86_64]
   - 10.12              # [osx and x86_64]

--- a/conda-recipes/llvmdev_for_wheel/meta.yaml
+++ b/conda-recipes/llvmdev_for_wheel/meta.yaml
@@ -12,16 +12,16 @@ source:
   - url: https://github.com/llvm/llvm-project/releases/download/llvmorg-{{ version.replace(".rc", "-rc") }}/llvm-project-{{ version.replace(".rc", "rc") }}.src.tar.xz
     sha256: {{ sha256_llvm }}
     patches:
-    - ../llvm15-clear-gotoffsetmap.patch
-    - ../llvm15-remove-use-of-clonefile.patch
-    - ../llvm15-svml.patch
-    - ../compiler-rt-cfi-startproc-war.patch
-    - ../compiler-rt-macos-build.patch
+    # - ../llvm15-clear-gotoffsetmap.patch
+    # - ../llvm15-remove-use-of-clonefile.patch
+    # - ../llvm15-svml.patch
+    # - ../compiler-rt-cfi-startproc-war.patch
+    # - ../compiler-rt-macos-build.patch
     # Patches from conda-forge needed for windows to build
     # backport of zlib patches, can be dropped for vs15.0.3, see
     # https://reviews.llvm.org/D135457 & https://reviews.llvm.org/D136065
-    - ../llvmdev/patches/0002-CMake-Fix-Findzstd-module-for-shared-DLL-on-Windows.patch
-    - ../llvmdev/patches/no-windows-symlinks.patch
+    # - ../llvmdev/patches/0002-CMake-Fix-Findzstd-module-for-shared-DLL-on-Windows.patch
+    # - ../llvmdev/patches/no-windows-symlinks.patch
 
 build:
   number: {{ build_number }}


### PR DESCRIPTION
Fixes llvmdev build failures.
Changes:
- pin macOS compilers to 19
- remove libunwind from llvmdev_for_wheel recipe
- remove obsolete patches from llvmdev_for_wheel recipe