### PR TITLE
Add `win-arm64` support for llvmlite

### DIFF
--- a/.github/workflows/llvmlite_win-arm64_conda_builder.yml
+++ b/.github/workflows/llvmlite_win-arm64_conda_builder.yml
@@ -10,11 +10,10 @@ on:
       - versioneer.py
   workflow_dispatch:
     inputs:
-      upload_conda_to_anaconda:
-        description: 'Upload conda package to Anaconda Cloud (swap357 channel)'
+      llvmdev_run_id:
+        description: 'llvmdev workflow run ID (optional)'
         required: false
-        type: boolean
-        default: false
+        type: string
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
@@ -67,12 +66,13 @@ jobs:
           echo "${CONDA_PREFIX}/Library/bin" >> "${GITHUB_PATH}"
 
       - name: Download llvmdev artifact
-        if: env.LLVMDEV_RUN_ID != ''
+        if: ${{ inputs.llvmdev_run_id != '' }}
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: llvmdev_win-arm64
           path: llvmdev_channel
-          run-id: ${{ env.LLVMDEV_RUN_ID }}
+          run-id: ${{ inputs.llvmdev_run_id }}
+          repository: ${{ github.repository }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build llvmlite conda package
@@ -150,46 +150,3 @@ jobs:
           conda-build --test \
             -c "${LLVMDEV_CHANNEL}" -c "${WIN_ARM64_CONDA_CHANNEL}" -c m2-winarm64 -c main \
             conda_channel_dir/win-arm64/llvmlite-*.conda
-
-  win-arm64-upload:
-    name: win-arm64-upload-py${{ matrix.python-version }}
-    needs: win-arm64-test
-    if: github.event_name == 'workflow_dispatch' && inputs.upload_conda_to_anaconda
-    runs-on: windows-11-arm
-    defaults:
-      run:
-        shell: bash -elx {0}
-    strategy:
-      fail-fast: false
-      matrix:
-        python-version: ["3.14"]
-
-    steps:
-      - name: Set up conda-standalone
-        uses: conda-incubator/setup-conda-standalone@00a34805e93a8b640aee5f8a20e8f481ad77e3b4 # v0.1.0
-        with:
-          channel: ${{ env.WIN_ARM64_CONDA_CHANNEL }}
-          conda-standalone-version: 26.3.2.post1
-          destination-directory: ${{ runner.temp }}/conda-standalone
-
-      - name: Install anaconda-client
-        run: |
-          export CONDA_PREFIX="${RUNNER_TEMP}/conda-upload-env"
-          "${CONDA_EXE}" create --prefix "${CONDA_PREFIX}" --yes \
-            -c "${WIN_ARM64_CONDA_CHANNEL}" -c main anaconda-client
-          echo "${CONDA_PREFIX}" >> "${GITHUB_PATH}"
-          echo "${CONDA_PREFIX}/Scripts" >> "${GITHUB_PATH}"
-
-      - name: Download llvmlite conda package
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-        with:
-          name: llvmlite-win-arm64-conda-py${{ matrix.python-version }}
-          path: conda_channel_dir
-
-      - name: Upload conda package to Anaconda Cloud
-        env:
-          ANACONDA_API_TOKEN: ${{ secrets.ANACONDA_API_TOKEN }}
-        run: |
-          pkg=$(ls -1 conda_channel_dir/win-arm64/llvmlite-*.conda)
-          echo "Uploading conda package: $pkg"
-          anaconda -t "$ANACONDA_API_TOKEN" upload --force -u swap357 "$pkg"

--- a/.github/workflows/llvmlite_win-arm64_conda_builder.yml
+++ b/.github/workflows/llvmlite_win-arm64_conda_builder.yml
@@ -1,0 +1,195 @@
+name: llvmlite_win-arm64_conda_builder
+
+on:
+  pull_request:
+    paths:
+      - .github/workflows/llvmlite_win-arm64_conda_builder.yml
+      - conda-recipes/llvmlite/**
+      - ffi/**
+      - setup.py
+      - versioneer.py
+  workflow_dispatch:
+    inputs:
+      upload_conda_to_anaconda:
+        description: 'Upload conda package to Anaconda Cloud (swap357 channel)'
+        required: false
+        type: boolean
+        default: false
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+env:
+  ARTIFACT_RETENTION_DAYS: 7
+  LLVMDEV_CHANNEL: numba/label/llvm
+  # win-arm64 has no Miniconda installer, so the base environment is
+  # bootstrapped from conda-standalone using the win-arm64 native channel.
+  WIN_ARM64_CONDA_CHANNEL: bootstrap-win-arm64-round-2-native
+
+jobs:
+  win-arm64-build:
+    name: win-arm64-build-py${{ matrix.python-version }}
+    runs-on: windows-11-arm
+    defaults:
+      run:
+        shell: bash -elx {0}
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.14"]
+
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Set up conda-standalone
+        uses: conda-incubator/setup-conda-standalone@00a34805e93a8b640aee5f8a20e8f481ad77e3b4 # v0.1.0
+        with:
+          channel: ${{ env.WIN_ARM64_CONDA_CHANNEL }}
+          conda-standalone-version: 26.3.2.post1
+          destination-directory: ${{ runner.temp }}/conda-standalone
+
+      - name: Install conda-build
+        run: |
+          export CONDA_PREFIX="${RUNNER_TEMP}/conda-base"
+          "${CONDA_EXE}" create --prefix "${CONDA_PREFIX}" \
+            -c "${WIN_ARM64_CONDA_CHANNEL}" -c m2-winarm64 -c main --yes conda-build
+          echo "CONDA_PREFIX=${CONDA_PREFIX}" >> "${GITHUB_ENV}"
+          echo "${CONDA_PREFIX}" >> "${GITHUB_PATH}"
+          echo "${CONDA_PREFIX}/Scripts" >> "${GITHUB_PATH}"
+          echo "${CONDA_PREFIX}/Library/bin" >> "${GITHUB_PATH}"
+
+      - name: Download llvmdev artifact
+        if: env.LLVMDEV_RUN_ID != ''
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: llvmdev_win-arm64
+          path: llvmdev_channel
+          run-id: ${{ env.LLVMDEV_RUN_ID }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build llvmlite conda package
+        env:
+          CONDA_CHANNEL_DIR: conda_channel_dir
+          PY_MATRIX: ${{ matrix.python-version }}
+        run: |
+          mkdir -p "${CONDA_CHANNEL_DIR}"
+          conda config --set channel_priority strict
+          if [ -d llvmdev_channel/win-arm64 ]; then
+            LLVMDEV_SRC="-c ${GITHUB_WORKSPACE}/llvmdev_channel"
+          else
+            LLVMDEV_SRC="-c ${LLVMDEV_CHANNEL}"
+          fi
+          # bld.bat selects the ARM64 CMake generator when ARCH==arm64.
+          conda-build --no-test \
+            ${LLVMDEV_SRC} -c "${WIN_ARM64_CONDA_CHANNEL}" -c m2-winarm64 -c main \
+            --python="${PY_MATRIX}" \
+            ./conda-recipes/llvmlite "--output-folder=${CONDA_CHANNEL_DIR}"
+          ls -lah "${CONDA_CHANNEL_DIR}"
+
+      - name: Upload llvmlite conda package
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: llvmlite-win-arm64-conda-py${{ matrix.python-version }}
+          path: conda_channel_dir
+          compression-level: 0
+          retention-days: ${{ env.ARTIFACT_RETENTION_DAYS }}
+          if-no-files-found: error
+
+      - name: Show Workflow Run ID
+        env:
+          RUN_ID: ${{ github.run_id }}
+        run: |
+          echo "Workflow Run ID: ${RUN_ID}"
+
+  win-arm64-test:
+    name: win-arm64-test-py${{ matrix.python-version }}
+    needs: win-arm64-build
+    runs-on: windows-11-arm
+    defaults:
+      run:
+        shell: bash -elx {0}
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.14"]
+
+    steps:
+      - name: Set up conda-standalone
+        uses: conda-incubator/setup-conda-standalone@00a34805e93a8b640aee5f8a20e8f481ad77e3b4 # v0.1.0
+        with:
+          channel: ${{ env.WIN_ARM64_CONDA_CHANNEL }}
+          conda-standalone-version: 26.3.2.post1
+          destination-directory: ${{ runner.temp }}/conda-standalone
+
+      - name: Install conda-build
+        run: |
+          export CONDA_PREFIX="${RUNNER_TEMP}/conda-base"
+          "${CONDA_EXE}" create --prefix "${CONDA_PREFIX}" \
+            -c "${WIN_ARM64_CONDA_CHANNEL}" -c m2-winarm64 -c main --yes conda-build
+          echo "CONDA_PREFIX=${CONDA_PREFIX}" >> "${GITHUB_ENV}"
+          echo "${CONDA_PREFIX}" >> "${GITHUB_PATH}"
+          echo "${CONDA_PREFIX}/Scripts" >> "${GITHUB_PATH}"
+          echo "${CONDA_PREFIX}/Library/bin" >> "${GITHUB_PATH}"
+
+      - name: Download llvmlite conda package
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: llvmlite-win-arm64-conda-py${{ matrix.python-version }}
+          path: conda_channel_dir
+
+      - name: Test llvmlite conda package
+        run: |
+          conda-build --test \
+            -c "${LLVMDEV_CHANNEL}" -c "${WIN_ARM64_CONDA_CHANNEL}" -c m2-winarm64 -c main \
+            conda_channel_dir/win-arm64/llvmlite-*.conda
+
+  win-arm64-upload:
+    name: win-arm64-upload-py${{ matrix.python-version }}
+    needs: win-arm64-test
+    if: github.event_name == 'workflow_dispatch' && inputs.upload_conda_to_anaconda
+    runs-on: windows-11-arm
+    defaults:
+      run:
+        shell: bash -elx {0}
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.14"]
+
+    steps:
+      - name: Set up conda-standalone
+        uses: conda-incubator/setup-conda-standalone@00a34805e93a8b640aee5f8a20e8f481ad77e3b4 # v0.1.0
+        with:
+          channel: ${{ env.WIN_ARM64_CONDA_CHANNEL }}
+          conda-standalone-version: 26.3.2.post1
+          destination-directory: ${{ runner.temp }}/conda-standalone
+
+      - name: Install anaconda-client
+        run: |
+          export CONDA_PREFIX="${RUNNER_TEMP}/conda-upload-env"
+          "${CONDA_EXE}" create --prefix "${CONDA_PREFIX}" --yes \
+            -c "${WIN_ARM64_CONDA_CHANNEL}" -c main anaconda-client
+          echo "${CONDA_PREFIX}" >> "${GITHUB_PATH}"
+          echo "${CONDA_PREFIX}/Scripts" >> "${GITHUB_PATH}"
+
+      - name: Download llvmlite conda package
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: llvmlite-win-arm64-conda-py${{ matrix.python-version }}
+          path: conda_channel_dir
+
+      - name: Upload conda package to Anaconda Cloud
+        env:
+          ANACONDA_API_TOKEN: ${{ secrets.ANACONDA_API_TOKEN }}
+        run: |
+          pkg=$(ls -1 conda_channel_dir/win-arm64/llvmlite-*.conda)
+          echo "Uploading conda package: $pkg"
+          anaconda -t "$ANACONDA_API_TOKEN" upload --force -u swap357 "$pkg"

--- a/.github/workflows/llvmlite_win-arm64_wheel_builder.yml
+++ b/.github/workflows/llvmlite_win-arm64_wheel_builder.yml
@@ -1,0 +1,229 @@
+name: llvmlite_win-arm64_wheel_builder
+
+on:
+  push:
+    branches:
+      - exp/win-arm64
+  pull_request:
+    paths:
+      - .github/workflows/llvmlite_win-arm64_wheel_builder.yml
+      - ffi/**
+      - setup.py
+      - versioneer.py
+  workflow_dispatch:
+    inputs:
+      upload_wheel_to_anaconda:
+        description: 'Upload wheel to Anaconda Cloud (swap357 channel)'
+        required: false
+        type: boolean
+        default: false
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+env:
+  FALLBACK_LLVMDEV_VERSION: "22"
+  ARTIFACT_RETENTION_DAYS: 7
+  LLVMDEV_CHANNEL: numba/label/llvm
+  # win-arm64 has no Miniconda installer, so the base environment is
+  # bootstrapped from conda-standalone using the win-arm64 native channel.
+  WIN_ARM64_CONDA_CHANNEL: bootstrap-win-arm64-round-2-native
+
+jobs:
+  win-arm64-build:
+    name: win-arm64-build-py${{ matrix.python-version }}
+    runs-on: windows-11-arm
+    defaults:
+      run:
+        shell: bash -elx {0}
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.14"]
+
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Set up conda-standalone
+        uses: conda-incubator/setup-conda-standalone@00a34805e93a8b640aee5f8a20e8f481ad77e3b4 # v0.1.0
+        with:
+          channel: ${{ env.WIN_ARM64_CONDA_CHANNEL }}
+          conda-standalone-version: 26.3.2.post1
+          destination-directory: ${{ runner.temp }}/conda-standalone
+
+      - name: Download llvmdev artifact
+        if: env.LLVMDEV_RUN_ID != ''
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: llvmdev_for_wheel_win-arm64
+          path: llvmdev_channel
+          run-id: ${{ env.LLVMDEV_RUN_ID }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Create build environment
+        env:
+          PY_MATRIX: ${{ matrix.python-version }}
+        run: |
+          PY_VER="${PY_MATRIX}"
+          export CONDA_PREFIX="${RUNNER_TEMP}/conda-build-env"
+          # Free-threaded builds ship as python-freethreading on conda-forge.
+          if [[ "${PY_VER}" == *t ]]; then
+            PY_SPEC="python-freethreading=${PY_VER%t}"
+            EXTRA_CHANNEL="-c conda-forge"
+          else
+            PY_SPEC="python=${PY_VER}"
+            EXTRA_CHANNEL=""
+          fi
+          if [ -d llvmdev_channel/win-arm64 ]; then
+            LLVMDEV_SRC="-c ${GITHUB_WORKSPACE}/llvmdev_channel"
+          else
+            LLVMDEV_SRC="-c ${LLVMDEV_CHANNEL}"
+          fi
+          "${CONDA_EXE}" create --prefix "${CONDA_PREFIX}" --yes \
+            ${LLVMDEV_SRC} -c "${WIN_ARM64_CONDA_CHANNEL}" ${EXTRA_CHANNEL} \
+            -c m2-winarm64 -c main \
+            "${PY_SPEC}" "llvmdev=${FALLBACK_LLVMDEV_VERSION}" cmake libxml2 setuptools pip
+          echo "${CONDA_PREFIX}" >> "${GITHUB_PATH}"
+          echo "${CONDA_PREFIX}/Scripts" >> "${GITHUB_PATH}"
+          echo "${CONDA_PREFIX}/Library/bin" >> "${GITHUB_PATH}"
+          # Let CMake find the LLVM install shipped by llvmdev.
+          echo "CMAKE_PREFIX_PATH=${CONDA_PREFIX}/Library" >> "${GITHUB_ENV}"
+
+      - name: Build wheel
+        env:
+          LLVMLITE_PACKAGE_FORMAT: "wheel"
+        run: |
+          # ffi/build.py auto-detects ARM64 (platform.machine()) and selects the
+          # ARM64 CMake generator; no CMAKE_GENERATOR_ARCH override needed.
+          python -m pip install build wheel delvewheel
+          python -m build --wheel --no-isolation
+
+      - name: Repair wheel with delvewheel
+        run: |
+          mkdir -p wheel_temp
+          mv dist/*.whl wheel_temp/
+          python -m delvewheel repair --analyze-existing -w dist wheel_temp/*.whl
+          ls -l dist
+
+      - name: Upload llvmlite wheel
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: llvmlite-win-arm64-py${{ matrix.python-version }}
+          path: dist/*.whl
+          compression-level: 0
+          retention-days: ${{ env.ARTIFACT_RETENTION_DAYS }}
+          if-no-files-found: error
+
+      - name: Show Workflow Run ID
+        env:
+          RUN_ID: ${{ github.run_id }}
+        run: |
+          echo "Workflow Run ID: ${RUN_ID}"
+
+  win-arm64-test:
+    name: win-arm64-test-py${{ matrix.python-version }}
+    needs: win-arm64-build
+    runs-on: windows-11-arm
+    defaults:
+      run:
+        shell: bash -elx {0}
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.14"]
+
+    steps:
+      - name: Set up conda-standalone
+        uses: conda-incubator/setup-conda-standalone@00a34805e93a8b640aee5f8a20e8f481ad77e3b4 # v0.1.0
+        with:
+          channel: ${{ env.WIN_ARM64_CONDA_CHANNEL }}
+          conda-standalone-version: 26.3.2.post1
+          destination-directory: ${{ runner.temp }}/conda-standalone
+
+      - name: Create test environment
+        env:
+          PY_MATRIX: ${{ matrix.python-version }}
+        run: |
+          PY_VER="${PY_MATRIX}"
+          export CONDA_PREFIX="${RUNNER_TEMP}/conda-test-env"
+          if [[ "${PY_VER}" == *t ]]; then
+            PY_SPEC="python-freethreading=${PY_VER%t}"
+            EXTRA_CHANNEL="-c conda-forge"
+          else
+            PY_SPEC="python=${PY_VER}"
+            EXTRA_CHANNEL=""
+          fi
+          "${CONDA_EXE}" create --prefix "${CONDA_PREFIX}" --yes \
+            -c "${WIN_ARM64_CONDA_CHANNEL}" ${EXTRA_CHANNEL} -c main \
+            "${PY_SPEC}" pip
+          echo "${CONDA_PREFIX}" >> "${GITHUB_PATH}"
+          echo "${CONDA_PREFIX}/Scripts" >> "${GITHUB_PATH}"
+
+      - name: Download llvmlite wheel
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: llvmlite-win-arm64-py${{ matrix.python-version }}
+          path: dist
+
+      - name: Install and test
+        env:
+          LLVMLITE_DIST_TEST: "1"
+        run: |
+          python -m pip install --upgrade pip
+          cd dist
+          whl=$(ls -1 ./*.whl)
+          echo "Using wheel: $whl"
+          python -m pip install "$whl"
+          python -m llvmlite.tests
+
+  win-arm64-upload:
+    name: win-arm64-upload-py${{ matrix.python-version }}
+    needs: win-arm64-test
+    if: github.event_name == 'workflow_dispatch' && inputs.upload_wheel_to_anaconda
+    runs-on: windows-11-arm
+    defaults:
+      run:
+        shell: bash -elx {0}
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.14"]
+
+    steps:
+      - name: Set up conda-standalone
+        uses: conda-incubator/setup-conda-standalone@00a34805e93a8b640aee5f8a20e8f481ad77e3b4 # v0.1.0
+        with:
+          channel: ${{ env.WIN_ARM64_CONDA_CHANNEL }}
+          conda-standalone-version: 26.3.2.post1
+          destination-directory: ${{ runner.temp }}/conda-standalone
+
+      - name: Install anaconda-client
+        run: |
+          export CONDA_PREFIX="${RUNNER_TEMP}/conda-upload-env"
+          "${CONDA_EXE}" create --prefix "${CONDA_PREFIX}" --yes \
+            -c "${WIN_ARM64_CONDA_CHANNEL}" -c main anaconda-client
+          echo "${CONDA_PREFIX}" >> "${GITHUB_PATH}"
+          echo "${CONDA_PREFIX}/Scripts" >> "${GITHUB_PATH}"
+
+      - name: Download llvmlite wheel
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: llvmlite-win-arm64-py${{ matrix.python-version }}
+          path: dist
+
+      - name: Upload wheel to Anaconda Cloud
+        env:
+          ANACONDA_API_TOKEN: ${{ secrets.ANACONDA_API_TOKEN }}
+        run: |
+          cd dist
+          whl=$(ls -1 ./*.whl)
+          echo "Uploading wheel: $whl"
+          anaconda -t "$ANACONDA_API_TOKEN" upload --force -u swap357 "$whl"

--- a/.github/workflows/llvmlite_win-arm64_wheel_builder.yml
+++ b/.github/workflows/llvmlite_win-arm64_wheel_builder.yml
@@ -1,9 +1,6 @@
 name: llvmlite_win-arm64_wheel_builder
 
 on:
-  push:
-    branches:
-      - exp/win-arm64
   pull_request:
     paths:
       - .github/workflows/llvmlite_win-arm64_wheel_builder.yml
@@ -12,8 +9,12 @@ on:
       - versioneer.py
   workflow_dispatch:
     inputs:
+      llvmdev_run_id:
+        description: 'llvmdev workflow run ID (optional)'
+        required: false
+        type: string
       upload_wheel_to_anaconda:
-        description: 'Upload wheel to Anaconda Cloud (swap357 channel)'
+        description: 'Upload wheel to Anaconda Cloud - numba channel'
         required: false
         type: boolean
         default: false
@@ -60,12 +61,13 @@ jobs:
           destination-directory: ${{ runner.temp }}/conda-standalone
 
       - name: Download llvmdev artifact
-        if: env.LLVMDEV_RUN_ID != ''
+        if: ${{ inputs.llvmdev_run_id != '' }}
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: llvmdev_for_wheel_win-arm64
           path: llvmdev_channel
-          run-id: ${{ env.LLVMDEV_RUN_ID }}
+          run-id: ${{ inputs.llvmdev_run_id }}
+          repository: ${{ github.repository }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Create build environment
@@ -221,9 +223,9 @@ jobs:
 
       - name: Upload wheel to Anaconda Cloud
         env:
-          ANACONDA_API_TOKEN: ${{ secrets.ANACONDA_API_TOKEN }}
+          ANACONDA_API_TOKEN: ${{ secrets.NUMBA_CHANNEL_WHEEL_UPLOAD }}
         run: |
           cd dist
           whl=$(ls -1 ./*.whl)
           echo "Uploading wheel: $whl"
-          anaconda -t "$ANACONDA_API_TOKEN" upload --force -u swap357 "$whl"
+          anaconda -t "$ANACONDA_API_TOKEN" upload --force -u numba -l dev "$whl"

--- a/buildscripts/github/validate_win-64_wheel.py
+++ b/buildscripts/github/validate_win-64_wheel.py
@@ -28,7 +28,6 @@ for path in pathlib.Path(".").rglob("**/*.dll"):
         "KERNEL32.dll",
         "MSVCP140.dll",
         "VCRUNTIME140.dll",
-        "VCRUNTIME140_1.dll",
         "api-ms-win-crt-convert-l1-1-0.dll",
         "api-ms-win-crt-environment-l1-1-0.dll",
         "api-ms-win-crt-heap-l1-1-0.dll",
@@ -41,6 +40,9 @@ for path in pathlib.Path(".").rglob("**/*.dll"):
         "api-ms-win-crt-utility-l1-1-0.dll",
         "ntdll.dll",
     }
