### PR TITLE
Python 3.14 cleanup on official support

### DIFF
--- a/.github/workflows/llvmlite_conda_builder.yml
+++ b/.github/workflows/llvmlite_conda_builder.yml
@@ -69,7 +69,7 @@ jobs:
     name: ${{ matrix.platform }}-py${{ matrix.python-version }}-build
     runs-on: ${{ matrix.runner }}
     env:
-      EXTRA_CHANNELS: ${{ matrix.python-version == '3.14' && '-c ad-testing/label/py314' || '' }}
+      EXTRA_CHANNELS: ''
     defaults:
       run:
         shell: bash -elx {0}
@@ -135,7 +135,7 @@ jobs:
     needs: [check, build]
     runs-on: ${{ matrix.runner }}
     env:
-      EXTRA_CHANNELS: ${{ matrix.python-version == '3.14' && '-c ad-testing/label/py314' || '' }}
+      EXTRA_CHANNELS: ''
     defaults:
       run:
         shell: bash -elx {0}


### PR DESCRIPTION
Cleanup after 3.14 GA:
- remove extra channel (`ad-testing/label/py314`) used on conda builder workflow.

https://github.com/numba/llvmlite/issues/1281