### PR TITLE
fix/ azure win builds

### DIFF
--- a/buildscripts/incremental/setup_conda_environment.cmd
+++ b/buildscripts/incremental/setup_conda_environment.cmd
@@ -11,5 +11,5 @@ call activate %CONDA_ENV%
 if %errorlevel% neq 0 exit /b %errorlevel%
 
 @rem Install llvmdev 20
-call conda install -y -q -c numba/label/dev llvmdev=20 libxml2
+call conda install -y -q numba/label/dev::llvmdev=20 libxml2
 if %errorlevel% neq 0 exit /b %errorlevel%


### PR DESCRIPTION
On Azure CI, the conda env is now created with `zlib 1.3.1` which is incompatible with llvmdev from `numba/label/dev`. 
To make sure right llvmdev is used (from numba channel), conda install command needs to be more explicit.
`conda install -y -q numba/label/dev::llvmdev=20 libxml2` as it requires downgrading `zlib`.

```
The following NEW packages will be INSTALLED:

  llvmdev            numba/label/dev/osx-arm64::llvmdev-20.1.8-h1329283_0 
  lz4-c              pkgs/main/osx-arm64::lz4-c-1.9.4-h313beb8_1 
  zstd               pkgs/main/osx-arm64::zstd-1.5.6-hfb09047_0 

The following packages will be REMOVED:

  libzlib-1.3.1-h5f15de7_0

The following packages will be DOWNGRADED:

  zlib                                     1.3.1-h5f15de7_0 --> 1.2.13-ha1e9f54_2 
  ```
  