### PR TITLE
enable py-lief test dependency for py314 on llvmlite recipe

### DIFF
--- a/conda-recipes/llvmlite/meta.yaml
+++ b/conda-recipes/llvmlite/meta.yaml
@@ -41,7 +41,7 @@ requirements:
 
 test:
   requires:
-    - py-lief # [py<314]
+    - py-lief
   imports:
     - llvmlite
     - llvmlite.binding


### PR DESCRIPTION
closes https://github.com/numba/llvmlite/issues/1281