### PR TITLE
Cherry pick 0.45.0

### DIFF
--- a/.github/workflows/llvmlite_linux-64_wheel_builder.yml
+++ b/.github/workflows/llvmlite_linux-64_wheel_builder.yml
@@ -29,7 +29,7 @@ env:
 
 jobs:
   linux-64-build:
-    name: linux-64-build-py${{ matrix.python-version }}
+    name: linux-64-build
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -116,7 +116,7 @@ jobs:
         run: "echo \"Workflow Run ID: ${{ github.run_id }}\""
 
   linux-64-validate:
-    name: validate-py${{ matrix.python-version }}
+    name: linux-64-validate
     needs: linux-64-build
     runs-on: ubuntu-latest
     defaults:
@@ -157,7 +157,7 @@ jobs:
           done
 
   linux-64-test:
-    name: test-py${{ matrix.python-version }}
+    name: linux-64-test
     needs: linux-64-build
     runs-on: ubuntu-latest
     defaults:
@@ -213,7 +213,7 @@ jobs:
           "${PYTHON_PATH}" -m llvmlite.tests
 
   linux-64-upload:
-    name: upload-py${{ matrix.python-version }}
+    name: linux-64-upload
     needs: [linux-64-test, linux-64-validate]
     if: github.event_name == 'workflow_dispatch' && inputs.upload_wheel_to_anaconda
     runs-on: ubuntu-latest

--- a/.github/workflows/llvmlite_linux-aarch64_wheel_builder.yml
+++ b/.github/workflows/llvmlite_linux-aarch64_wheel_builder.yml
@@ -29,7 +29,7 @@ env:
 
 jobs:
   linux-aarch64-build:
-    name: linux-aarch64-build-py${{ matrix.python-version }}
+    name: linux-aarch64-build
     runs-on: ubuntu-24.04-arm
     defaults:
       run:
@@ -113,7 +113,7 @@ jobs:
         run: "echo \"Workflow Run ID: ${{ github.run_id }}\""
 
   linux-aarch64-validate:
-    name: validate-py${{ matrix.python-version }}
+    name: linux-aarch64-validate
     needs: linux-aarch64-build
     runs-on: ubuntu-24.04-arm
     defaults:
@@ -154,7 +154,7 @@ jobs:
           done
 
   linux-aarch64-test:
-    name: test-py${{ matrix.python-version }}
+    name: linux-aarch64-test
     needs: linux-aarch64-build
     runs-on: ubuntu-24.04-arm
     defaults:
@@ -210,7 +210,7 @@ jobs:
           "${PYTHON_PATH}" -m llvmlite.tests
 
   linux-aarch64-upload:
-    name: upload-py${{ matrix.python-version }}
+    name: linux-aarch64-upload
     needs: [linux-aarch64-test, linux-aarch64-validate]
     if: github.event_name == 'workflow_dispatch' && inputs.upload_wheel_to_anaconda
     runs-on: ubuntu-24.04-arm

--- a/.github/workflows/llvmlite_osx-64_wheel_builder.yml
+++ b/.github/workflows/llvmlite_osx-64_wheel_builder.yml
@@ -66,10 +66,11 @@ jobs:
         run: |
           if [ "${{ inputs.llvmdev_run_id }}" != "" ]; then
               CHAN="file://${{ github.workspace }}/llvmdev_conda_packages"
+              conda install -c defaults -c "$CHAN" llvmdev=${{ env.FALLBACK_LLVMDEV_VERSION }}
           else
               CHAN="${{ env.CONDA_CHANNEL_NUMBA }}"
+              conda install -c defaults "${CHAN}"::llvmdev=${{ env.FALLBACK_LLVMDEV_VERSION }}
           fi
-          conda install -c "$CHAN" llvmdev=${{ env.FALLBACK_LLVMDEV_VERSION }}
           conda install -c defaults cmake libxml2 python-build
 
           # Hide libunwind to prevent it from being linked against during build

--- a/.github/workflows/llvmlite_osx-arm64_wheel_builder.yml
+++ b/.github/workflows/llvmlite_osx-arm64_wheel_builder.yml
@@ -66,10 +66,11 @@ jobs:
         run: |
           if [ "${{ inputs.llvmdev_run_id }}" != "" ]; then
               CHAN="file://${{ github.workspace }}/llvmdev_conda_packages"
+              conda install -c defaults -c "$CHAN" "llvmdev=${{ env.FALLBACK_LLVMDEV_VERSION }}"
           else
               CHAN="${{ env.CONDA_CHANNEL_NUMBA }}"
+              conda install -c defaults "${CHAN}::llvmdev=${{ env.FALLBACK_LLVMDEV_VERSION }}"
           fi
-          conda install -c "$CHAN" llvmdev="${{ env.FALLBACK_LLVMDEV_VERSION }}"
           conda install -c defaults python-build
 
           # Hide libunwind to prevent it from being linked against during build

--- a/.github/workflows/llvmlite_osx-arm64_wheel_builder.yml
+++ b/.github/workflows/llvmlite_osx-arm64_wheel_builder.yml
@@ -97,6 +97,20 @@ jobs:
           retention-days: ${{ env.ARTIFACT_RETENTION_DAYS }}
           if-no-files-found: error
 
