### PR TITLE
fix `llvmdev_for_wheel` linux builds

### DIFF
--- a/.github/workflows/llvmdev_build.yml
+++ b/.github/workflows/llvmdev_build.yml
@@ -136,7 +136,7 @@ jobs:
         run: |
           set -x
           mkdir -p "${CONDA_CHANNEL_DIR}"
-          conda build "./conda-recipes/${{ matrix.recipe }}" "--output-folder=${CONDA_CHANNEL_DIR}"
+          conda build -c defaults "./conda-recipes/${{ matrix.recipe }}" "--output-folder=${CONDA_CHANNEL_DIR}"
           ls -lah "${CONDA_CHANNEL_DIR}"
 
       - name: Upload conda package

--- a/buildscripts/manylinux/build_llvmdev.sh
+++ b/buildscripts/manylinux/build_llvmdev.sh
@@ -15,4 +15,4 @@ else
 fi
 conda activate buildenv
 conda list
-conda-build /root/llvmlite/conda-recipes/llvmdev_for_wheel --output-folder=/root/llvmlite/docker_output
+conda-build -c defaults /root/llvmlite/conda-recipes/llvmdev_for_wheel --output-folder=/root/llvmlite/docker_output


### PR DESCRIPTION
linux workflows to build conda package from `llvmdev_for_wheel` recipe have been failing -
https://github.com/numba/llvmlite/actions/runs/18365054444
https://github.com/numba/llvmlite/actions/runs/18365074425

This was due to removal of implicit inclusion of defaults channel which worked previously. (pre conda 25.9.0)
This PR resolves the issue by adding explicit `-c defaults` to conda build commands on llvmdev workflow and manylinux buildscript. 