### PR TITLE
InlineAsm: fix formatting

### DIFF
--- a/llvmlite/ir/instructions.py
+++ b/llvmlite/ir/instructions.py
@@ -765,7 +765,7 @@ class InlineAsm(object):
 
     def descr(self, buf):
         sideeffect = 'sideeffect' if self.side_effect else ''
-        fmt = 'asm {sideeffect} "{asm}", "{constraint}"\n'
+        fmt = 'asm {sideeffect} "{asm}", "{constraint}"'
         buf.append(fmt.format(sideeffect=sideeffect, asm=self.asm,
                               constraint=self.constraint))
 

--- a/llvmlite/tests/test_ir.py
+++ b/llvmlite/tests/test_ir.py
@@ -633,7 +633,7 @@ class TestIR(TestBase):
         asm = ir.InlineAsm(asmty, "mov $1, $2", "=r,r", side_effect=True)
         builder.call(asm, [int32(123)])
         builder.ret_void()
-        pat = 'call i32 asm sideeffect "mov $1, $2", "=r,r" ( i32 123 )'
+        pat = 'call i32 asm sideeffect "mov $1, $2", "=r,r"( i32 123 )'
         self.assertInText(pat, str(mod))
         self.assert_valid_ir(mod)
 


### PR DESCRIPTION
Since a15799e7618068b8c4663c511168ecacfffb1e7e, calls to `InlineAsm` instructions insert a newline between the constraints and the arguments. I believe this change to have been accidentally introduced, with the `end=''` argument to `print` in `InlineAsm` having not been noticed.

This makes the generated code harder to read and less idiomatic. For example, for `test_inline_assembly`:

```llvm
define void @"foo"()
{
.2:
  %".3" = call i32 asm sideeffect "mov $1, $2", "=r,r"
(i32 123)
  ret void
}
```

With this change, the code now reads as:

```llvm
define void @"foo"()
{
.2:
  %".3" = call i32 asm sideeffect "mov $1, $2", "=r,r"(i32 123)
  ret void
}
```

I have updated the regex in `test_inline_assembly` to disallow whitespace between the constraints and the arguments. This is in line with other LLVM IR emitters, as seen in examples in the LLVM Language Reference manual. For example:

```llvm
%X = call i32 asm "bswap $0", "=r,r"(i32 %Y)
```

from https://llvm.org/docs/LangRef.html#inline-assembler-expressions.