### PR TITLE
Add 3.14t wheel builds by skipping PyLIEF install

### DIFF
--- a/.github/workflows/llvmlite_linux-64_wheel_builder.yml
+++ b/.github/workflows/llvmlite_linux-64_wheel_builder.yml
@@ -36,7 +36,7 @@ jobs:
         shell: bash -elx {0}
     strategy:
       matrix:
-        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14", "3.14t"]
       fail-fast: false
 
     steps:
@@ -64,6 +64,7 @@ jobs:
             "3.12") echo "PYTHON_PATH=cp312-cp312" >> "$GITHUB_ENV" ;;
             "3.13") echo "PYTHON_PATH=cp313-cp313" >> "$GITHUB_ENV" ;;
             "3.14") echo "PYTHON_PATH=cp314-cp314" >> "$GITHUB_ENV" ;;
+            "3.14t") echo "PYTHON_PATH=cp314-cp314t" >> "$GITHUB_ENV" ;;
             *) echo "Invalid Python version" && exit 1 ;;
           esac
 
@@ -118,7 +119,7 @@ jobs:
         shell: bash -elx {0}
     strategy:
       matrix:
-        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14", "3.14t"]
       fail-fast: false
     steps:
       - name: Clone repository
@@ -159,7 +160,7 @@ jobs:
         shell: bash -elx {0}
     strategy:
       matrix:
-        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14", "3.14t"]
       fail-fast: false
 
     steps:
@@ -199,7 +200,10 @@ jobs:
           fi
 
           echo "Installing lief for distribution testing"
-          "${PYTHON_PATH}" -m pip install -v lief
+          # TODO: make unconditional when PyLIEF ships free-threaded wheels
+          if [[ "${{ matrix.python-version }}" != *t ]]; then
+              "${PYTHON_PATH}" -m pip install -v lief
+          fi
 
           echo "Using wheel: $whl"
           "${PYTHON_PATH}" -m pip install -v "$whl"
@@ -217,7 +221,7 @@ jobs:
         shell: bash -elx {0}
     strategy:
       matrix:
-        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14", "3.14t"]
       fail-fast: false
     steps:
       - name: Setup Miniconda

--- a/.github/workflows/llvmlite_linux-aarch64_wheel_builder.yml
+++ b/.github/workflows/llvmlite_linux-aarch64_wheel_builder.yml
@@ -36,7 +36,7 @@ jobs:
         shell: bash -elx {0}
     strategy:
       matrix:
-        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14", "3.14t"]
       fail-fast: false
 
     steps:
@@ -64,6 +64,7 @@ jobs:
             "3.12") echo "PYTHON_PATH=cp312-cp312" >> "$GITHUB_ENV" ;;
             "3.13") echo "PYTHON_PATH=cp313-cp313" >> "$GITHUB_ENV" ;;
             "3.14") echo "PYTHON_PATH=cp314-cp314" >> "$GITHUB_ENV" ;;
+            "3.14t") echo "PYTHON_PATH=cp314-cp314t" >> "$GITHUB_ENV" ;;
             *) echo "Invalid Python version" && exit 1 ;;
           esac
 
@@ -115,7 +116,7 @@ jobs:
         shell: bash -elx {0}
     strategy:
       matrix:
-        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14", "3.14t"]
       fail-fast: false
     steps:
       - name: Clone repository
@@ -156,7 +157,7 @@ jobs:
         shell: bash -elx {0}
     strategy:
       matrix:
-        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14", "3.14t"]
       fail-fast: false
 
     steps:
@@ -196,7 +197,10 @@ jobs:
           fi
 
           echo "Installing lief for distribution testing"
-          "${PYTHON_PATH}" -m pip install -v lief
+          # TODO: make unconditional when PyLIEF ships free-threaded wheels
+          if [[ "${{ matrix.python-version }}" != *t ]]; then
+              "${PYTHON_PATH}" -m pip install -v lief
+          fi
 
           echo "Using wheel: $whl"
           "${PYTHON_PATH}" -m pip install -v "$whl"
@@ -214,7 +218,7 @@ jobs:
         shell: bash -elx {0}
     strategy:
       matrix:
-        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14", "3.14t"]
       fail-fast: false
     steps:
       - name: Setup Miniconda

--- a/.github/workflows/llvmlite_osx-arm64_wheel_builder.yml
+++ b/.github/workflows/llvmlite_osx-arm64_wheel_builder.yml
@@ -35,7 +35,7 @@ jobs:
         shell: bash -elx {0}
     strategy:
       matrix:
-        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14", "3.14t"]
       fail-fast: false
 
     steps:
@@ -47,7 +47,6 @@ jobs:
       - name: Setup Miniconda
         uses: conda-incubator/setup-miniconda@835234971496cad1653abb28a638a281cf32541f # v3.2.0
         with:
-          python-version: ${{ matrix.python-version }}
           auto-update-conda: true
           auto-activate-base: true
 
@@ -63,6 +62,12 @@ jobs:
 
       - name: Install build dependencies
         run: |
+          if [[ "${{ matrix.python-version }}" == *t ]]; then
+              PY_VER=${{ matrix.python-version }}
+              conda install -c conda-forge python-freethreading="${PY_VER%t}"
+          else
+              conda install -c defaults python="${{ matrix.python-version }}"
+          fi
           if [ "${{ inputs.llvmdev_run_id }}" != "" ]; then
               CHAN="file://${{ github.workspace }}/llvmdev_conda_packages"
               conda install -c defaults -c "$CHAN" "llvmdev=${{ env.FALLBACK_LLVMDEV_VERSION }}"
@@ -123,7 +128,7 @@ jobs:
         shell: bash -elx {0}
     strategy:
       matrix:
-        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14", "3.14t"]
       fail-fast: false
     steps:
       - name: Clone repository
@@ -159,7 +164,7 @@ jobs:
         shell: bash -elx {0}
     strategy:
       matrix:
-        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14", "3.14t"]
       fail-fast: false
 
     steps:
@@ -183,7 +188,10 @@ jobs:
           "$PYTHON_PATH" -m venv .venv && source .venv/bin/activate
           python -m pip install --upgrade pip wheel
           echo "Installing lief for distribution testing"
-          python -m pip install -v lief
+          # TODO: make unconditional when PyLIEF ships free-threaded wheels
+          if [[ "${{ matrix.python-version }}" != *t ]]; then
+              python -m pip install -v lief
+          fi
           cd dist && python -m pip install -v ./*.whl
           DYLIB_PATH=$(find "$(python -c "import llvmlite; print(llvmlite.__path__[0])")" -name "libllvmlite.dylib")
           echo "Found dylib at: $DYLIB_PATH" && otool -L "$DYLIB_PATH"
@@ -199,7 +207,7 @@ jobs:
         shell: bash -elx {0}
     strategy:
       matrix:
-        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14", "3.14t"]
       fail-fast: false
     steps:
       - name: Setup Miniconda

--- a/.github/workflows/llvmlite_win-64_wheel_builder.yml
+++ b/.github/workflows/llvmlite_win-64_wheel_builder.yml
@@ -36,7 +36,7 @@ jobs:
         shell: bash -elx {0}
     strategy:
       matrix:
-        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14", "3.14t"]
       fail-fast: false
 
     steps:
@@ -112,7 +112,7 @@ jobs:
         shell: bash -elx {0}
     strategy:
       matrix:
-        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14", "3.14t"]
       fail-fast: false
     steps:
       - name: Clone repository
@@ -152,7 +152,7 @@ jobs:
         shell: bash -elx {0}
     strategy:
       matrix:
-        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14", "3.14t"]
       fail-fast: false
 
     steps:
@@ -176,7 +176,10 @@ jobs:
           python -m pip install --upgrade pip wheel
 
           echo "Installing lief for distribution testing"
-          python -m pip install -v lief
+          # TODO: make unconditional when PyLIEF ships free-threaded wheels
+          if [[ "${{ matrix.python-version }}" != *t ]]; then
+              python -m pip install -v lief
+          fi
 
           # Install wheel and run tests
           cd dist
@@ -198,7 +201,7 @@ jobs:
         shell: bash -elx {0}
     strategy:
       matrix:
-        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14", "3.14t"]
       fail-fast: false
     steps:
       - name: Setup Miniconda


### PR DESCRIPTION
Adds 3.14t to the wheel building matrix. Because PyLIEF doesn't yet ship cp314t wheels (https://github.com/lief-project/LIEF/issues/1255) and PyLIEF doesn't list any build requirements in its pyproject.toml, it's necessary to set up the PyLIEF build manually.

Unfortunately this adds a decent amount of overhead to the builds, particularly for the Mac builds, where the PyLIEF build happens twice during the build and install steps. We could probably optimize that but I'm curious if the maintainers are opposed to this approach and would prefer I work on getting PyLIEF wheels ready instead.