+    # VCRUNTIME140_1.dll is not required for Windows ARM64
+    if "VCRUNTIME140_1.dll" in imports:
+        expected_imports.add("VCRUNTIME140_1.dll")
     assert imports == expected_imports, (
         f"Unexpected imports: {imports - expected_imports}\n"
         f"Missing imports: {expected_imports - imports}"

--- a/conda-recipes/llvmlite/bld.bat
+++ b/conda-recipes/llvmlite/bld.bat
@@ -9,6 +9,8 @@ if "%ARCH%"=="32" (
     @rem VS2022:
     @rem set CMAKE_GENERATOR_ARCH=
     set CMAKE_GENERATOR_ARCH=Win32
+) else if "%ARCH%"=="arm64" (
+    set CMAKE_GENERATOR_ARCH=ARM64
 ) else (
     @rem VS2022
     @rem set CMAKE_GENERATOR_ARCH=Win64

--- a/conda-recipes/llvmlite/conda_build_config.yaml
+++ b/conda-recipes/llvmlite/conda_build_config.yaml
@@ -14,3 +14,7 @@ c_compiler:              # [win]
   - vs2022               # [win]
 cxx_compiler:            # [win]
   - vs2022               # [win]
+
+target_platform:
+  - win-64               # [win and not arm64]
+  - win-arm64            # [win and arm64]

--- a/conda-recipes/llvmlite/meta.yaml
+++ b/conda-recipes/llvmlite/meta.yaml
@@ -26,14 +26,16 @@ requirements:
     - setuptools
     # On channel https://anaconda.org/numba/
     - llvmdev 22
-    - vs2015_runtime # [win]
+    - vs2015_runtime # [win and not arm64]
+    - vc14_runtime # [win and arm64]
     # llvmdev is built with libz compression support
     - zlib           # [unix]
     # requires libxml2
     - libxml2        # [win]
   run:
     - python >=3.10
-    - vs2015_runtime # [win]
+    - vs2015_runtime # [win and not arm64]
+    - vc14_runtime # [win and arm64]
     # osx has dynamically linked libstdc++
     - libcxx >=4.0.1 # [osx]
     - zlib

--- a/ffi/build.py
+++ b/ffi/build.py
@@ -172,9 +172,9 @@ def find_windows_generator():
         # use VS2026 first, with the v143 toolset: llvmdev packages are
         # built with MSVC v14.44 (v143), and VS2026 ships a v143
         # compatibility toolset alongside its native v14.5x
-        ('Visual Studio 18 2026', ('x64' if is_64bit else 'Win32'), 'v143'),
+        ('Visual Studio 18 2026', arch, 'v143'),
         # try VS2022 next
-        ('Visual Studio 17 2022', ('x64' if is_64bit else 'Win32'), 'v143'),
+        ('Visual Studio 17 2022', arch, 'v143'),
         # try VS2019 next
         ('Visual Studio 16 2019', arch, 'v142'),
         # # This is the generator configuration for VS2017

--- a/ffi/build.py
+++ b/ffi/build.py
@@ -7,6 +7,7 @@ from __future__ import print_function
 
 import functools
 import os
+import platform
 import subprocess
 import shutil
 import sys
@@ -19,7 +20,18 @@ build_dir = os.path.join(here_dir, 'build')
 target_dir = os.path.join(os.path.dirname(here_dir), 'llvmlite', 'binding')
 
 
-is_64bit = sys.maxsize >= 2**32
+is_windows = sys.platform == "win32"
+is_arm64 = False
+is_64bit = False
+if is_windows:
+    machine = platform.machine().lower()
+    arch_env = os.environ.get("ARCH", "").lower()
+    if machine in ("arm64", "aarch64") or arch_env == "arm64":
+        is_arm64 = True
+    elif machine in ("amd64", "x86_64"):
+        is_64bit = True
+else:
+    is_64bit = sys.maxsize >= 2**32
 
 
 def env_var_options_to_cmake_options():
@@ -140,18 +152,27 @@ def find_windows_generator():
     # LLVM 9.0 and later needs VS 2017 minimum.
     generators = []
     env_generator = os.environ.get("CMAKE_GENERATOR", None)
+    if is_arm64:
+        arch = "ARM64"
+    elif is_64bit:
+        arch = "x64"
+    else:
+        arch = "Win32"
+
     if env_generator is not None:
         env_arch = os.environ.get("CMAKE_GENERATOR_ARCH", None)
         env_toolkit = os.environ.get("CMAKE_GENERATOR_TOOLKIT", None)
+        if is_arm64 and env_arch and env_arch.lower() == "x64":
+            env_arch = "ARM64"
         generators.append(
             (env_generator, env_arch, env_toolkit)
         )
 
     generators.extend([
         # use VS2022 first
-        ('Visual Studio 17 2022', ('x64' if is_64bit else 'Win32'), 'v143'),
+        ('Visual Studio 17 2022', arch, 'v143'),
         # try VS2019 next
-        ('Visual Studio 16 2019', ('x64' if is_64bit else 'Win32'), 'v142'),
+        ('Visual Studio 16 2019', arch, 'v142'),
         # # This is the generator configuration for VS2017
         # ('Visual Studio 15 2017' + (' Win64' if is_64bit else ''), None, None)
     ])

--- a/llvmlite/tests/test_binding.py
+++ b/llvmlite/tests/test_binding.py
@@ -2252,6 +2252,10 @@ class TestTarget(BaseTest):
              llvm.targets.Triple(Arch="wasm64", SubArch='',
                                  Vendor="unknown", OS="wasi",
                                  Env="unknown", ObjectFormat="Wasm")),
+            ("aarch64-pc-windows-msvc",
+             llvm.targets.Triple(Arch="aarch64", SubArch='',
+                                 Vendor="pc", OS="windows",
+                                 Env="msvc", ObjectFormat="COFF")),
         ]
 
         for case in cases:
