### PR TITLE
gha/fix llvmdev build disk space issue 

### DIFF
--- a/.github/workflows/llvmdev_build.yml
+++ b/.github/workflows/llvmdev_build.yml
@@ -87,6 +87,7 @@ jobs:
       - name: Free up disk space
         if: matrix.platform == 'linux-64' || matrix.platform == 'linux-aarch64'
         run: |
+          echo "Disk space before cleanup:" && df -h /
           # Removes pre-installed packages, frees ~20GB
           sudo rm -rf /usr/share/dotnet
           sudo rm -rf /usr/local/lib/android
@@ -96,6 +97,7 @@ jobs:
           sudo rm -rf /usr/share/swift
           sudo apt-get clean
           docker system prune -af || true
+          echo "Disk space after cleanup:" && df -h /
 
       - name: Setup Miniconda
         uses: conda-incubator/setup-miniconda@835234971496cad1653abb28a638a281cf32541f # v3.2.0


### PR DESCRIPTION
To resolve disk space issue encountered on llvmdev build - https://github.com/numba/llvmlite/actions/runs/19659854543/job/57700218071/
and blocking PRs - https://github.com/numba/llvmlite/pull/1372 and https://github.com/numba/llvmlite/pull/1369
This PR adds step to cleanup disk space on linux runners before llvmdev build to avoid running out of disk space. 