### PR TITLE
upgrade llvmdev to 22.1.0

### DIFF
--- a/conda-recipes/llvmdev/meta.yaml
+++ b/conda-recipes/llvmdev/meta.yaml
@@ -1,6 +1,6 @@
-{% set shortversion = "20.1" %}
-{% set version = "20.1.8" %}
-{% set sha256_llvm = "6898f963c8e938981e6c4a302e83ec5beb4630147c7311183cf61069af16333d" %}
+{% set shortversion = "22.1" %}
+{% set version = "22.1.0" %}
+{% set sha256_llvm = "25d2e2adc4356d758405dd885fcfd6447bce82a90eb78b6b87ce0934bd077173" %}
 {% set build_number = "0" %}
 
 package:

--- a/conda-recipes/llvmdev_for_wheel/meta.yaml
+++ b/conda-recipes/llvmdev_for_wheel/meta.yaml
@@ -1,7 +1,7 @@
 # This file is a copy of ../llvmdev/meta.yaml with minor changes for wheel # building
-{% set shortversion = "20.1" %}
-{% set version = "20.1.8" %}
-{% set sha256_llvm = "6898f963c8e938981e6c4a302e83ec5beb4630147c7311183cf61069af16333d" %}
+{% set shortversion = "22.1" %}
+{% set version = "22.1.0" %}
+{% set sha256_llvm = "25d2e2adc4356d758405dd885fcfd6447bce82a90eb78b6b87ce0934bd077173" %}
 {% set build_number = "1" %}
 
 package:

--- a/conda-recipes/llvmdev_for_wheel/meta.yaml
+++ b/conda-recipes/llvmdev_for_wheel/meta.yaml
@@ -2,7 +2,7 @@
 {% set shortversion = "22.1" %}
 {% set version = "22.1.0" %}
 {% set sha256_llvm = "25d2e2adc4356d758405dd885fcfd6447bce82a90eb78b6b87ce0934bd077173" %}
-{% set build_number = "1" %}
+{% set build_number = "0" %}
 
 package:
   name: llvmdev


### PR DESCRIPTION
This PR updates llvmdev recipe, upgrades llvm version from `20.1.8` to `22.1.0`