### PR TITLE
Add s390x support to GHA workflow

### DIFF
--- a/.github/workflows/llvmdev_build.yml
+++ b/.github/workflows/llvmdev_build.yml
@@ -20,6 +20,7 @@ on:
           - all
           - linux-64
           - linux-aarch64
+          - linux-s390x
           - osx-arm64
           - win-64
       recipe:
@@ -93,7 +94,7 @@ jobs:
           run-post: false
 
       - name: Build and test conda package in manylinux - linux platforms
-        if: (matrix.platform == 'linux-64' || matrix.platform == 'linux-aarch64') && matrix.recipe == 'llvmdev_for_wheel'
+        if: (matrix.platform == 'linux-64' || matrix.platform == 'linux-aarch64' || matrix.platform == 'linux-s390x') && matrix.recipe == 'llvmdev_for_wheel'
         env:
           CONDA_CHANNEL_DIR: conda_channel_dir
         run: |
@@ -107,6 +108,9 @@ jobs:
           elif [[ "${{ matrix.platform }}" == "linux-aarch64" ]]; then
             MANYLINUX_IMAGE="quay.io/pypa/manylinux_2_28_aarch64"
             MINICONDA_FILE="https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-aarch64.sh"
+          elif [[ "${{ matrix.platform }}" == "linux-s390x" ]]; then
+            MANYLINUX_IMAGE="quay.io/pypa/manylinux2014_s390x"
+            MINICONDA_FILE="https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-s390x.sh"
           fi
 
           echo "Building in manylinux container for ${{ matrix.platform }}"
@@ -125,12 +129,12 @@ jobs:
           ls -lah "${CONDA_CHANNEL_DIR}"
 
       - name: Install conda-build
-        if: (matrix.platform != 'linux-64' && matrix.platform != 'linux-aarch64') || matrix.recipe != 'llvmdev_for_wheel'
+        if: (matrix.platform != 'linux-64' && matrix.platform != 'linux-aarch64' && matrix.platform != 'linux-s390x') || matrix.recipe != 'llvmdev_for_wheel'
         run: |
           conda install -c defaults conda-build
 
       - name: Build and test conda package - non-linux platforms
-        if: (matrix.platform != 'linux-64' && matrix.platform != 'linux-aarch64') || matrix.recipe != 'llvmdev_for_wheel'
+        if: (matrix.platform != 'linux-64' && matrix.platform != 'linux-aarch64' && matrix.platform != 'linux-s390x') || matrix.recipe != 'llvmdev_for_wheel'
         env:
           CONDA_CHANNEL_DIR: conda_channel_dir
         run: |

--- a/.github/workflows/llvmlite_conda_builder.yml
+++ b/.github/workflows/llvmlite_conda_builder.yml
@@ -24,6 +24,7 @@ on:
           - all
           - linux-64
           - linux-aarch64
+          - linux-s390x
           - osx-arm64
           - win-64
 