@@ -3082,6 +3086,23 @@ class TestBuild(TestCase):
                                                 "api-ms-win-crt-utility-l1-1-0",
                                                 "shell32",  # this is delayed
                                                 "ole32",]), # also delayed
+                                  "arm64": set(["advapi32",
+                                                "kernel32",
+                                                "ntdll",
+                                                "msvcp140",
+                                                "vcruntime140",
+                                                "api-ms-win-crt-convert-l1-1-0",
+                                                "api-ms-win-crt-environment-l1-1-0", # noqa: E501
+                                                "api-ms-win-crt-heap-l1-1-0",
+                                                "api-ms-win-crt-locale-l1-1-0",
+                                                "api-ms-win-crt-math-l1-1-0",
+                                                "api-ms-win-crt-runtime-l1-1-0",
+                                                "api-ms-win-crt-stdio-l1-1-0",
+                                                "api-ms-win-crt-string-l1-1-0",
+                                                "api-ms-win-crt-time-l1-1-0",
+                                                "api-ms-win-crt-utility-l1-1-0",
+                                                "shell32",  # this is delayed
+                                                "ole32",]), # also delayed
                                   }, # end windows
                       "darwin": {"x86_64": set(["llvmlite",
                                                 "system",
@@ -3137,6 +3158,25 @@ class TestBuild(TestCase):
                                                 "api-ms-win-crt-utility-l1-1-0",
                                                 "shell32",  # this is delayed
                                                 "ole32",]), # also delayed
+                                  "arm64": set(["z",
+                                                "zstd",
+                                                "advapi32",
+                                                "kernel32",
+                                                "ntdll",
+                                                "msvcp140",
+                                                "vcruntime140",
+                                                "api-ms-win-crt-convert-l1-1-0",
+                                                "api-ms-win-crt-environment-l1-1-0", # noqa: E501
+                                                "api-ms-win-crt-heap-l1-1-0",
+                                                "api-ms-win-crt-locale-l1-1-0",
+                                                "api-ms-win-crt-math-l1-1-0",
+                                                "api-ms-win-crt-runtime-l1-1-0",
+                                                "api-ms-win-crt-stdio-l1-1-0",
+                                                "api-ms-win-crt-string-l1-1-0",
+                                                "api-ms-win-crt-time-l1-1-0",
+                                                "api-ms-win-crt-utility-l1-1-0",
+                                                "shell32",  # this is delayed
+                                                "ole32",]), # also delayed
                                   }, # end windows
                       "darwin": {"x86_64": set(["llvmlite",
                                                 "system",
@@ -3150,7 +3190,7 @@ class TestBuild(TestCase):
                                                "zstd",
                                                "c++",]),
                                  },# end darwin
-                      } # end wheel_expected
+                      } # end conda_expected
 
     def check_linkage(self, info, package_type):
         machine = platform.machine().lower()


### PR DESCRIPTION
This PR adds GHA workflows and updates build/test scripts to support `win-arm64` binaries for both conda packages and wheels.

Since `miniconda` installer is not available yet on `win-arm64`, the workflows use `conda-incubator/setup-conda-standalone` to setup conda environment.

Credits: I’d like to extend special thanks to @MugundanMCW for initiating this work and showing a path to building `llvmlite` and `numba` on `win-arm64` with https://github.com/numba/llvmlite/pull/1387.

Related issues: #1243 , https://github.com/numba/numba/issues/10549