+      - name: Build sdist [once - py3.10]
+        if: ${{ matrix.python-version == '3.10' }}
+        run: arch -arm64 python -m build --sdist
+
+      - name: Upload sdist (once with python 3.10)
+        if: ${{ matrix.python-version == '3.10' }}
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: llvmlite-sdist
+          path: dist/*.tar.gz
+          compression-level: 0
+          retention-days: ${{ env.ARTIFACT_RETENTION_DAYS }}
+          if-no-files-found: error
+
       - name: Show Workflow Run ID
         run: "echo \"Workflow Run ID: ${{ github.run_id }}\""
 

--- a/.github/workflows/llvmlite_win-64_wheel_builder.yml
+++ b/.github/workflows/llvmlite_win-64_wheel_builder.yml
@@ -67,10 +67,11 @@ jobs:
         run: |
           if [ "${{ inputs.llvmdev_run_id }}" != "" ]; then
               CHAN="file:///${{ github.workspace }}/llvmdev_conda_packages"
+              conda install -c defaults -c "$CHAN" "llvmdev=${{ env.FALLBACK_LLVMDEV_VERSION }}"
           else
               CHAN="${{ env.CONDA_CHANNEL_NUMBA }}"
+              conda install -c defaults "${CHAN}::llvmdev=${{ env.FALLBACK_LLVMDEV_VERSION }}"
           fi
-          conda install -c "$CHAN" llvmdev=${{ env.FALLBACK_LLVMDEV_VERSION }}
           conda install -c defaults cmake libxml2 python-build
 
       - name: Build wheel

--- a/CHANGE_LOG
+++ b/CHANGE_LOG
@@ -1,4 +1,4 @@
-v0.45.0-rc1 (Aug 26, 2025)
+v0.45.0rc2 (Sept 10, 2025)
 --------------------------
 
 This release of llvmlite introduces support for LLVM 20. For more information
@@ -112,7 +112,11 @@ Pull-Requests:
 * PR `#1262 <https://github.com/numba/llvmlite/pull/1262>`_: llvmdev-20 recipe fixes (`swap357 <https://github.com/swap357>`_)
 * PR `#1266 <https://github.com/numba/llvmlite/pull/1266>`_: update compatability matrix in the `README.rst` to reflect LLVM 20 (`esc <https://github.com/esc>`_)
 * PR `#1267 <https://github.com/numba/llvmlite/pull/1267>`_: adding llvm20 docs (`esc <https://github.com/esc>`_)
+* PR `#1268 <https://github.com/numba/llvmlite/pull/1268>`_: Release 0.45: `CHANGE_LOG` (`esc <https://github.com/esc>`_)
 * PR `#1269 <https://github.com/numba/llvmlite/pull/1269>`_: add sdist build and upload steps on wheel workflow (`swap357 <https://github.com/swap357>`_)
+* PR `#1274 <https://github.com/numba/llvmlite/pull/1274>`_: GHA/ standardize job names on workflows for linux builds (`swap357 <https://github.com/swap357>`_)
+* PR `#1276 <https://github.com/numba/llvmlite/pull/1276>`_: Fix build-string on llvmdev_for_wheels conda recipe (`swap357 <https://github.com/swap357>`_)
+* PR `#1278 <https://github.com/numba/llvmlite/pull/1278>`_: Update deprecation page (`sklam <https://github.com/sklam>`_)
 
 Authors:
 

--- a/CHANGE_LOG
+++ b/CHANGE_LOG
@@ -1,3 +1,134 @@
+v0.45.0-rc1 (Aug 26, 2025)
+--------------------------
+
+This release of llvmlite introduces support for LLVM 20. For more information
+about the state of the support and breaking changes, please see: https://llvmlite.readthedocs.io/en/latest/user-guide/llvm20.html
+
+Pull-Requests:
+
+* PR `#1091 <https://github.com/numba/llvmlite/pull/1091>`_: [NPM] Add hooks for llvm passes in llvmlite (`gmarkall <https://github.com/gmarkall>`_ `yashssh <https://github.com/yashssh>`_)
+* PR `#1092 <https://github.com/numba/llvmlite/pull/1092>`_: Move llvmlite to LLVM 20 (`sklam <https://github.com/sklam>`_ `swap357 <https://github.com/swap357>`_ `yashssh <https://github.com/yashssh>`_ `esc <https://github.com/esc>`_)
+* PR `#1096 <https://github.com/numba/llvmlite/pull/1096>`_: Added changelog for 0.44.0rc1 (`kc611 <https://github.com/kc611>`_)
+* PR `#1101 <https://github.com/numba/llvmlite/pull/1101>`_: Updated date and llvm versioning for 0.44.0rc1 (`kc611 <https://github.com/kc611>`_)
+* PR `#1112 <https://github.com/numba/llvmlite/pull/1112>`_: adding bullet to first RC checklist regarding LLVM updates (`esc <https://github.com/esc>`_)
+* PR `#1113 <https://github.com/numba/llvmlite/pull/1113>`_: Merge pull request #1104 from sklam/misc/osx_wheel_fix (`kc611 <https://github.com/kc611>`_ `esc <https://github.com/esc>`_)
+* PR `#1114 <https://github.com/numba/llvmlite/pull/1114>`_: Merge pull request #1108 from sklam/fix/win_wheel (`kc611 <https://github.com/kc611>`_ `esc <https://github.com/esc>`_)
+* PR `#1115 <https://github.com/numba/llvmlite/pull/1115>`_: Update changelog for v0.44.0rc2 (`kc611 <https://github.com/kc611>`_)
+* PR `#1124 <https://github.com/numba/llvmlite/pull/1124>`_: Changed version number and release date (`kc611 <https://github.com/kc611>`_)
+* PR `#1125 <https://github.com/numba/llvmlite/pull/1125>`_: Fix flag condition when creating SimpleLoopUnswitchLegacyPass (`HighW4y2H3ll <https://github.com/HighW4y2H3ll>`_)
+* PR `#1128 <https://github.com/numba/llvmlite/pull/1128>`_: Adding llvmdev win 64 conda builder (`esc <https://github.com/esc>`_)
+* PR `#1129 <https://github.com/numba/llvmlite/pull/1129>`_: llvmlite win-64 conda builder GHA (`esc <https://github.com/esc>`_)
+* PR `#1130 <https://github.com/numba/llvmlite/pull/1130>`_: Configure Renovate (`renovate[bot] <https://github.com/apps/renovate>`_ `esc <https://github.com/esc>`_)
+* PR `#1131 <https://github.com/numba/llvmlite/pull/1131>`_: llvmdev_linux-64_conda_builder.yml (`esc <https://github.com/esc>`_)
+* PR `#1132 <https://github.com/numba/llvmlite/pull/1132>`_: llvmlite_linux-64_conda_builder.yml (`esc <https://github.com/esc>`_)
+* PR `#1133 <https://github.com/numba/llvmlite/pull/1133>`_: Cherry-pick changes to the `CHANGE_LOG` to `main` (`kc611 <https://github.com/kc611>`_)
+* PR `#1139 <https://github.com/numba/llvmlite/pull/1139>`_: Add win-64 wheel builder GHA workflow (`dbast <https://github.com/dbast>`_ `swap357 <https://github.com/swap357>`_ `esc <https://github.com/esc>`_)
+* PR `#1141 <https://github.com/numba/llvmlite/pull/1141>`_: refactor llvmdev win builder (`swap357 <https://github.com/swap357>`_)
+* PR `#1142 <https://github.com/numba/llvmlite/pull/1142>`_: point conda build to correct package path (`esc <https://github.com/esc>`_)
+* PR `#1143 <https://github.com/numba/llvmlite/pull/1143>`_: remove release.yml -- it's stale and outdated (`esc <https://github.com/esc>`_)
+* PR `#1144 <https://github.com/numba/llvmlite/pull/1144>`_: Refactor recipe build flows (`dbast <https://github.com/dbast>`_)
+* PR `#1146 <https://github.com/numba/llvmlite/pull/1146>`_: Extend pre-commit config (`dbast <https://github.com/dbast>`_)
+* PR `#1148 <https://github.com/numba/llvmlite/pull/1148>`_: Update pre-commit hook pre-commit/mirrors-clang-format to v19 (`renovate[bot] <https://github.com/apps/renovate>`_)
+* PR `#1149 <https://github.com/numba/llvmlite/pull/1149>`_: Rename llvmdev manylinux (`esc <https://github.com/esc>`_)
+* PR `#1150 <https://github.com/numba/llvmlite/pull/1150>`_: enable running workflow as part of pull-request (`esc <https://github.com/esc>`_)
+* PR `#1151 <https://github.com/numba/llvmlite/pull/1151>`_: fix flake8 issues (`esc <https://github.com/esc>`_)
+* PR `#1152 <https://github.com/numba/llvmlite/pull/1152>`_: adding pre-commit workflow (`esc <https://github.com/esc>`_)
+* PR `#1154 <https://github.com/numba/llvmlite/pull/1154>`_: execute dist tests for linux-64 conda pkgs via Azure (`esc <https://github.com/esc>`_)
+* PR `#1156 <https://github.com/numba/llvmlite/pull/1156>`_: Enable Github Action pinning via renovate (`dbast <https://github.com/dbast>`_)
+* PR `#1157 <https://github.com/numba/llvmlite/pull/1157>`_: Update pre-commit hook PyCQA/flake8 to v7.1.2 (`renovate[bot] <https://github.com/apps/renovate>`_)
+* PR `#1158 <https://github.com/numba/llvmlite/pull/1158>`_: Opaque pointer fixes (`rj-jesus <https://github.com/rj-jesus>`_ `gmarkall <https://github.com/gmarkall>`_)
+* PR `#1159 <https://github.com/numba/llvmlite/pull/1159>`_: Add IR layer typed pointers mode (`rj-jesus <https://github.com/rj-jesus>`_ `gmarkall <https://github.com/gmarkall>`_)
+* PR `#1160 <https://github.com/numba/llvmlite/pull/1160>`_: Drop binding layer typed pointer support. (`rj-jesus <https://github.com/rj-jesus>`_)
+* PR `#1161 <https://github.com/numba/llvmlite/pull/1161>`_: Update pre-commit hook python-jsonschema/check-jsonschema to v0.31.3 (`renovate[bot] <https://github.com/apps/renovate>`_)
+* PR `#1163 <https://github.com/numba/llvmlite/pull/1163>`_: Enable pass timings reporting with NewPassManager (`gmarkall <https://github.com/gmarkall>`_ `yashssh <https://github.com/yashssh>`_)
+* PR `#1165 <https://github.com/numba/llvmlite/pull/1165>`_: Fix the metadata deduplication (`jiel-nv <https://github.com/jiel-nv>`_)
+* PR `#1169 <https://github.com/numba/llvmlite/pull/1169>`_: Update pre-commit hook pre-commit/mirrors-clang-format to v20 (`renovate[bot] <https://github.com/apps/renovate>`_)
+* PR `#1171 <https://github.com/numba/llvmlite/pull/1171>`_: Pin dependencies (`renovate[bot] <https://github.com/apps/renovate>`_)
+* PR `#1172 <https://github.com/numba/llvmlite/pull/1172>`_: Update actions/checkout action to v4.2.2 (`renovate[bot] <https://github.com/apps/renovate>`_)
+* PR `#1173 <https://github.com/numba/llvmlite/pull/1173>`_: Update actions/download-artifact action to v4.1.9 (`renovate[bot] <https://github.com/apps/renovate>`_)
+* PR `#1174 <https://github.com/numba/llvmlite/pull/1174>`_: Update actions/setup-python action to v5.4.0 (`renovate[bot] <https://github.com/apps/renovate>`_)
+* PR `#1175 <https://github.com/numba/llvmlite/pull/1175>`_: Update actions/upload-artifact action to v4.6.2  (`renovate[bot] <https://github.com/apps/renovate>`_)
+* PR `#1176 <https://github.com/numba/llvmlite/pull/1176>`_: Update conda-incubator/setup-miniconda action to v3.1.1 (`renovate[bot] <https://github.com/apps/renovate>`_)
+* PR `#1177 <https://github.com/numba/llvmlite/pull/1177>`_: fix typo in workflow options for llvmdev_build.yml (`swap357 <https://github.com/swap357>`_)
+* PR `#1178 <https://github.com/numba/llvmlite/pull/1178>`_: Update actions/download-artifact action to v4.2.1 (`renovate[bot] <https://github.com/apps/renovate>`_)
+* PR `#1180 <https://github.com/numba/llvmlite/pull/1180>`_: Update actions/setup-python action to v5.5.0 (`renovate[bot] <https://github.com/apps/renovate>`_)
+* PR `#1181 <https://github.com/numba/llvmlite/pull/1181>`_: Update pre-commit hook python-jsonschema/check-jsonschema to v0.32.1 (`renovate[bot] <https://github.com/apps/renovate>`_)
+* PR `#1185 <https://github.com/numba/llvmlite/pull/1185>`_: Update pre-commit hook PyCQA/flake8 to v7.2.0 (`renovate[bot] <https://github.com/apps/renovate>`_)
+* PR `#1187 <https://github.com/numba/llvmlite/pull/1187>`_: gha/add llvmlite osx 64 wheel builder (`swap357 <https://github.com/swap357>`_)
+* PR `#1188 <https://github.com/numba/llvmlite/pull/1188>`_: bump min CMake (`esc <https://github.com/esc>`_)
+* PR `#1189 <https://github.com/numba/llvmlite/pull/1189>`_: bump Ubuntu to 24.04 (`esc <https://github.com/esc>`_)
+* PR `#1190 <https://github.com/numba/llvmlite/pull/1190>`_: gha/add llvmlite osx 64 conda builder (`swap357 <https://github.com/swap357>`_)
+* PR `#1193 <https://github.com/numba/llvmlite/pull/1193>`_: Update pre-commit hook python-jsonschema/check-jsonschema to v0.33.0 (`renovate[bot] <https://github.com/apps/renovate>`_)
+* PR `#1195 <https://github.com/numba/llvmlite/pull/1195>`_: gha/add llvmlite osx-arm64 conda builder (`swap357 <https://github.com/swap357>`_)
+* PR `#1196 <https://github.com/numba/llvmlite/pull/1196>`_: Pin dependencies (`renovate[bot] <https://github.com/apps/renovate>`_)
+* PR `#1197 <https://github.com/numba/llvmlite/pull/1197>`_: Update actions/checkout action to v4.2.2 (`renovate[bot] <https://github.com/apps/renovate>`_)
+* PR `#1198 <https://github.com/numba/llvmlite/pull/1198>`_: Update actions/download-artifact action to v4.3.0 (`renovate[bot] <https://github.com/apps/renovate>`_)
+* PR `#1199 <https://github.com/numba/llvmlite/pull/1199>`_: Update actions/setup-python action to v5.6.0 (`renovate[bot] <https://github.com/apps/renovate>`_)
+* PR `#1200 <https://github.com/numba/llvmlite/pull/1200>`_: Update actions/upload-artifact action to v4.6.2 (`renovate[bot] <https://github.com/apps/renovate>`_)
+* PR `#1201 <https://github.com/numba/llvmlite/pull/1201>`_: Update conda-incubator/setup-miniconda action to v3.1.1 (`renovate[bot] <https://github.com/apps/renovate>`_)
+* PR `#1203 <https://github.com/numba/llvmlite/pull/1203>`_: gha/add llvmlite osx-arm64 wheel builder workflow (`swap357 <https://github.com/swap357>`_)
+* PR `#1205 <https://github.com/numba/llvmlite/pull/1205>`_: gha/add llvmlite_linux-64 wheel builder workflow (`swap357 <https://github.com/swap357>`_)
+* PR `#1206 <https://github.com/numba/llvmlite/pull/1206>`_: gha/add llvmlite linux-arm64 wheel builder (`swap357 <https://github.com/swap357>`_)
+* PR `#1209 <https://github.com/numba/llvmlite/pull/1209>`_: remove singular clang-format check based on ubuntu/apt (`esc <https://github.com/esc>`_)
+* PR `#1210 <https://github.com/numba/llvmlite/pull/1210>`_: Update pre-commit hook pre-commit/mirrors-clang-format to v20.1.4 (`renovate[bot] <https://github.com/apps/renovate>`_)
+* PR `#1211 <https://github.com/numba/llvmlite/pull/1211>`_: gha/fix llvmlite linux workflows for version tags (`swap357 <https://github.com/swap357>`_)
+* PR `#1213 <https://github.com/numba/llvmlite/pull/1213>`_: unify clang format check (`esc <https://github.com/esc>`_)
+* PR `#1215 <https://github.com/numba/llvmlite/pull/1215>`_: gha/add llvmlite linux-arm64 conda builder (`swap357 <https://github.com/swap357>`_)
+* PR `#1216 <https://github.com/numba/llvmlite/pull/1216>`_: gha/refactor llvmlite osx wheel workflows (`swap357 <https://github.com/swap357>`_)
+* PR `#1217 <https://github.com/numba/llvmlite/pull/1217>`_: gha/refactor llvmlite win-64 workflows (`swap357 <https://github.com/swap357>`_)
+* PR `#1218 <https://github.com/numba/llvmlite/pull/1218>`_: Pin conda-incubator/setup-miniconda action to 505e639 (`renovate[bot] <https://github.com/apps/renovate>`_)
+* PR `#1219 <https://github.com/numba/llvmlite/pull/1219>`_: Update actions/checkout action to v4.2.2 (`renovate[bot] <https://github.com/apps/renovate>`_)
+* PR `#1220 <https://github.com/numba/llvmlite/pull/1220>`_: Update actions/download-artifact action to v4.3.0 (`renovate[bot] <https://github.com/apps/renovate>`_)
+* PR `#1221 <https://github.com/numba/llvmlite/pull/1221>`_: Update actions/upload-artifact action to v4.6.2 (`renovate[bot] <https://github.com/apps/renovate>`_)
+* PR `#1222 <https://github.com/numba/llvmlite/pull/1222>`_: Update conda-incubator/setup-miniconda action to v3.1.1 (`renovate[bot] <https://github.com/apps/renovate>`_)
+* PR `#1223 <https://github.com/numba/llvmlite/pull/1223>`_: fix/revert gha recipe changes (`swap357 <https://github.com/swap357>`_)
+* PR `#1224 <https://github.com/numba/llvmlite/pull/1224>`_: Update pre-commit hook pre-commit/mirrors-clang-format to v20.1.8 (`renovate[bot] <https://github.com/apps/renovate>`_)
+* PR `#1226 <https://github.com/numba/llvmlite/pull/1226>`_: [WIP] LLVM 20 llvmdev recipe (`gmarkall <https://github.com/gmarkall>`_ `swap357 <https://github.com/swap357>`_ `esc <https://github.com/esc>`_)
+* PR `#1227 <https://github.com/numba/llvmlite/pull/1227>`_: fix llvmdev_build.yml to resolve toolchain incompatibility on osx-64 (`swap357 <https://github.com/swap357>`_)
+* PR `#1228 <https://github.com/numba/llvmlite/pull/1228>`_: Update conda-incubator/setup-miniconda action to v3.2.0 (`renovate[bot] <https://github.com/apps/renovate>`_)
+* PR `#1231 <https://github.com/numba/llvmlite/pull/1231>`_: azure-pipelines/win-2019 to 2025 (`swap357 <https://github.com/swap357>`_)
+* PR `#1232 <https://github.com/numba/llvmlite/pull/1232>`_: gha/llvmdev upgrade win-2019 to 2025 (`swap357 <https://github.com/swap357>`_)
+* PR `#1233 <https://github.com/numba/llvmlite/pull/1233>`_: gha/llvmlite upgrade win-2019 to 2025 (`swap357 <https://github.com/swap357>`_)
+* PR `#1235 <https://github.com/numba/llvmlite/pull/1235>`_: Update pre-commit hook PyCQA/flake8 to v7.3.0 (`renovate[bot] <https://github.com/apps/renovate>`_)
+* PR `#1236 <https://github.com/numba/llvmlite/pull/1236>`_: Update pre-commit hook python-jsonschema/check-jsonschema to v0.33.1 (`renovate[bot] <https://github.com/apps/renovate>`_)
+* PR `#1238 <https://github.com/numba/llvmlite/pull/1238>`_: gha/restructure llvmdev ci (`swap357 <https://github.com/swap357>`_)
+* PR `#1239 <https://github.com/numba/llvmlite/pull/1239>`_: Update pre-commit hook python-jsonschema/check-jsonschema to v0.33.2 (`renovate[bot] <https://github.com/apps/renovate>`_)
+* PR `#1240 <https://github.com/numba/llvmlite/pull/1240>`_: pin compilers on llvmlite and llvmdev conda_build_config.yaml (`swap357 <https://github.com/swap357>`_)
+* PR `#1241 <https://github.com/numba/llvmlite/pull/1241>`_: gha/llvmlite wheel workflow fixes (`swap357 <https://github.com/swap357>`_)
+* PR `#1242 <https://github.com/numba/llvmlite/pull/1242>`_: gha/unify llvmlite conda builder workflows (`swap357 <https://github.com/swap357>`_)
+* PR `#1245 <https://github.com/numba/llvmlite/pull/1245>`_: set CONDA_PLUGINS_AUTO_ACCEPT_TOS to manylinux env setup script (`swap357 <https://github.com/swap357>`_)
+* PR `#1246 <https://github.com/numba/llvmlite/pull/1246>`_: gha/fix artifact usage manylinux wheels (`swap357 <https://github.com/swap357>`_)
+* PR `#1248 <https://github.com/numba/llvmlite/pull/1248>`_: Update actions/download-artifact action to v5 (`renovate[bot] <https://github.com/apps/renovate>`_)
+* PR `#1249 <https://github.com/numba/llvmlite/pull/1249>`_: gha/update PR path triggers to include conda recipes (`swap357 <https://github.com/swap357>`_)
+* PR `#1250 <https://github.com/numba/llvmlite/pull/1250>`_: Fix pass timing logic to stop printing to stdout. (`stuartarchibald <https://github.com/stuartarchibald>`_)
+* PR `#1251 <https://github.com/numba/llvmlite/pull/1251>`_: Fix various C++ issues and a linkage issue. (`stuartarchibald <https://github.com/stuartarchibald>`_)
+* PR `#1252 <https://github.com/numba/llvmlite/pull/1252>`_: Move llvmlite to solely CMake based build system.  (`stuartarchibald <https://github.com/stuartarchibald>`_)
+* PR `#1253 <https://github.com/numba/llvmlite/pull/1253>`_: Update pre-commit hook pre-commit/pre-commit-hooks to v6 (`renovate[bot] <https://github.com/apps/renovate>`_)
+* PR `#1256 <https://github.com/numba/llvmlite/pull/1256>`_: Update actions/checkout action to v5 (`renovate[bot] <https://github.com/apps/renovate>`_)
+* PR `#1257 <https://github.com/numba/llvmlite/pull/1257>`_: remove code climate integration (`esc <https://github.com/esc>`_)
+* PR `#1258 <https://github.com/numba/llvmlite/pull/1258>`_: Update pre-commit hook python-jsonschema/check-jsonschema to v0.33.3 (`renovate[bot] <https://github.com/apps/renovate>`_)
+* PR `#1259 <https://github.com/numba/llvmlite/pull/1259>`_: update osx-64 sdk on recipes and CI scripts to use MacOSX10.15 SDK (`swap357 <https://github.com/swap357>`_)
+* PR `#1260 <https://github.com/numba/llvmlite/pull/1260>`_: llvmdev 20 build patches (`swap357 <https://github.com/swap357>`_)
+* PR `#1262 <https://github.com/numba/llvmlite/pull/1262>`_: llvmdev-20 recipe fixes (`swap357 <https://github.com/swap357>`_)
+* PR `#1266 <https://github.com/numba/llvmlite/pull/1266>`_: update compatability matrix in the `README.rst` to reflect LLVM 20 (`esc <https://github.com/esc>`_)
+* PR `#1267 <https://github.com/numba/llvmlite/pull/1267>`_: adding llvm20 docs (`esc <https://github.com/esc>`_)
+
+Authors:
+
+* `alexander-shaposhnikov <https://github.com/alexander-shaposhnikov>`_
+* `dbast <https://github.com/dbast>`_
+* `esc <https://github.com/esc>`_
+* `gmarkall <https://github.com/gmarkall>`_
+* `HighW4y2H3ll <https://github.com/HighW4y2H3ll>`_
+* `jiel-nv <https://github.com/jiel-nv>`_
+* `kc611 <https://github.com/kc611>`_
+* `renovate[bot] <https://github.com/apps/renovate>`_
+* `rj-jesus <https://github.com/rj-jesus>`_
+* `sklam <https://github.com/sklam>`_
+* `stuartarchibald <https://github.com/stuartarchibald>`_
+* `swap357 <https://github.com/swap357>`_
+* `yashssh <https://github.com/yashssh>`_
+
 v0.44.0 (16 January, 2025)
 --------------------------
 

--- a/CHANGE_LOG
+++ b/CHANGE_LOG
@@ -1,5 +1,5 @@
-v0.45.0rc2 (Sept 10, 2025)
---------------------------
+v0.45.0 (Sept 17, 2025)
+-----------------------
 
 This release of llvmlite introduces support for LLVM 20. For more information
 about the state of the support and breaking changes, please see: https://llvmlite.readthedocs.io/en/latest/user-guide/llvm20.html
@@ -117,6 +117,8 @@ Pull-Requests:
 * PR `#1274 <https://github.com/numba/llvmlite/pull/1274>`_: GHA/ standardize job names on workflows for linux builds (`swap357 <https://github.com/swap357>`_)
 * PR `#1276 <https://github.com/numba/llvmlite/pull/1276>`_: Fix build-string on llvmdev_for_wheels conda recipe (`swap357 <https://github.com/swap357>`_)
 * PR `#1278 <https://github.com/numba/llvmlite/pull/1278>`_: Update deprecation page (`sklam <https://github.com/sklam>`_)
+* PR `#1287 <https://github.com/numba/llvmlite/pull/1287>`_: change-log for 0.45.0 FINAL (`esc <https://github.com/esc>`_)
+* PR `#1289 <https://github.com/numba/llvmlite/pull/1289>`_: use explicit channel specification for llvmdev=20 installation (`swap357 <https://github.com/swap357>`_ `esc <https://github.com/esc>`_)
 
 Authors:
 

--- a/CHANGE_LOG
+++ b/CHANGE_LOG
@@ -112,6 +112,7 @@ Pull-Requests:
 * PR `#1262 <https://github.com/numba/llvmlite/pull/1262>`_: llvmdev-20 recipe fixes (`swap357 <https://github.com/swap357>`_)
 * PR `#1266 <https://github.com/numba/llvmlite/pull/1266>`_: update compatability matrix in the `README.rst` to reflect LLVM 20 (`esc <https://github.com/esc>`_)
 * PR `#1267 <https://github.com/numba/llvmlite/pull/1267>`_: adding llvm20 docs (`esc <https://github.com/esc>`_)
+* PR `#1269 <https://github.com/numba/llvmlite/pull/1269>`_: add sdist build and upload steps on wheel workflow (`swap357 <https://github.com/swap357>`_)
 
 Authors:
 

--- a/buildscripts/incremental/setup_conda_environment.cmd
+++ b/buildscripts/incremental/setup_conda_environment.cmd
@@ -11,5 +11,5 @@ call activate %CONDA_ENV%
 if %errorlevel% neq 0 exit /b %errorlevel%
 
 @rem Install llvmdev 20
-call conda install -y -q numba/label/dev::llvmdev=20 libxml2
+call conda install -y -c defaults numba/label/dev::llvmdev=20 libxml2
 if %errorlevel% neq 0 exit /b %errorlevel%

--- a/buildscripts/incremental/setup_conda_environment.sh
+++ b/buildscripts/incremental/setup_conda_environment.sh
@@ -23,7 +23,7 @@ source activate $CONDA_ENV
 set -v
 
 # Install llvmdev 20
-$CONDA_INSTALL -c numba/label/dev llvmdev=20
+$CONDA_INSTALL  numba/label/dev::llvmdev=20
 
 # Install the compiler toolchain, for osx, bootstrapping needed
 # which happens in build.sh

--- a/buildscripts/manylinux/build_llvmlite.sh
+++ b/buildscripts/manylinux/build_llvmlite.sh
@@ -24,7 +24,7 @@ conda activate $envname
 if [ -n "$LLVMDEV_ARTIFACT_PATH" ] && [ -d "$LLVMDEV_ARTIFACT_PATH" ]; then
     conda install -y "$LLVMDEV_ARTIFACT_PATH"/llvmdev-*.conda --no-deps
 else
-    conda install -y -c numba/label/llvm20-wheel llvmdev=20 --no-deps
+    conda install -y -c defaults numba/label/llvm20-wheel::llvmdev=20 --no-deps
 fi
 
 # Prepend builtin Python Path

--- a/conda-recipes/llvmdev_for_wheel/meta.yaml
+++ b/conda-recipes/llvmdev_for_wheel/meta.yaml
@@ -25,7 +25,7 @@ source:
 
 build:
   number: {{ build_number }}
-  string: "manylinux"
+  string: "manylinux_{{ build_number }}"
   script_env:
     - CFLAGS        [linux]
     - CXXFLAGS      [linux]

--- a/docs/source/user-guide/deprecation.rst
+++ b/docs/source/user-guide/deprecation.rst
@@ -10,10 +10,45 @@ for their deprecation and reasoning behind the changes, along with examples, is
 provided.
 
 
+Deprecation of LLVM initialization
+==================================
+
+A breaking change has occurred with the upgrade to LLVM 20.
+Initialization of LLVM core is now automatic, and ``llvm.binding.initialize()`` 
+will raise a ``RuntimeError`` with a suitable message.
+LLVM 20 includes many behavior changes that may break user code
+or expectations. This hard error warns users of such potential breakage.
+See :ref:`llvm20` for more details on LLVM 20 changes.
+
+Reason for deprecation
+----------------------
+
+This is an unscheduled deprecation due to removal of the underlying API in LLVM 20.
+
+
+Schedule
+--------
+
+- In llvmlite 0.45, ``llvm.binding.initialize()`` will raise a hard error to 
+  notify users of the breaking change. 
+- In llvmlite 0.46, ``llvm.binding.initialize()`` will be removed.
+
+
+Recommendations
+---------------
+
+Simply remove ``llvm.binding.initialize()``.
+
+
 .. _deprecation-of-typed-pointers:
 
 Deprecation of Typed Pointers
 =============================
+
+.. note:: Typed pointers support has been removed as llvmlite now uses LLVM 20,
+          which dropped support for typed pointers. All pointer operations now 
+          use opaque pointers. See the migration guide below for updating 
+          existing code.
 
 The use of Typed Pointers is deprecated, and :ref:`Opaque Pointers
 <pointer-types>` will be the default (and eventually required) in a future
@@ -53,7 +88,7 @@ required by the user.
 Schedule
 --------
 
-- In llvmlite 0.45, support for Typed Pointers in the binding layer will be
+- In llvmlite 0.45, support for Typed Pointers in the binding layer was
   removed. The IR layer will still use Typed Pointers by default.
 - In a future version of llvmlite (>= 0.46), the IR layer will use Opaque
   Pointers by default.
@@ -148,156 +183,3 @@ When passing assembly to :func:`llvmlite.binding.parse_assembly`:
 - IR passed to ``parse_assembly()`` is free to use either Typed or Opaque
   Pointers.
 
-
-Deprecation of `llvmlite.llvmpy` module
-=======================================
-The `llvmlite.llvmpy` module was originally created for compatibility with
-`llvmpy`. As time has passed, that functionality was redesigned and put in
-`llvmlite.ir` with `llvmlite.llvmpy` remaining as a compatibility layer. No
-continued maintenance has ensured that it provides a matching API to `llvmpy`
-and it provides no advantage over the `llvmlite.ir` module.
-
-Reason for deprecation
-----------------------
-The functionality provided by `llvmlite.llvmpy` and its child modules is now
-present in `llvmlite.ir`, so this module will be dropped.
-
-Example(s) of the impact
-------------------------
-Code that imports `llvmlite.llvmpy`, `llvmlite.llvmpy.core` or
-`llvmlite.llvmpy.passes` will break.
-
-Schedule
---------
-The feature change was implemented as follows:
-
-* v0.39 module is deprecated
-* v0.40 module is removed
-
-Recommendations
----------------
-Since similar functionality already exists in `llvmlite.ir`, the transition
-path is relatively short:
-
-- replace `llvmlite.llvmpy.core.Builder` with `llvmlite.ir.IRBuilder`
-- replace `llvmlite.llvmpy.core.Builder.icmp` with
-  `llvmlite.ir.IRBuilder.icmp_signed` and `icmp_unsigned`, as appropriate
-- replace `llvmlite.llvmpy.core.Builder.fcmp` with
-  `llvmlite.ir.IRBuilder.fcmp_ordered` and `fcmp_unordered`, as appropriate
-- replace calls to the static methods of `llvmlite.llvmpy.core.Type` with the
-  constructors provided in `llvmlite.ir` (_e.g._, `Type.int(8)` with
-  `IntType(8)`)
-- Replace calls to the static methods of `llvmlite.llvmpy.core.Constant` with
-  calls to the constructor of `llvmlite.ir.Constant` or
-  `llvmlite.ir.Constant.literal_struct`, as appropriate. Note that `stringz`
-  and `array` have no direct equivalents.
-- replace `llvmlite.llvmpy.core.Module`, `Function`, `MetaDataString`,
-  `InlineAsm` with the classes of the same name in `llvmlite.ir.`
-- replace `llvmlite.llvmpy.core.MetaData.get` with
-  `llvmlite.ir.Module.add_metadata`
-- replace `llvmlite.llvmpy.core.Function.intrinsic` with
-  `llvmlite.ir.Module.declare_intrinsic`
-- for `llvmlite.llvmpy.passes`, create the pass manager directly using
-  `llvmlite.binding`
-
-Deprecation of use of memset/memcpy llvm intrinsic with specified alignment
-===========================================================================
-From LLVM 7 onward the `memset <https://releases.llvm.org/7.0.0/docs/LangRef.html#llvm-memset-intrinsics>`_
-and `memcpy <https://releases.llvm.org/7.0.0/docs/LangRef.html#llvm-memcpy-intrinsic>`_
-intrinsics dropped the use of an alignment, specified as the third argument, and
-instead use the alignment of the first argument for this purpose. Specifying
-the alignment in third argument continued to work as LLVM auto-updates this use
-case.
-
-Reason for deprecation
-----------------------
-LLVM has changed the behaviour of the previously mentioned intrinsics, and so as
-to increase compatibility with future releases of LLVM, llvmlite is adapting to
-match.
-
-Example(s) of the impact
-------------------------
-
-As of 0.30 the following worked::
-
-    from llvmlite import ir
-
-    bit = ir.IntType(1)
-    int8 = ir.IntType(8)
-    int32 = ir.IntType(32)
-    int64 = ir.IntType(64)
-    int8ptr = int8.as_pointer()
-
-    mod = ir.Module()
-    fnty = ir.FunctionType(int32, ())
-    func = ir.Function(mod, fnty, "some_function")
-    block = func.append_basic_block('some_block')
-    builder = ir.IRBuilder(block)
-
-    some_address = int64(0xdeaddead)
-    dest = builder.bitcast(some_address, int8ptr)
-    value = int8(0xa5)
-    memset = mod.declare_intrinsic('llvm.memset', [int8ptr, int32])
-    memcpy = mod.declare_intrinsic('llvm.memcpy', [int8ptr, int8ptr, int32])
-
-    # NOTE: 5 argument call site (dest, value, length, align, isvolatile)
-    builder.call(memset, [dest, value, int32(10), int32(0), bit(0)])
-
-    some_other_address = int64(0xcafecafe)
-    src = builder.bitcast(some_other_address, int8ptr)
-
-    # NOTE: 5 argument call site (dest, src, length, align, isvolatile)
-    builder.call(memcpy, [dest, src, int32(10), int32(0), bit(0)])
-
-    builder.ret(int32(0))
-    print(str(mod))
-
-
-From 0.31 onwards only the following works::
-
-    from llvmlite import ir
-
-    bit = ir.IntType(1)
-    int8 = ir.IntType(8)
-    int32 = ir.IntType(32)
-    int64 = ir.IntType(64)
-    int8ptr = int8.as_pointer()
-
-    mod = ir.Module()
-    fnty = ir.FunctionType(int32, ())
-    func = ir.Function(mod, fnty, "some_function")
-    block = func.append_basic_block('some_block')
-    builder = ir.IRBuilder(block)
-
-    some_address = int64(0xdeaddead)
-    dest = builder.bitcast(some_address, int8ptr)
-    value = int8(0xa5)
-    memset = mod.declare_intrinsic('llvm.memset', [int8ptr, int32])
-    memcpy = mod.declare_intrinsic('llvm.memcpy', [int8ptr, int8ptr, int32])
-
-    # NOTE: 4 argument call site (dest, value, length, isvolatile)
-    builder.call(memset, [dest, value, int32(10), bit(0)])
-
-    some_other_address = int64(0xcafecafe)
-    src = builder.bitcast(some_other_address, int8ptr)
-
-    # NOTE: 4 argument call site (dest, src, length, isvolatile)
-    builder.call(memcpy, [dest, src, int32(10), bit(0)])
-
-    builder.ret(int32(0))
-    print(str(mod))
-
-
-Schedule
---------
-The feature change was implemented as follows:
-
-* v0.30 was the last release to support an alignment specified as the third
-  argument (5 argument style).
-* v0.31 onwards supports the 4 argument style call only.
-
-
-Recommendations
----------------
-Projects that need/rely on the deprecated behaviour should pin their dependency
-on llvmlite to a version prior to removal of this behaviour.


### PR DESCRIPTION
This is the set of cherry-picks from the `release0.45` branch. The SHA1 sum and order was determined using:


```
zsh» git --no-pager log --oneline --merges `git merge-base main release0.45`..release0.45 | tac
89a5f22f16 Merge pull request #1268 from esc/release0.45
5e0c0977c7 Merge pull request #1269 from swap357/gha/add_llvmlite_sdist_wheel_workflow
bbe3985e6c Merge pull request #1276 from swap357/gha/fix_llvmdev_for_wheels_buildstring
222bfdc485 Merge pull request #1274 from swap357/gha/refactor_gha_job_names
52ad9b3187 Merge pull request #1278 from sklam/misc/update_deprecation_llvm20
47730fd806 Merge pull request #1282 from esc/release0.45
17c5a9843b Merge pull request #1289 from esc/gha/use_explicit_channel_pin_llvmdev_for_wheel
2d479c9ce4 Merge pull request #1287 from esc/release0.45
```