### PR TITLE
CI: add gha workflow to build llvmdev on win-arm64

### DIFF
--- a/.github/workflows/llvmdev_build_win-arm64.yml
+++ b/.github/workflows/llvmdev_build_win-arm64.yml
@@ -52,7 +52,7 @@ jobs:
           persist-credentials: false
 
       - name: Set up conda-standalone
-        uses: conda-incubator/setup-conda-standalone@18545a35fdf222190f61c631201efdf86dd05982 # main
+        uses: conda-incubator/setup-conda-standalone@00a34805e93a8b640aee5f8a20e8f481ad77e3b4 # v0.1.0
         with:
           channel: ${{ env.WIN_ARM64_CONDA_CHANNEL }}
           destination-directory: ${{ runner.temp }}/conda-standalone

--- a/.github/workflows/llvmdev_build_win-arm64.yml
+++ b/.github/workflows/llvmdev_build_win-arm64.yml
@@ -1,0 +1,91 @@
+name: llvmdev-win-arm64
+
+on:
+  pull_request:
+    paths:
+      - .github/workflows/llvmdev_build_win-arm64.yml
+      - conda-recipes/llvmdev/**
+      - conda-recipes/llvmdev_for_wheel/**
+  label:
+    types: [created]
+  workflow_dispatch:
+
+concurrency:
+  # Concurrency group that uses the workflow name and PR number if available
+  # or commit SHA as a fallback. If a new build is triggered under that
+  # concurrency group while a previous build is running it will be canceled.
+  # Repeated pushes to a PR will cancel all previous builds, while multiple
+  # merges to master will not cancel.
+  group: >-
+    ${{ github.workflow }}-
+    ${{ github.event.pull_request.number
+      || toJson(github.event.inputs)
+      || github.event.label.name
+      || github.sha }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+env:
+  ARTIFACT_RETENTION_DAYS: 7
+  # win-arm64 has no Miniconda installer, so the base environment is
+  # bootstrapped from conda-standalone using the win-arm64 native channel.
+  WIN_ARM64_CONDA_CHANNEL: bootstrap-win-arm64-round-2-native
+
+jobs:
+
+  build:
+    name: ${{ matrix.recipe }}-win-arm64
+    runs-on: windows-11-arm
+    defaults:
+      run:
+        shell: bash -el {0}
+    strategy:
+      fail-fast: false
+      matrix:
+        recipe: [llvmdev, llvmdev_for_wheel]
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Set up conda-standalone
+        uses: conda-incubator/setup-conda-standalone@18545a35fdf222190f61c631201efdf86dd05982 # main
+        with:
+          channel: ${{ env.WIN_ARM64_CONDA_CHANNEL }}
+          destination-directory: ${{ runner.temp }}/conda-standalone
+
+      - name: Install conda-build
+        run: |
+          export CONDA_PREFIX="${RUNNER_TEMP}/conda-base"
+          "${CONDA_EXE}" create --prefix "${CONDA_PREFIX}" \
+            -c "${WIN_ARM64_CONDA_CHANNEL}" --yes conda-build
+          echo "CONDA_PREFIX=${CONDA_PREFIX}" >> "${GITHUB_ENV}"
+          echo "${CONDA_PREFIX}" >> "${GITHUB_PATH}"
+          echo "${CONDA_PREFIX}/Scripts" >> "${GITHUB_PATH}"
+          echo "${CONDA_PREFIX}/Library/bin" >> "${GITHUB_PATH}"
+
+      - name: Build and test conda package - non-linux platforms
+        env:
+          CONDA_CHANNEL_DIR: conda_channel_dir
+        run: |
+          mkdir -p "${CONDA_CHANNEL_DIR}"
+          conda-build -c "${WIN_ARM64_CONDA_CHANNEL}" -c m2-winarm64 -c main \
+            "./conda-recipes/${{ matrix.recipe }}" "--output-folder=${CONDA_CHANNEL_DIR}"
+          ls -lah "${CONDA_CHANNEL_DIR}"
+
+      - name: Upload conda package
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: ${{ matrix.recipe }}_win-arm64
+          path: conda_channel_dir
+          compression-level: 0
+          retention-days: ${{ env.ARTIFACT_RETENTION_DAYS }}
+          if-no-files-found: error
+
+      - name: Get Workflow Run ID
+        run: |
+          echo "Current workflow run ID: ${{ github.run_id }}"
+          echo "Use this ID when triggering llvmlite workflow"

--- a/conda-recipes/llvmdev/bld.bat
+++ b/conda-recipes/llvmdev/bld.bat
@@ -31,6 +31,8 @@ set "CC=cl.exe"
 set "CXX=cl.exe"
 
 if "%ARCH%"=="arm64" (
+    REM compiler-rt excluded for win-arm64 (as of 2026-06-03):
+    REM Build fails in aarch64/fp_mode.c and cpu_model/aarch64.c with MSVC
     set "LLVM_ENABLE_PROJECTS=lld"
 ) else (
     set "LLVM_ENABLE_PROJECTS=lld;compiler-rt"

--- a/conda-recipes/llvmdev/bld.bat
+++ b/conda-recipes/llvmdev/bld.bat
@@ -11,7 +11,16 @@ if not exist "%VSINSTALLDIR%" (
 )
 
 echo "Found VS 2022 in %VSINSTALLDIR%"
-call "%VSINSTALLDIR%VC\\Auxiliary\\Build\\vcvarsall.bat" x64
+
+REM ARCH is set by conda-build (e.g., "64" for x64, "arm64" for ARM64)
+if "%ARCH%"=="arm64" (
+    set "VCVARS_ARCH=arm64"
+) else (
+    set "VCVARS_ARCH=x64"
+)
+
+echo "Building for architecture: %VCVARS_ARCH%"
+call "%VSINSTALLDIR%VC\\Auxiliary\\Build\\vcvarsall.bat" %VCVARS_ARCH%
 
 mkdir build
 cd build
@@ -20,6 +29,12 @@ REM remove GL flag for now
 set "CXXFLAGS=-MD"
 set "CC=cl.exe"
 set "CXX=cl.exe"
+
+if "%ARCH%"=="arm64" (
+    set "LLVM_ENABLE_PROJECTS=lld"
+) else (
+    set "LLVM_ENABLE_PROJECTS=lld;compiler-rt"
+)
 
 cmake -G "Ninja" ^
     -DCMAKE_BUILD_TYPE="Release" ^
@@ -40,7 +55,7 @@ cmake -G "Ninja" ^
     -DLLVM_BUILD_LLVM_C_DYLIB=no ^
     -DLLVM_EXPERIMENTAL_TARGETS_TO_BUILD=WebAssembly ^
     -DCMAKE_POLICY_DEFAULT_CMP0111=NEW ^
-    -DLLVM_ENABLE_PROJECTS:STRING=lld;compiler-rt ^
+    -DLLVM_ENABLE_PROJECTS:STRING=%LLVM_ENABLE_PROJECTS% ^
     -DLLVM_ENABLE_ASSERTIONS=ON ^
     -DLLVM_ENABLE_DIA_SDK=OFF ^
     -DCOMPILER_RT_BUILD_BUILTINS=ON ^

--- a/conda-recipes/llvmdev_for_wheel/bld.bat
+++ b/conda-recipes/llvmdev_for_wheel/bld.bat
@@ -31,6 +31,8 @@ set "CC=cl.exe"
 set "CXX=cl.exe"
 
 if "%ARCH%"=="arm64" (
+    REM compiler-rt excluded for win-arm64 (as of 2026-06-03):
+    REM Build fails in aarch64/fp_mode.c and cpu_model/aarch64.c with MSVC
     set "LLVM_ENABLE_PROJECTS=lld"
 ) else (
     set "LLVM_ENABLE_PROJECTS=lld;compiler-rt"

--- a/conda-recipes/llvmdev_for_wheel/bld.bat
+++ b/conda-recipes/llvmdev_for_wheel/bld.bat
@@ -11,7 +11,16 @@ if not exist "%VSINSTALLDIR%" (
 )
 
 echo "Found VS 2022 in %VSINSTALLDIR%"
-call "%VSINSTALLDIR%VC\\Auxiliary\\Build\\vcvarsall.bat" x64
+
+REM ARCH is set by conda-build (e.g., "64" for x64, "arm64" for ARM64)
+if "%ARCH%"=="arm64" (
+    set "VCVARS_ARCH=arm64"
+) else (
+    set "VCVARS_ARCH=x64"
+)
+
+echo "Building for architecture: %VCVARS_ARCH%"
+call "%VSINSTALLDIR%VC\\Auxiliary\\Build\\vcvarsall.bat" %VCVARS_ARCH%
 
 mkdir build
 cd build
@@ -20,6 +29,12 @@ REM remove GL flag for now
 set "CXXFLAGS=-MD"
 set "CC=cl.exe"
 set "CXX=cl.exe"
+
+if "%ARCH%"=="arm64" (
+    set "LLVM_ENABLE_PROJECTS=lld"
+) else (
+    set "LLVM_ENABLE_PROJECTS=lld;compiler-rt"
+)
 
 cmake -G "Ninja" ^
     -DCMAKE_BUILD_TYPE="Release" ^
@@ -40,7 +55,7 @@ cmake -G "Ninja" ^
     -DLLVM_BUILD_LLVM_C_DYLIB=no ^
     -DLLVM_EXPERIMENTAL_TARGETS_TO_BUILD=WebAssembly ^
     -DCMAKE_POLICY_DEFAULT_CMP0111=NEW ^
-    -DLLVM_ENABLE_PROJECTS:STRING=lld;compiler-rt ^
+    -DLLVM_ENABLE_PROJECTS:STRING=%LLVM_ENABLE_PROJECTS% ^
     -DLLVM_ENABLE_ASSERTIONS=ON ^
     -DLLVM_ENABLE_DIA_SDK=OFF ^
     -DCOMPILER_RT_BUILD_BUILTINS=ON ^


### PR DESCRIPTION
As initial step to adding `win-arm64` support to Numba and llvmlite (https://github.com/numba/numba/issues/10549), this PR adds GHA workflow that builds llvmdev recipes with `win-arm64`.

The workflow has been kept separate than the [llvmdev build](https://github.com/numba/llvmlite/blob/main/.github/workflows/llvmdev_build.yml) workflow because there is no Miniconda support available for win-arm64, which the existing workflow relies on for its build environment.