### PR TITLE
Cherry pick 0.46.0

### DIFF
--- a/CHANGE_LOG
+++ b/CHANGE_LOG
@@ -1,5 +1,5 @@
-v0.46.0rc1 (November 13, 2025)
-------------------------------
+v0.46.0 (December 8, 2025)
+--------------------------
 
 Highlights of this release include:
 
@@ -43,6 +43,7 @@ Pull-Requests:
 * PR `#1358 <https://github.com/numba/llvmlite/pull/1358>`_: Pin gcc/gxx to 11 (`sklam <https://github.com/sklam>`_)
 * PR `#1359 <https://github.com/numba/llvmlite/pull/1359>`_: update macos image version from `macos-13` to `macos-15` on azure ci (`swap357 <https://github.com/swap357>`_)
 * PR `#1360 <https://github.com/numba/llvmlite/pull/1360>`_: chore(deps): update pre-commit hook python-jsonschema/check-jsonschema to v0.35.0 (`renovate[bot] <https://github.com/apps/renovate>`_)
+* PR `#1376 <https://github.com/numba/llvmlite/pull/1376>`_: update changelog for 0.46.0 (`swap357 <https://github.com/swap357>`_)
 
 Authors:
 


### PR DESCRIPTION
This PR cherry-picks merges from release0.46 branch onto main. (post-release process)
```
% git --no-pager log --oneline --merges `git merge-base upstream/main upstream/release0.46`..upstream/release0.46
50404fd4 (tag: v0.46.0, upstream/release0.46, release0.46) Merge pull request #1376 from swap357/release0.46
8f5c1e03 (tag: v0.46.0rc1) Merge pull request #1364 from swap357/release0.46
```