### PR TITLE
CI: fix llvmdev recipe and workflow for `win-arm64`

### DIFF
--- a/.github/workflows/llvmdev_build_win-arm64.yml
+++ b/.github/workflows/llvmdev_build_win-arm64.yml
@@ -55,13 +55,14 @@ jobs:
         uses: conda-incubator/setup-conda-standalone@00a34805e93a8b640aee5f8a20e8f481ad77e3b4 # v0.1.0
         with:
           channel: ${{ env.WIN_ARM64_CONDA_CHANNEL }}
+          conda-standalone-version: 26.3.2.post1
           destination-directory: ${{ runner.temp }}/conda-standalone
 
       - name: Install conda-build
         run: |
           export CONDA_PREFIX="${RUNNER_TEMP}/conda-base"
           "${CONDA_EXE}" create --prefix "${CONDA_PREFIX}" \
-            -c "${WIN_ARM64_CONDA_CHANNEL}" --yes conda-build
+            -c "${WIN_ARM64_CONDA_CHANNEL}" -c m2-winarm64 -c main --yes conda-build
           echo "CONDA_PREFIX=${CONDA_PREFIX}" >> "${GITHUB_ENV}"
           echo "${CONDA_PREFIX}" >> "${GITHUB_PATH}"
           echo "${CONDA_PREFIX}/Scripts" >> "${GITHUB_PATH}"

--- a/conda-recipes/llvmdev/conda_build_config.yaml
+++ b/conda-recipes/llvmdev/conda_build_config.yaml
@@ -14,3 +14,7 @@ c_compiler:              # [win]
   - vs2022               # [win]
 cxx_compiler:            # [win]
   - vs2022               # [win]
+
+target_platform:
+  - win-64               # [win and not arm64]
+  - win-arm64            # [win and arm64]


### PR DESCRIPTION
This PR includes fixes to llvmdev recipe and workflow for `win-arm64` support. 

Changes:
- `conda-standalone-version: 26.3.2.post1` this pins the `conda-standalone-version` with fix for setting correct `win-arm64` target_platform on environment.
- adds additional channels required to get dependencies to install condo-build on `win-arm64`
- adds `target_platform` spec on conda-build-config.yaml following recommended practice which helps conda pick correct platform arch on conda-build

Fixes failures observed on `win-arm64` workflow on `main`-
https://github.com/numba/llvmlite/actions/runs/27311696034