--- a/.github/workflows/llvmlite_linux-s390x_wheel_builder.yml
+++ b/.github/workflows/llvmlite_linux-s390x_wheel_builder.yml
@@ -1,0 +1,257 @@
+name: llvmlite_linux-s390x_wheel_builder
+
+on:
+  pull_request:
+    paths:
+      - .github/workflows/llvmlite_linux-s390x_wheel_builder.yml
+  workflow_dispatch:
+    inputs:
+      llvmdev_run_id:
+        description: 'llvmdev workflow run ID (optional)'
+        required: false
+        type: string
+      upload_wheel_to_anaconda:
+        description: 'Upload wheel to Anaconda Cloud - numba channel'
+        required: false
+        type: boolean
+        default: false
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: true
+
+env:
+  FALLBACK_LLVMDEV_VERSION: "20"
+  CONDA_CHANNEL_NUMBA: numba/label/llvm20-wheel
+  VALIDATION_PYTHON_VERSION: "3.12"
+  ARTIFACT_RETENTION_DAYS: 7
+  MANYLINUX_IMAGE: "manylinux2014_s390x"
+
+jobs:
+  linux-s390x-build:
+    name: linux-s390x-build
+    runs-on: ubuntu-24.04-s390x
+    defaults:
+      run:
+        shell: bash -elx {0}
+    strategy:
+      matrix:
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
+      fail-fast: false
+
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          fetch-depth: 0
+
+      - name: Download llvmdev Artifact
+        if: ${{ inputs.llvmdev_run_id != '' }}
+        uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5.0.0
+        with:
+          name: llvmdev_for_wheel_linux-s390x
+          path: llvmdev_conda_packages
+          run-id: ${{ inputs.llvmdev_run_id }}
+          repository: ${{ github.repository }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Map Python version
+        run: |
+          # Map Python version to manylinux path
+          case "${{ matrix.python-version }}" in
+            "3.10") echo "PYTHON_PATH=cp310-cp310" >> "$GITHUB_ENV" ;;
+            "3.11") echo "PYTHON_PATH=cp311-cp311" >> "$GITHUB_ENV" ;;
+            "3.12") echo "PYTHON_PATH=cp312-cp312" >> "$GITHUB_ENV" ;;
+            "3.13") echo "PYTHON_PATH=cp313-cp313" >> "$GITHUB_ENV" ;;
+            "3.14") echo "PYTHON_PATH=cp314-cp314" >> "$GITHUB_ENV" ;;
+            *) echo "Invalid Python version" && exit 1 ;;
+          esac
+
+          # Define Miniconda installer URL
+          echo "MINICONDA_FILE=https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-s390x.sh" >> "$GITHUB_ENV"
+
+      - name: Build wheel in manylinux container
+        run: |
+          LLVMDEV_ARTIFACT_PATH="/root/llvmlite/llvmdev_conda_packages"
+
+          # Run the build script in manylinux container using the existing script
+          docker run --rm \
+            -v "$(pwd):/root/llvmlite" \
+            quay.io/pypa/${{ env.MANYLINUX_IMAGE }} \
+            bash -c "git config --global --add safe.directory /root/llvmlite && /root/llvmlite/buildscripts/manylinux/build_llvmlite.sh ${{ env.MINICONDA_FILE }} ${{ env.PYTHON_PATH }} $LLVMDEV_ARTIFACT_PATH"
+
+          # Create wheelhouse directory for artifact upload
+          mkdir -p wheelhouse
+
+          # The script creates output in a specific location based on architecture and Python version
+          WHEEL_DIR="docker_output/dist_s390x_${{ env.PYTHON_PATH }}/wheelhouse"
+
+          # List wheels to debug
+          echo "Available wheels in $WHEEL_DIR:"
+          find "$WHEEL_DIR" -type f -name "*.whl" -print
+
+          # Copy wheels to upload directory
+          cp "$WHEEL_DIR"/*.whl wheelhouse/ || echo "Warning: No matching wheel found!"
+
+          # Verify we have the correct wheel
+          echo "--- Final wheel for upload: ---"
+          find wheelhouse -type f -name "*.whl" -print
+
+      - name: Upload wheel
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: llvmlite-linux-s390x-py${{ matrix.python-version }}
+          path: wheelhouse/*.whl
+          compression-level: 0
+          retention-days: ${{ env.ARTIFACT_RETENTION_DAYS }}
+          if-no-files-found: error
+
+      - name: Show Workflow Run ID
+        run: "echo \"Workflow Run ID: ${{ github.run_id }}\""
+
+  linux-s390x-validate:
+    name: linux-s390x-validate
+    needs: linux-s390x-build
+    runs-on: ubuntu-24.04-s390x
+    defaults:
+      run:
+        shell: bash -elx {0}
+    strategy:
+      matrix:
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
+      fail-fast: false
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+
+      - name: Setup Miniconda
+        uses: conda-incubator/setup-miniconda@835234971496cad1653abb28a638a281cf32541f # v3.2.0
+        with:
+          python-version: ${{ env.VALIDATION_PYTHON_VERSION }}
+          auto-update-conda: true
+          auto-activate-base: true
+          activate-environment: true
+
+      - name: Install validation dependencies
+        run: conda install -c defaults wheel twine keyring rfc3986
+
+      - name: Download llvmlite wheels
+        uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5.0.0
+        with:
+          name: llvmlite-linux-s390x-py${{ matrix.python-version }}
+          path: dist
+
+      - name: Validate wheels
+        run: |
+          cd dist
+          for WHL_FILE in *.whl; do
+            echo "=== Validating $WHL_FILE ==="
+            # Check wheel structure
+            twine check "$WHL_FILE"
+          done
+
+  linux-s390x-test:
+    name: linux-s390x-test
+    needs: linux-s390x-build
+    runs-on: ubuntu-24.04-s390x
+    defaults:
+      run:
+        shell: bash -elx {0}
+    strategy:
+      matrix:
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
+      fail-fast: false
+
+    steps:
+      - name: Setup Python
+        uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c # v6.0.0
+        with:
+          python-version: ${{ matrix.python-version }}
+          allow-prereleases: true
+
+      - name: Download llvmlite wheel
+        uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5.0.0
+        with:
+          name: llvmlite-linux-s390x-py${{ matrix.python-version }}
+          path: dist
+
+      - name: Install and test
+        env:
+          LLVMLITE_DIST_TEST: "1"
+        run: |
+          # Get the Python executable path
+          PYTHON_PATH=$(which python)
+
+          # Upgrade pip and install wheel
+          "${PYTHON_PATH}" -m pip install --upgrade pip wheel
+
+          # Install wheel
+          cd dist
+          # Look for wheel matching this python version
+          PY_TAG=$(python -c "import sys; print(f'cp{sys.version_info.major}{sys.version_info.minor}')")
+          # Use find instead of ls for better handling of non-alphanumeric filenames
+          whl=$(find . -type f -name "*${PY_TAG}*.whl" | sort | head -n 1)
+
+          if [ -z "$whl" ]; then
+            echo "ERROR: No matching wheel found for Python ${{ matrix.python-version }} (tag: $PY_TAG)"
+            find . -type f -name "*.whl" -print
+            exit 1
+          fi
+
+          echo "Installing lief for distribution testing"
+          "${PYTHON_PATH}" -m pip install -v lief
+
+          echo "Using wheel: $whl"
+          "${PYTHON_PATH}" -m pip install -v "$whl"
+
+          # Run tests
+          "${PYTHON_PATH}" -m llvmlite.tests
+
+  linux-s390x-upload:
+    name: linux-s390x-upload
+    needs: [linux-s390x-test, linux-s390x-validate]
+    if: github.event_name == 'workflow_dispatch' && inputs.upload_wheel_to_anaconda
+    runs-on: ubuntu-24.04-s390x
+    defaults:
+      run:
+        shell: bash -elx {0}
+    strategy:
+      matrix:
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
+      fail-fast: false
+    steps:
+      - name: Setup Miniconda
+        uses: conda-incubator/setup-miniconda@835234971496cad1653abb28a638a281cf32541f # v3.2.0
+        with:
+          python-version: ${{ env.VALIDATION_PYTHON_VERSION }}
+          auto-update-conda: true
+          auto-activate-base: true
+          activate-environment: true
+
+      - name: Install anaconda-client
+        run: conda install -c anaconda anaconda-client
+
+      - name: Download llvmlite wheel
+        uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5.0.0
+        with:
+          name: llvmlite-linux-s390x-py${{ matrix.python-version }}
+          path: dist
+
+      - name: Upload wheel to Anaconda Cloud
+        env:
+          ANACONDA_API_TOKEN: ${{ secrets.NUMBA_CHANNEL_WHEEL_UPLOAD }}
+        run: |
+          cd dist
+          # Find appropriate wheel for Python version
+          PY_TAG="cp$(echo "${{ matrix.python-version }}" | tr -d '.')"
+          # Use find instead of ls for better handling of non-alphanumeric filenames
+          whl=$(find . -type f -name "*${PY_TAG}*.whl" | sort | head -n 1)
+
+          if [ -z "$whl" ]; then
+            echo "ERROR: No matching wheel found for Python ${{ matrix.python-version }}"
+            find . -type f -name "*.whl" -print
+            exit 1
+          fi
+
+          echo "Uploading wheel: $whl"
+          anaconda -t "$ANACONDA_API_TOKEN" upload --force -u numba -l dev "$whl"

--- a/buildscripts/github/llvmdev_evaluate.py
+++ b/buildscripts/github/llvmdev_evaluate.py
@@ -12,6 +12,7 @@ inputs = os.environ.get("GITHUB_WORKFLOW_INPUT", "{}")
 runner_mapping = {
     "linux-64": "ubuntu-24.04",
     "linux-aarch64": "ubuntu-24.04-arm",
+    "linux-s390x": "ubuntu-24.04-s390x",
     "osx-arm64": "macos-14",
     "win-64": "windows-2025",
 }
@@ -37,6 +38,17 @@ default_include = [
     {
         "runner": runner_mapping["linux-aarch64"],
         "platform": "linux-aarch64",
+        "recipe": "llvmdev_for_wheel",
+    },
+    # linux-s390x
+    {
+        "runner": runner_mapping["linux-s390x"],
+        "platform": "linux-s390x",
+        "recipe": "llvmdev",
+    },
+    {
+        "runner": runner_mapping["linux-s390x"],
+        "platform": "linux-s390x",
         "recipe": "llvmdev_for_wheel",
     },
     # osx-arm64

--- a/buildscripts/github/llvmlite_evaluate.py
+++ b/buildscripts/github/llvmlite_evaluate.py
@@ -12,6 +12,7 @@ inputs = os.environ.get("GITHUB_WORKFLOW_INPUT", "{}")
 runner_mapping = {
     "linux-64": "ubuntu-24.04",
     "linux-aarch64": "ubuntu-24.04-arm",
+    "linux-s390x": "ubuntu-24.04-s390x",
     "osx-arm64": "macos-14",
     "win-64": "windows-2025",
 }
@@ -30,6 +31,13 @@ default_include = [
     {"runner": runner_mapping["linux-aarch64"], "platform": "linux-aarch64", "python-version": "3.12"},
     {"runner": runner_mapping["linux-aarch64"], "platform": "linux-aarch64", "python-version": "3.13"},
     {"runner": runner_mapping["linux-aarch64"], "platform": "linux-aarch64", "python-version": "3.14"},
+
+    # linux-s390x
+    {"runner": runner_mapping["linux-s390x"], "platform": "linux-s390x", "python-version": "3.10"},
+    {"runner": runner_mapping["linux-s390x"], "platform": "linux-s390x", "python-version": "3.11"},
+    {"runner": runner_mapping["linux-s390x"], "platform": "linux-s390x", "python-version": "3.12"},
+    {"runner": runner_mapping["linux-s390x"], "platform": "linux-s390x", "python-version": "3.13"},
+    {"runner": runner_mapping["linux-s390x"], "platform": "linux-s390x", "python-version": "3.14"},
 
     # osx-arm64
     {"runner": runner_mapping["osx-arm64"], "platform": "osx-arm64", "python-version": "3.10"},

--- a/buildscripts/manylinux/README.md
+++ b/buildscripts/manylinux/README.md
@@ -9,6 +9,8 @@ Run the script below to start docker off building `llvmdev` base from the curren
     - uses manylinux2014 image for glibc 2.17+: `pypa.io/pypa/manylinux2014_x86_64`
 - aarch64 linux: `./buildscripts/manylinux/docker_run_aarch64.sh build_llvmdev.sh`
     - uses manylinux_2_28 image for glibc 2.28+: `pypa.io/pypa/manylinux_2_28_aarch64`
+- s390x linux: `./buildscripts/manylinux/docker_run_s390x.sh build_llvmdev.sh`
+    - uses manylinux2014 image for glibc 2.17+: `pypa.io/pypa/manylinux2014_s390x`
 
 The conda packages will be stored into `<llvmlite_source_root>/docker_output`
 
@@ -26,6 +28,7 @@ Run the script below to start docker off building `llvmlite` base from the curre
 
 - x86_64 linux: `./buildscripts/manylinux/docker_run_x64.sh build_llvmlite.sh <pyver>`
 - aarch64 linux: `./buildscripts/manylinux/docker_run_aarch64.sh build_llvmlite.sh <pyver>`
+- s390x linux: `./buildscripts/manylinux/docker_run_s390x.sh build_llvmlite.sh`
 
 The conda packages will be stored into `<llvmlite_source_root>/docker_output/dist_<arch>_<pyver>`
 

--- a/buildscripts/manylinux/docker_run_s390x.sh
+++ b/buildscripts/manylinux/docker_run_s390x.sh
@@ -1,0 +1,4 @@
+export MANYLINUX_IMAGE="manylinux2014_s390x"
+export MINICONDA_FILE="https://repo.anaconda.com/miniconda/Miniconda3-py311_24.9.2-0-Linux-s390x.sh"
+cd $(dirname $0)
+./docker_run.sh $1 $2


### PR DESCRIPTION
Hi,

This PR adds support for s390x to the GitHub Actions workflow. llvmdev [builds successfully](https://github.com/MarkVeerasingam/llvmlite/actions/runs/18131314484) and the results of the LLVM tests were:

> Total Discovered Tests: 16827
> Excluded         :     1 (0.01%)
> Unsupported      :   404 (2.40%)
> Passed           : 16362 (97.24%)
> Expectedly Failed:    60 (0.36%)

llvmlite also [builds successfully](https://github.com/MarkVeerasingam/llvmlite/actions/runs/18135386784/job/51612653358) and the results of the tests were:

<img width="1917" height="886" alt="Screenshot From 2025-10-01 09-35-20" src="https://github.com/user-attachments/assets/d03e9e86-bf7b-4ab6-9f04-b5ee479d08b5" />

---

GitHub does not host an s390x runner, however open source projects can request access to the IBM hosted s390x/ppc64le runners by submitting an issue on the [ActionsPZ GitHub repo](https://github.com/IBM/actionspz). 

The process is straight forward:
1. An admin submits an issue on the actionsPZ repo using [this template](https://github.com/IBM/actionspz/blob/main/.github/ISSUE_TEMPLATE/new-project-template.md) 
2. The same admin creates an IBM ID using the same email as their GitHub account. 
3. Once approved the [GitHub app](https://github.com/apps/power-z-gha-runner/) can be added to the project which allows the use of s390x and POWER9/10 runners.

We are happy to make any changes needed to this PR and provide support when requesting access to actionspz.

Ref: #780 