### PR TITLE
GHA/ add Python 3.14 to CI

### DIFF
--- a/.github/workflows/llvmlite_conda_builder.yml
+++ b/.github/workflows/llvmlite_conda_builder.yml
@@ -68,6 +68,8 @@ jobs:
     needs: check
     name: ${{ matrix.platform }}-py${{ matrix.python-version }}-build
     runs-on: ${{ matrix.runner }}
+    env:
+      EXTRA_CHANNELS: ''
     defaults:
       run:
         shell: bash -elx {0}
@@ -109,7 +111,12 @@ jobs:
           fi
           CONDA_CHANNEL_DIR="conda_channel_dir"
           mkdir $CONDA_CHANNEL_DIR
-          conda build --debug -c "$LLVMDEV_CHANNEL" -c defaults --python=${{ matrix.python-version }} conda-recipes/llvmlite --output-folder=$CONDA_CHANNEL_DIR --no-test
+          if [ -n "${EXTRA_CHANNELS}" ]; then
+            extra_args=(${EXTRA_CHANNELS})
+          else
+            extra_args=()
+          fi
+          conda build --debug -c "${LLVMDEV_CHANNEL}" "${extra_args[@]}" -c defaults --python=${{ matrix.python-version }} conda-recipes/llvmlite --output-folder="${CONDA_CHANNEL_DIR}" --no-test
 
       - name: Upload llvmlite conda package
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
@@ -127,6 +134,8 @@ jobs:
     name: ${{ matrix.platform }}-py${{ matrix.python-version }}-test
     needs: [check, build]
     runs-on: ${{ matrix.runner }}
+    env:
+      EXTRA_CHANNELS: ''
     defaults:
       run:
         shell: bash -elx {0}
@@ -147,4 +156,10 @@ jobs:
         run: conda install conda-build
 
       - name: Run tests
-        run: conda build --test ${{ matrix.platform }}/llvmlite*.conda
+        run: |
+          if [ -n "${EXTRA_CHANNELS}" ]; then
+            extra_args=(${EXTRA_CHANNELS})
+          else
+            extra_args=()
+          fi
+          conda build --test "${extra_args[@]}" "${{ matrix.platform }}"/llvmlite*.conda

--- a/.github/workflows/llvmlite_conda_builder.yml
+++ b/.github/workflows/llvmlite_conda_builder.yml
@@ -69,7 +69,7 @@ jobs:
     name: ${{ matrix.platform }}-py${{ matrix.python-version }}-build
     runs-on: ${{ matrix.runner }}
     env:
-      EXTRA_CHANNELS: ''
+      EXTRA_CHANNELS: ${{ matrix.python-version == '3.14' && '-c ad-testing/label/py314' || '' }}
     defaults:
       run:
         shell: bash -elx {0}
@@ -135,7 +135,7 @@ jobs:
     needs: [check, build]
     runs-on: ${{ matrix.runner }}
     env:
-      EXTRA_CHANNELS: ''
+      EXTRA_CHANNELS: ${{ matrix.python-version == '3.14' && '-c ad-testing/label/py314' || '' }}
     defaults:
       run:
         shell: bash -elx {0}

--- a/.github/workflows/llvmlite_linux-64_wheel_builder.yml
+++ b/.github/workflows/llvmlite_linux-64_wheel_builder.yml
@@ -36,7 +36,7 @@ jobs:
         shell: bash -elx {0}
     strategy:
       matrix:
-        python-version: ["3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
       fail-fast: false
 
     steps:
@@ -70,6 +70,7 @@ jobs:
             "3.11") echo "PYTHON_PATH=cp311-cp311" >> "$GITHUB_ENV" ;;
             "3.12") echo "PYTHON_PATH=cp312-cp312" >> "$GITHUB_ENV" ;;
             "3.13") echo "PYTHON_PATH=cp313-cp313" >> "$GITHUB_ENV" ;;
+            "3.14") echo "PYTHON_PATH=cp314-cp314" >> "$GITHUB_ENV" ;;
             *) echo "Invalid Python version" && exit 1 ;;
           esac
 
@@ -124,7 +125,7 @@ jobs:
         shell: bash -elx {0}
     strategy:
       matrix:
