### PR TITLE
Fix OptimizationLevel mapping for Os

### DIFF
--- a/ffi/newpassmanagers.cpp
+++ b/ffi/newpassmanagers.cpp
@@ -277,7 +277,7 @@ static OptimizationLevel mapLevel(int speed_level, int size_level) {
             llvm_unreachable("Invalid optimization level");
         }
     case 1:
-        if (speed_level == 1)
+        if (speed_level == 2)
             return OptimizationLevel::Os;
         llvm_unreachable("Invalid optimization level for size level 1");
     case 2:


### PR DESCRIPTION
For Os LLVM defined speed level is 2 not 1.
(https://github.com/llvm/llvm-project/blob/main/llvm/lib/Passes/OptimizationLevel.cpp)

fixes #1306