### PR TITLE
GHA/ fix llvmlite `osx-arm64` wheel build tag

### DIFF
--- a/.github/workflows/llvmlite_osx-arm64_wheel_builder.yml
+++ b/.github/workflows/llvmlite_osx-arm64_wheel_builder.yml
@@ -83,7 +83,7 @@ jobs:
 
       - name: Build wheel
         env:
-          MACOSX_DEPLOYMENT_TARGET: "11.1"
+          MACOSX_DEPLOYMENT_TARGET: "11.0"
           LLVMLITE_PACKAGE_FORMAT: "wheel"
           LDFLAGS: "-v -Wl,-rpath,/usr/lib"
         run: |


### PR DESCRIPTION
resolves: https://github.com/numba/llvmlite/issues/1319

Fixes tag issue on `osx-arm64` wheels produced by `llvmlite_osx-arm64_wheel_builder.yml` workflow.
root cause similar to - https://github.com/numba/numba/pull/10274