### PR TITLE
GHA/ use explicit channel specification for llvmdev=20 installation

### DIFF
--- a/.github/workflows/llvmlite_osx-arm64_wheel_builder.yml
+++ b/.github/workflows/llvmlite_osx-arm64_wheel_builder.yml
@@ -66,10 +66,11 @@ jobs:
         run: |
           if [ "${{ inputs.llvmdev_run_id }}" != "" ]; then
               CHAN="file://${{ github.workspace }}/llvmdev_conda_packages"
+              conda install -c defaults -c "$CHAN" "llvmdev=${{ env.FALLBACK_LLVMDEV_VERSION }}"
           else
               CHAN="${{ env.CONDA_CHANNEL_NUMBA }}"
+              conda install -c defaults "${CHAN}::llvmdev=${{ env.FALLBACK_LLVMDEV_VERSION }}"
           fi
-          conda install -c "$CHAN" llvmdev="${{ env.FALLBACK_LLVMDEV_VERSION }}"
           conda install -c defaults python-build
 
           # Hide libunwind to prevent it from being linked against during build

--- a/.github/workflows/llvmlite_win-64_wheel_builder.yml
+++ b/.github/workflows/llvmlite_win-64_wheel_builder.yml
@@ -67,10 +67,11 @@ jobs:
         run: |
           if [ "${{ inputs.llvmdev_run_id }}" != "" ]; then
               CHAN="file:///${{ github.workspace }}/llvmdev_conda_packages"
+              conda install -c defaults -c "$CHAN" "llvmdev=${{ env.FALLBACK_LLVMDEV_VERSION }}"
           else
               CHAN="${{ env.CONDA_CHANNEL_NUMBA }}"
+              conda install -c defaults "${CHAN}::llvmdev=${{ env.FALLBACK_LLVMDEV_VERSION }}"
           fi
-          conda install -c "$CHAN" llvmdev=${{ env.FALLBACK_LLVMDEV_VERSION }}
           conda install -c defaults cmake libxml2 python-build
 
       - name: Build wheel

--- a/buildscripts/manylinux/build_llvmlite.sh
+++ b/buildscripts/manylinux/build_llvmlite.sh
@@ -24,7 +24,7 @@ conda activate $envname
 if [ -n "$LLVMDEV_ARTIFACT_PATH" ] && [ -d "$LLVMDEV_ARTIFACT_PATH" ]; then
     conda install -y "$LLVMDEV_ARTIFACT_PATH"/llvmdev-*.conda --no-deps
 else
-    conda install -y -c numba/label/llvm20-wheel llvmdev=20 --no-deps
+    conda install -y -c defaults numba/label/llvm20-wheel::llvmdev=20 --no-deps
 fi
 
 # Prepend builtin Python Path


### PR DESCRIPTION
use explicit channel specification to install llvmdev on llvmlite wheel workflows to avoid build step getting `llvmdev` from main because of updated libs on base env.
`numba/label/llvm20-wheel::llvmdev=20`

resolves failures seen on `osx-arm64` during `0.46.0dev0` testing -
https://github.com/numba/llvmlite/actions/runs/17668266419/job/50214067366