### PR TITLE
GHA/ standardize job names on workflows for linux builds

### DIFF
--- a/.github/workflows/llvmlite_linux-64_wheel_builder.yml
+++ b/.github/workflows/llvmlite_linux-64_wheel_builder.yml
@@ -29,7 +29,7 @@ env:
 
 jobs:
   linux-64-build:
-    name: linux-64-build-py${{ matrix.python-version }}
+    name: linux-64-build
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -116,7 +116,7 @@ jobs:
         run: "echo \"Workflow Run ID: ${{ github.run_id }}\""
 
   linux-64-validate:
-    name: validate-py${{ matrix.python-version }}
+    name: linux-64-validate
     needs: linux-64-build
     runs-on: ubuntu-latest
     defaults:
@@ -157,7 +157,7 @@ jobs:
           done
 
   linux-64-test:
-    name: test-py${{ matrix.python-version }}
+    name: linux-64-test
     needs: linux-64-build
     runs-on: ubuntu-latest
     defaults:
@@ -213,7 +213,7 @@ jobs:
           "${PYTHON_PATH}" -m llvmlite.tests
 
   linux-64-upload:
-    name: upload-py${{ matrix.python-version }}
+    name: linux-64-upload
     needs: [linux-64-test, linux-64-validate]
     if: github.event_name == 'workflow_dispatch' && inputs.upload_wheel_to_anaconda
     runs-on: ubuntu-latest

--- a/.github/workflows/llvmlite_linux-aarch64_wheel_builder.yml
+++ b/.github/workflows/llvmlite_linux-aarch64_wheel_builder.yml
@@ -29,7 +29,7 @@ env:
 
 jobs:
   linux-aarch64-build:
-    name: linux-aarch64-build-py${{ matrix.python-version }}
+    name: linux-aarch64-build
     runs-on: ubuntu-24.04-arm
     defaults:
       run:
@@ -113,7 +113,7 @@ jobs:
         run: "echo \"Workflow Run ID: ${{ github.run_id }}\""
 
   linux-aarch64-validate:
-    name: validate-py${{ matrix.python-version }}
+    name: linux-aarch64-validate
     needs: linux-aarch64-build
     runs-on: ubuntu-24.04-arm
     defaults:
@@ -154,7 +154,7 @@ jobs:
           done
 
   linux-aarch64-test:
-    name: test-py${{ matrix.python-version }}
+    name: linux-aarch64-test
     needs: linux-aarch64-build
     runs-on: ubuntu-24.04-arm
     defaults:
@@ -210,7 +210,7 @@ jobs:
           "${PYTHON_PATH}" -m llvmlite.tests
 
   linux-aarch64-upload:
-    name: upload-py${{ matrix.python-version }}
+    name: linux-aarch64-upload
     needs: [linux-aarch64-test, linux-aarch64-validate]
     if: github.event_name == 'workflow_dispatch' && inputs.upload_wheel_to_anaconda
     runs-on: ubuntu-24.04-arm


### PR DESCRIPTION
updates job naming on linux GHA workflows to follow the same as others. eg.`linux-64-validate`
resolves https://github.com/numba/llvmlite/issues/1271