### PR TITLE
refactor: conda build command on GHA workflows

### DIFF
--- a/.github/workflows/llvmdev_build.yml
+++ b/.github/workflows/llvmdev_build.yml
@@ -151,7 +151,7 @@ jobs:
         run: |
           set -x
           mkdir -p "${CONDA_CHANNEL_DIR}"
-          conda build -c defaults "./conda-recipes/${{ matrix.recipe }}" "--output-folder=${CONDA_CHANNEL_DIR}"
+          conda-build -c defaults "./conda-recipes/${{ matrix.recipe }}" "--output-folder=${CONDA_CHANNEL_DIR}"
           ls -lah "${CONDA_CHANNEL_DIR}"
 
       - name: Upload conda package

--- a/.github/workflows/llvmlite_conda_builder.yml
+++ b/.github/workflows/llvmlite_conda_builder.yml
@@ -120,8 +120,7 @@ jobs:
           else
             extra_args=()
           fi
-          conda-build --debug -c "${LLVMDEV_CHANNEL}" "${extra_args[@]}" -c defaults --python=${{ matrix.python-version }} conda-recipes/llvmlite --output-folder="${CONDA_CHANNEL_DIR}" --no-test
-
+          conda-build --debug --channel-priority strict -c "${LLVMDEV_CHANNEL}" "${extra_args[@]}" -c defaults --python=${{ matrix.python-version }} conda-recipes/llvmlite --output-folder="${CONDA_CHANNEL_DIR}" --no-test
       - name: Upload llvmlite conda package
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:

--- a/.github/workflows/llvmlite_conda_builder.yml
+++ b/.github/workflows/llvmlite_conda_builder.yml
@@ -120,7 +120,7 @@ jobs:
           else
             extra_args=()
           fi
-          conda build --debug -c "${LLVMDEV_CHANNEL}" "${extra_args[@]}" -c defaults --python=${{ matrix.python-version }} conda-recipes/llvmlite --output-folder="${CONDA_CHANNEL_DIR}" --no-test
+          conda-build --debug -c "${LLVMDEV_CHANNEL}" "${extra_args[@]}" -c defaults --python=${{ matrix.python-version }} conda-recipes/llvmlite --output-folder="${CONDA_CHANNEL_DIR}" --no-test
 
       - name: Upload llvmlite conda package
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
@@ -166,4 +166,4 @@ jobs:
           else
             extra_args=()
           fi
-          conda build --test "${extra_args[@]}" "${{ matrix.platform }}"/llvmlite*.conda
+          conda-build --test "${extra_args[@]}" "${{ matrix.platform }}"/llvmlite*.conda

--- a/.github/workflows/llvmlite_conda_builder.yml
+++ b/.github/workflows/llvmlite_conda_builder.yml
@@ -120,7 +120,8 @@ jobs:
           else
             extra_args=()
           fi
-          conda-build --debug --channel-priority strict -c "${LLVMDEV_CHANNEL}" "${extra_args[@]}" -c defaults --python=${{ matrix.python-version }} conda-recipes/llvmlite --output-folder="${CONDA_CHANNEL_DIR}" --no-test
+          conda config --set channel_priority strict
+          conda-build --debug -c "${LLVMDEV_CHANNEL}" "${extra_args[@]}" -c defaults --python=${{ matrix.python-version }} conda-recipes/llvmlite --output-folder="${CONDA_CHANNEL_DIR}" --no-test
       - name: Upload llvmlite conda package
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:

--- a/.github/workflows/llvmlite_conda_builder.yml
+++ b/.github/workflows/llvmlite_conda_builder.yml
@@ -166,4 +166,4 @@ jobs:
           else
             extra_args=()
           fi
-          conda-build --test "${extra_args[@]}" "${{ matrix.platform }}"/llvmlite*.conda
+          conda-build --test "${extra_args[@]}" -c defaults "${{ matrix.platform }}"/llvmlite*.conda


### PR DESCRIPTION
conda 26.3.1 removed use of conda executable (`conda-build`) with subcommands (`conda build`) -

> Conda no longer discovers subcommands by scanning conda-* executables on PATH when building the CLI (prefer the plugin system).

https://conda.org/blog/2026-04-06-march-releases/#changes-in-conda-26302631

This PR corrects the usage on conda builder GHA workflows to use executable directly `conda-build`.