### PR TITLE
use explicit channel specification for llvmdev=20 installation

### DIFF
--- a/.github/workflows/llvmlite_osx-arm64_wheel_builder.yml
+++ b/.github/workflows/llvmlite_osx-arm64_wheel_builder.yml
@@ -66,10 +66,11 @@ jobs:
         run: |
           if [ "${{ inputs.llvmdev_run_id }}" != "" ]; then
               CHAN="file://${{ github.workspace }}/llvmdev_conda_packages"
+              conda install -c defaults -c "$CHAN" "llvmdev=${{ env.FALLBACK_LLVMDEV_VERSION }}"
           else
               CHAN="${{ env.CONDA_CHANNEL_NUMBA }}"
+              conda install -c defaults "${CHAN}::llvmdev=${{ env.FALLBACK_LLVMDEV_VERSION }}"
           fi
-          conda install -c "$CHAN" llvmdev="${{ env.FALLBACK_LLVMDEV_VERSION }}"
           conda install -c defaults python-build
 
           # Hide libunwind to prevent it from being linked against during build

--- a/.github/workflows/llvmlite_win-64_wheel_builder.yml
+++ b/.github/workflows/llvmlite_win-64_wheel_builder.yml
@@ -67,10 +67,11 @@ jobs:
         run: |
           if [ "${{ inputs.llvmdev_run_id }}" != "" ]; then
               CHAN="file:///${{ github.workspace }}/llvmdev_conda_packages"
+              conda install -c defaults -c "$CHAN" "llvmdev=${{ env.FALLBACK_LLVMDEV_VERSION }}"
           else
               CHAN="${{ env.CONDA_CHANNEL_NUMBA }}"
+              conda install -c defaults "${CHAN}::llvmdev=${{ env.FALLBACK_LLVMDEV_VERSION }}"
           fi
-          conda install -c "$CHAN" llvmdev=${{ env.FALLBACK_LLVMDEV_VERSION }}
           conda install -c defaults cmake libxml2 python-build
 
       - name: Build wheel

--- a/buildscripts/manylinux/build_llvmlite.sh
+++ b/buildscripts/manylinux/build_llvmlite.sh
@@ -24,7 +24,7 @@ conda activate $envname
 if [ -n "$LLVMDEV_ARTIFACT_PATH" ] && [ -d "$LLVMDEV_ARTIFACT_PATH" ]; then
     conda install -y "$LLVMDEV_ARTIFACT_PATH"/llvmdev-*.conda --no-deps
 else
-    conda install -y -c numba/label/llvm20-wheel llvmdev=20 --no-deps
+    conda install -y -c defaults numba/label/llvm20-wheel::llvmdev=20 --no-deps
 fi
 
 # Prepend builtin Python Path


### PR DESCRIPTION
This fixes issues of the style, which were observed on Windows when attempting to perform a change-log update for the 0.45.0 FINAL:

https://github.com/numba/llvmlite/pull/1287

https://dev.azure.com/numba/numba/_build/results?buildId=19775&view=logs&jobId=2b18e8df-2ee7-5e01-73e9-0533d995635b

```
LINK : fatal error LNK1181: cannot open input file '\DIA SDK\lib\amd64\diaguids.lib' [D:\a\1\s\ffi\build\llvmlite.vcxproj]
Trying generator ('Visual Studio 17 2022', 'x64', 'v143')
Running: cmake -G Visual Studio 17 2022 -A x64 -T v143 D:\a\1\s\ffi\dummy
Running: cmake -G Visual Studio 17 2022 -A x64 -T v143 D:\a\1\s\ffi
Traceback (most recent call last):
  File "D:\a\1\s\ffi\build.py", line 198, in <module>
    main()
  File "D:\a\1\s\ffi\build.py", line 188, in main
    main_windows()
  File "D:\a\1\s\ffi\build.py", line 169, in main_windows
    subprocess.check_call(['cmake', '--build', build_dir, '--config', config])
  File "C:\Miniconda3\envs\cienv\Lib\subprocess.py", line 413, in check_call
    raise CalledProcessError(retcode, cmd)
subprocess.CalledProcessError: Command '['cmake', '--build', 'D:\\a\\1\\s\\ffi\\build', '--config', 'Release']' returned non-zero exit status 1.
error: command 'C:\\Miniconda3\\envs\\cienv\\python.exe' failed with exit code 1
```