### PR TITLE
GHA/refactor wheel builders to use system python for build

### DIFF
--- a/.github/workflows/llvmlite_linux-64_wheel_builder.yml
+++ b/.github/workflows/llvmlite_linux-64_wheel_builder.yml
@@ -55,13 +55,6 @@ jobs:
           repository: ${{ github.repository }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Setup Miniconda
-        uses: conda-incubator/setup-miniconda@835234971496cad1653abb28a638a281cf32541f # v3.2.0
-        with:
-          auto-update-conda: true
-          auto-activate-base: true
-          activate-environment: true
-
       - name: Map Python version
         run: |
           # Map Python version to manylinux path

--- a/.github/workflows/llvmlite_linux-aarch64_wheel_builder.yml
+++ b/.github/workflows/llvmlite_linux-aarch64_wheel_builder.yml
@@ -55,13 +55,6 @@ jobs:
           repository: ${{ github.repository }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Setup Miniconda
-        uses: conda-incubator/setup-miniconda@835234971496cad1653abb28a638a281cf32541f # v3.2.0
-        with:
-          auto-update-conda: true
-          auto-activate-base: true
-          activate-environment: true
-
       - name: Map Python version
         run: |
           # Map Python version to manylinux path

--- a/.github/workflows/llvmlite_osx-arm64_wheel_builder.yml
+++ b/.github/workflows/llvmlite_osx-arm64_wheel_builder.yml
@@ -47,10 +47,15 @@ jobs:
       - name: Setup Miniconda
         uses: conda-incubator/setup-miniconda@835234971496cad1653abb28a638a281cf32541f # v3.2.0
         with:
-          python-version: ${{ matrix.python-version }}
           conda-remove-defaults: true
           auto-update-conda: true
           auto-activate-base: true
+
+      - name: Setup Python
+        uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c # v6.0.0
+        with:
+          python-version: ${{ matrix.python-version }}
+          allow-prereleases: true
 
       - name: Download llvmdev Artifact
         if: ${{ inputs.llvmdev_run_id != '' }}
@@ -71,7 +76,7 @@ jobs:
               CHAN="${{ env.CONDA_CHANNEL_NUMBA }}"
               conda install -c defaults "${CHAN}::llvmdev=${{ env.FALLBACK_LLVMDEV_VERSION }}"
           fi
-          conda install -c defaults python-build
+          python -m pip install build wheel setuptools
 
           # Hide libunwind to prevent it from being linked against during build
           # On macOS, if libunwind.dylib from the llvmdev conda package gets linked, the resulting wheel
@@ -87,7 +92,7 @@ jobs:
           LLVMLITE_PACKAGE_FORMAT: "wheel"
           LDFLAGS: "-v -Wl,-rpath,/usr/lib"
         run: |
-          arch -arm64 python -m build --verbose --config-setting="--global-option=build_ext" --config-setting="--global-option=-v"
+          arch -arm64 python -m build --wheel --no-isolation
 
       - name: Upload wheel
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
@@ -100,7 +105,7 @@ jobs:
 
       - name: Build sdist [once - py3.10]
         if: ${{ matrix.python-version == '3.10' }}
-        run: arch -arm64 python -m build --sdist
+        run: arch -arm64 python -m build --sdist --no-isolation
 
       - name: Upload sdist (once with python 3.10)
         if: ${{ matrix.python-version == '3.10' }}

--- a/.github/workflows/llvmlite_win-64_wheel_builder.yml
+++ b/.github/workflows/llvmlite_win-64_wheel_builder.yml
@@ -48,10 +48,15 @@ jobs:
       - name: Setup Miniconda
         uses: conda-incubator/setup-miniconda@835234971496cad1653abb28a638a281cf32541f # v3.2.0
         with:
-          python-version: ${{ matrix.python-version }}
           conda-remove-defaults: true
           auto-update-conda: true
           auto-activate-base: true
+
+      - name: Setup Python
+        uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c # v6.0.0
+        with:
+          python-version: ${{ matrix.python-version }}
+          allow-prereleases: true
 
       - name: Download llvmdev Artifact
         if: ${{ inputs.llvmdev_run_id != '' }}
@@ -72,12 +77,13 @@ jobs:
               CHAN="${{ env.CONDA_CHANNEL_NUMBA }}"
               conda install -c defaults "${CHAN}::llvmdev=${{ env.FALLBACK_LLVMDEV_VERSION }}"
           fi
-          conda install -c defaults cmake libxml2 python-build
+          conda install -c defaults cmake libxml2
+          python -m pip install build wheel setuptools
 
       - name: Build wheel
         env:
           LLVMLITE_PACKAGE_FORMAT: "wheel"
-        run: python -m build
+        run: python -m build --wheel --no-isolation
 
       - name: Upload llvmlite wheel
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2


### PR DESCRIPTION
Currently, the wheel builder workflows for `osx-arm64` and `win-64` have been using `python`  from miniconda env.

This PR updates the python used on build step to system python using -`actions/setup-python`. This would also allow getting pre-release versions of python for build and test using `allow-prereleases: true` param.

This PR also cleans up `Setup Miniconda` step from linux wheel builders which are redundant as build is performed under `manylinux` docker containers for linux platforms.