### PR TITLE
fix/ remove 'conda-remove-defaults' option from `setup-miniconda`

### DIFF
--- a/.github/workflows/llvmlite_osx-arm64_wheel_builder.yml
+++ b/.github/workflows/llvmlite_osx-arm64_wheel_builder.yml
@@ -48,7 +48,6 @@ jobs:
         uses: conda-incubator/setup-miniconda@835234971496cad1653abb28a638a281cf32541f # v3.2.0
         with:
           python-version: ${{ matrix.python-version }}
-          conda-remove-defaults: true
           auto-update-conda: true
           auto-activate-base: true
 
@@ -134,7 +133,6 @@ jobs:
         uses: conda-incubator/setup-miniconda@835234971496cad1653abb28a638a281cf32541f # v3.2.0
         with:
           python-version: ${{ env.VALIDATION_PYTHON_VERSION }}
-          conda-remove-defaults: true
           auto-update-conda: true
           auto-activate-base: true
 
@@ -208,7 +206,6 @@ jobs:
         uses: conda-incubator/setup-miniconda@835234971496cad1653abb28a638a281cf32541f # v3.2.0
         with:
           python-version: ${{ env.VALIDATION_PYTHON_VERSION }}
-          conda-remove-defaults: true
           auto-update-conda: true
           auto-activate-base: true
 

--- a/.github/workflows/llvmlite_win-64_wheel_builder.yml
+++ b/.github/workflows/llvmlite_win-64_wheel_builder.yml
@@ -48,7 +48,6 @@ jobs:
       - name: Setup Miniconda
         uses: conda-incubator/setup-miniconda@835234971496cad1653abb28a638a281cf32541f # v3.2.0
         with:
-          conda-remove-defaults: true
           auto-update-conda: true
           auto-activate-base: true
 
@@ -123,7 +122,6 @@ jobs:
         uses: conda-incubator/setup-miniconda@835234971496cad1653abb28a638a281cf32541f # v3.2.0
         with:
           python-version: ${{ env.VALIDATION_PYTHON_VERSION }}
-          conda-remove-defaults: true
           auto-update-conda: true
           auto-activate-base: true
 
@@ -207,7 +205,6 @@ jobs:
         uses: conda-incubator/setup-miniconda@835234971496cad1653abb28a638a281cf32541f # v3.2.0
         with:
           python-version: ${{ env.VALIDATION_PYTHON_VERSION }}
-          conda-remove-defaults: true
           auto-update-conda: true
           auto-activate-base: true
 


### PR DESCRIPTION
closes: https://github.com/numba/llvmlite/issues/1343

The `setup-miniconda` action fails on `osx-arm64`. The issue occurs when using `conda-remove-defaults: true` which now effectively removes the defaults channel, and there's no channel to get `python-version: ${{ matrix.python-version }}` from.

This PR removes `conda-remove-defaults: true` option from `setup-miniconda` steps on all workflows where used(`osx-arm64` and `win-64`) as `defaults` channel is required to get python package onto build environment. 