-        python-version: ["3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
       fail-fast: false
     steps:
       - name: Clone repository
@@ -165,7 +166,7 @@ jobs:
         shell: bash -elx {0}
     strategy:
       matrix:
-        python-version: ["3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
       fail-fast: false
 
     steps:
@@ -222,7 +223,7 @@ jobs:
         shell: bash -elx {0}
     strategy:
       matrix:
-        python-version: ["3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
       fail-fast: false
     steps:
       - name: Setup Miniconda

--- a/.github/workflows/llvmlite_linux-64_wheel_builder.yml
+++ b/.github/workflows/llvmlite_linux-64_wheel_builder.yml
@@ -174,6 +174,7 @@ jobs:
         uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c # v6.0.0
         with:
           python-version: ${{ matrix.python-version }}
+          allow-prereleases: true
 
       - name: Download llvmlite wheel
         uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5.0.0

--- a/.github/workflows/llvmlite_linux-aarch64_wheel_builder.yml
+++ b/.github/workflows/llvmlite_linux-aarch64_wheel_builder.yml
@@ -36,7 +36,7 @@ jobs:
         shell: bash -elx {0}
     strategy:
       matrix:
-        python-version: ["3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
       fail-fast: false
 
     steps:
@@ -70,6 +70,7 @@ jobs:
             "3.11") echo "PYTHON_PATH=cp311-cp311" >> "$GITHUB_ENV" ;;
             "3.12") echo "PYTHON_PATH=cp312-cp312" >> "$GITHUB_ENV" ;;
             "3.13") echo "PYTHON_PATH=cp313-cp313" >> "$GITHUB_ENV" ;;
+            "3.14") echo "PYTHON_PATH=cp314-cp314" >> "$GITHUB_ENV" ;;
             *) echo "Invalid Python version" && exit 1 ;;
           esac
 
@@ -121,7 +122,7 @@ jobs:
         shell: bash -elx {0}
     strategy:
       matrix:
-        python-version: ["3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
       fail-fast: false
     steps:
       - name: Clone repository
@@ -162,7 +163,7 @@ jobs:
         shell: bash -elx {0}
     strategy:
       matrix:
-        python-version: ["3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
       fail-fast: false
 
     steps:
@@ -219,7 +220,7 @@ jobs:
         shell: bash -elx {0}
     strategy:
       matrix:
-        python-version: ["3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
       fail-fast: false
     steps:
       - name: Setup Miniconda

--- a/.github/workflows/llvmlite_linux-aarch64_wheel_builder.yml
+++ b/.github/workflows/llvmlite_linux-aarch64_wheel_builder.yml
@@ -171,6 +171,7 @@ jobs:
         uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c # v6.0.0
         with:
           python-version: ${{ matrix.python-version }}
+          allow-prereleases: true
 
       - name: Download llvmlite wheel
         uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5.0.0

--- a/.github/workflows/llvmlite_osx-arm64_wheel_builder.yml
+++ b/.github/workflows/llvmlite_osx-arm64_wheel_builder.yml
@@ -35,7 +35,7 @@ jobs:
         shell: bash -elx {0}
     strategy:
       matrix:
-        python-version: ["3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
       fail-fast: false
 
     steps:
@@ -124,7 +124,7 @@ jobs:
         shell: bash -elx {0}
     strategy:
       matrix:
-        python-version: ["3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
       fail-fast: false
     steps:
       - name: Clone repository
@@ -161,7 +161,7 @@ jobs:
         shell: bash -elx {0}
     strategy:
       matrix:
-        python-version: ["3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
       fail-fast: false
 
     steps:
@@ -200,7 +200,7 @@ jobs:
         shell: bash -elx {0}
     strategy:
       matrix:
-        python-version: ["3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
       fail-fast: false
     steps:
       - name: Setup Miniconda

--- a/.github/workflows/llvmlite_osx-arm64_wheel_builder.yml
+++ b/.github/workflows/llvmlite_osx-arm64_wheel_builder.yml
@@ -47,10 +47,15 @@ jobs:
       - name: Setup Miniconda
         uses: conda-incubator/setup-miniconda@835234971496cad1653abb28a638a281cf32541f # v3.2.0
         with:
-          python-version: ${{ matrix.python-version }}
+          python-version: ${{ matrix.python-version != '3.14' && matrix.python-version || '3.12'}}
           conda-remove-defaults: true
           auto-update-conda: true
           auto-activate-base: true
+
+      - name: Install Python 3.14
+        if: matrix.python-version == '3.14'
+        run: |
+          conda install -c ad-testing/label/py314 -c defaults python=${{ matrix.python-version }} -y
 
       - name: Download llvmdev Artifact
         if: ${{ inputs.llvmdev_run_id != '' }}
@@ -71,7 +76,7 @@ jobs:
               CHAN="${{ env.CONDA_CHANNEL_NUMBA }}"
               conda install -c defaults "${CHAN}::llvmdev=${{ env.FALLBACK_LLVMDEV_VERSION }}"
           fi
-          conda install -c defaults python-build
+          python -m pip install build
 
           # Hide libunwind to prevent it from being linked against during build
           # On macOS, if libunwind.dylib from the llvmdev conda package gets linked, the resulting wheel
@@ -169,6 +174,7 @@ jobs:
         uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c # v6.0.0
         with:
           python-version: ${{ matrix.python-version }}
+          allow-prereleases: true
 
       - name: Download llvmlite wheel
         uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5.0.0

--- a/.github/workflows/llvmlite_win-64_wheel_builder.yml
+++ b/.github/workflows/llvmlite_win-64_wheel_builder.yml
@@ -36,7 +36,7 @@ jobs:
         shell: bash -elx {0}
     strategy:
       matrix:
-        python-version: ["3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
       fail-fast: false
 
     steps:
@@ -100,7 +100,7 @@ jobs:
         shell: bash -elx {0}
     strategy:
       matrix:
-        python-version: ["3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
       fail-fast: false
     steps:
       - name: Clone repository
@@ -141,7 +141,7 @@ jobs:
         shell: bash -elx {0}
     strategy:
       matrix:
-        python-version: ["3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
       fail-fast: false
 
     steps:
@@ -186,7 +186,7 @@ jobs:
         shell: bash -elx {0}
     strategy:
       matrix:
-        python-version: ["3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
       fail-fast: false
     steps:
       - name: Setup Miniconda

--- a/.github/workflows/llvmlite_win-64_wheel_builder.yml
+++ b/.github/workflows/llvmlite_win-64_wheel_builder.yml
@@ -48,11 +48,16 @@ jobs:
       - name: Setup Miniconda
         uses: conda-incubator/setup-miniconda@835234971496cad1653abb28a638a281cf32541f # v3.2.0
         with:
-          python-version: ${{ matrix.python-version }}
+          python-version: ${{ matrix.python-version != '3.14' && matrix.python-version || '3.12'}}
           conda-remove-defaults: true
           auto-update-conda: true
           auto-activate-base: true
 
+      - name: Install Python 3.14
+        if: matrix.python-version == '3.14'
+        run: |
+          conda install -c ad-testing/label/py314 -c defaults python=${{ matrix.python-version }} -y
+  
       - name: Download llvmdev Artifact
         if: ${{ inputs.llvmdev_run_id != '' }}
         uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5.0.0
@@ -72,7 +77,8 @@ jobs:
               CHAN="${{ env.CONDA_CHANNEL_NUMBA }}"
               conda install -c defaults "${CHAN}::llvmdev=${{ env.FALLBACK_LLVMDEV_VERSION }}"
           fi
-          conda install -c defaults cmake libxml2 python-build
+          conda install -c defaults cmake libxml2 
+          python -m pip install build
 
       - name: Build wheel
         env:
@@ -149,6 +155,7 @@ jobs:
         uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c # v6.0.0
         with:
           python-version: ${{ matrix.python-version }}
+          allow-prereleases: true
 
       - name: Download llvmlite wheel
         uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5.0.0

--- a/buildscripts/github/llvmlite_evaluate.py
+++ b/buildscripts/github/llvmlite_evaluate.py
@@ -22,24 +22,28 @@ default_include = [
     {"runner": runner_mapping["linux-64"], "platform": "linux-64", "python-version": "3.11"},
     {"runner": runner_mapping["linux-64"], "platform": "linux-64", "python-version": "3.12"},
     {"runner": runner_mapping["linux-64"], "platform": "linux-64", "python-version": "3.13"},
+    {"runner": runner_mapping["linux-64"], "platform": "linux-64", "python-version": "3.14"},
 
     # linux-aarch64
     {"runner": runner_mapping["linux-aarch64"], "platform": "linux-aarch64", "python-version": "3.10"},
     {"runner": runner_mapping["linux-aarch64"], "platform": "linux-aarch64", "python-version": "3.11"},
     {"runner": runner_mapping["linux-aarch64"], "platform": "linux-aarch64", "python-version": "3.12"},
     {"runner": runner_mapping["linux-aarch64"], "platform": "linux-aarch64", "python-version": "3.13"},
+    {"runner": runner_mapping["linux-aarch64"], "platform": "linux-aarch64", "python-version": "3.14"},
 
     # osx-arm64
     {"runner": runner_mapping["osx-arm64"], "platform": "osx-arm64", "python-version": "3.10"},
     {"runner": runner_mapping["osx-arm64"], "platform": "osx-arm64", "python-version": "3.11"},
     {"runner": runner_mapping["osx-arm64"], "platform": "osx-arm64", "python-version": "3.12"},
     {"runner": runner_mapping["osx-arm64"], "platform": "osx-arm64", "python-version": "3.13"},
+    {"runner": runner_mapping["osx-arm64"], "platform": "osx-arm64", "python-version": "3.14"},
 
     # win-64
     {"runner": runner_mapping["win-64"], "platform": "win-64", "python-version": "3.10"},
     {"runner": runner_mapping["win-64"], "platform": "win-64", "python-version": "3.11"},
     {"runner": runner_mapping["win-64"], "platform": "win-64", "python-version": "3.12"},
     {"runner": runner_mapping["win-64"], "platform": "win-64", "python-version": "3.13"},
+    {"runner": runner_mapping["win-64"], "platform": "win-64", "python-version": "3.14"},
 ]
 
 print(

--- a/buildscripts/github/llvmlite_evaluate.py
+++ b/buildscripts/github/llvmlite_evaluate.py
@@ -16,17 +16,31 @@ runner_mapping = {
     "win-64": "windows-2025",
 }
 
-python_versions = ["3.10", "3.11", "3.12", "3.13"]
-platforms = ["linux-64", "linux-aarch64", "osx-arm64", "win-64"]
+default_include = [
+    # linux-64
+    {"runner": runner_mapping["linux-64"], "platform": "linux-64", "python-version": "3.10"},
+    {"runner": runner_mapping["linux-64"], "platform": "linux-64", "python-version": "3.11"},
+    {"runner": runner_mapping["linux-64"], "platform": "linux-64", "python-version": "3.12"},
+    {"runner": runner_mapping["linux-64"], "platform": "linux-64", "python-version": "3.13"},
 
-default_include = []
-for platform in platforms:
-    for python_version in python_versions:
-        default_include.append({
-            "runner": runner_mapping[platform],
-            "platform": platform,
-            "python-version": python_version,
-        })
+    # linux-aarch64
+    {"runner": runner_mapping["linux-aarch64"], "platform": "linux-aarch64", "python-version": "3.10"},
+    {"runner": runner_mapping["linux-aarch64"], "platform": "linux-aarch64", "python-version": "3.11"},
+    {"runner": runner_mapping["linux-aarch64"], "platform": "linux-aarch64", "python-version": "3.12"},
+    {"runner": runner_mapping["linux-aarch64"], "platform": "linux-aarch64", "python-version": "3.13"},
+
+    # osx-arm64
+    {"runner": runner_mapping["osx-arm64"], "platform": "osx-arm64", "python-version": "3.10"},
+    {"runner": runner_mapping["osx-arm64"], "platform": "osx-arm64", "python-version": "3.11"},
+    {"runner": runner_mapping["osx-arm64"], "platform": "osx-arm64", "python-version": "3.12"},
+    {"runner": runner_mapping["osx-arm64"], "platform": "osx-arm64", "python-version": "3.13"},
+
+    # win-64
+    {"runner": runner_mapping["win-64"], "platform": "win-64", "python-version": "3.10"},
+    {"runner": runner_mapping["win-64"], "platform": "win-64", "python-version": "3.11"},
+    {"runner": runner_mapping["win-64"], "platform": "win-64", "python-version": "3.12"},
+    {"runner": runner_mapping["win-64"], "platform": "win-64", "python-version": "3.13"},
+]
 
 print(
     "Deciding what to do based on event: "

--- a/conda-recipes/llvmlite/meta.yaml
+++ b/conda-recipes/llvmlite/meta.yaml
@@ -41,7 +41,7 @@ requirements:
 
 test:
   requires:
-    - py-lief
+    - py-lief # [py<314]
   imports:
     - llvmlite
     - llvmlite.binding


### PR DESCRIPTION
Adding support to build and test llvmlite with py3.14 on GHA CI.
- uses channel `ad-testing/label/py314` when using conda env
- for jobs using setup-python, we use `allow-prereleases: true` 
- skip using lief (`pip install -v lief`) on test job for python 3.14 (not yet supported)
