### PR TITLE
update build scripts to support Visual Studio 2026 

### DIFF
--- a/conda-recipes/llvmdev/bld.bat
+++ b/conda-recipes/llvmdev/bld.bat
@@ -1,16 +1,16 @@
 REM base on https://github.com/AnacondaRecipes/llvmdev-feedstock/blob/master/recipe/bld.bat
 echo on
 
-REM First, setup the VS2022 environment
-for /F "usebackq tokens=*" %%i in (`vswhere.exe -nologo -products * -version "[17.0,18.0)" -property installationPath`) do (
+REM First, setup the VS environment (VS2022 or VS2026)
+for /F "usebackq tokens=*" %%i in (`vswhere.exe -nologo -products * -version "[17.0,19.0)" -property installationPath`) do (
   set "VSINSTALLDIR=%%i\\"
 )
 if not exist "%VSINSTALLDIR%" (
-  echo "Could not find VS 2022"
+  echo "Could not find VS 2022 or VS 2026"
   exit /B 1
 )
 
-echo "Found VS 2022 in %VSINSTALLDIR%"
+echo "Found VS in %VSINSTALLDIR%"
 
 REM ARCH is set by conda-build (e.g., "64" for x64, "arm64" for ARM64)
 if "%ARCH%"=="arm64" (
@@ -20,7 +20,10 @@ if "%ARCH%"=="arm64" (
 )
 
 echo "Building for architecture: %VCVARS_ARCH%"
-call "%VSINSTALLDIR%VC\\Auxiliary\\Build\\vcvarsall.bat" %VCVARS_ARCH%
+REM Pin MSVC v14.44 (v143): the vs2022 activation package and llvmlite's
+REM link step are v14.44; VS2026 would otherwise default to v14.5x, and
+REM v14.5x objects cannot be linked by a v14.44 toolset.
+call "%VSINSTALLDIR%VC\\Auxiliary\\Build\\vcvarsall.bat" %VCVARS_ARCH% -vcvars_ver=14.44
 
 mkdir build
 cd build

--- a/conda-recipes/llvmdev_for_wheel/bld.bat
+++ b/conda-recipes/llvmdev_for_wheel/bld.bat
@@ -1,16 +1,16 @@
 REM base on https://github.com/AnacondaRecipes/llvmdev-feedstock/blob/master/recipe/bld.bat
 echo on
 
-REM First, setup the VS2022 environment
-for /F "usebackq tokens=*" %%i in (`vswhere.exe -nologo -products * -version "[17.0,18.0)" -property installationPath`) do (
+REM First, setup the VS environment (VS2022 or VS2026)
+for /F "usebackq tokens=*" %%i in (`vswhere.exe -nologo -products * -version "[17.0,19.0)" -property installationPath`) do (
   set "VSINSTALLDIR=%%i\\"
 )
 if not exist "%VSINSTALLDIR%" (
-  echo "Could not find VS 2022"
+  echo "Could not find VS 2022 or VS 2026"
   exit /B 1
 )
 
-echo "Found VS 2022 in %VSINSTALLDIR%"
+echo "Found VS in %VSINSTALLDIR%"
 
 REM ARCH is set by conda-build (e.g., "64" for x64, "arm64" for ARM64)
 if "%ARCH%"=="arm64" (
@@ -20,7 +20,10 @@ if "%ARCH%"=="arm64" (
 )
 
 echo "Building for architecture: %VCVARS_ARCH%"
-call "%VSINSTALLDIR%VC\\Auxiliary\\Build\\vcvarsall.bat" %VCVARS_ARCH%
+REM Pin MSVC v14.44 (v143): the vs2022 activation package and llvmlite's
+REM link step are v14.44; VS2026 would otherwise default to v14.5x, and
+REM v14.5x objects cannot be linked by a v14.44 toolset.
+call "%VSINSTALLDIR%VC\\Auxiliary\\Build\\vcvarsall.bat" %VCVARS_ARCH% -vcvars_ver=14.44
 
 mkdir build
 cd build

--- a/conda-recipes/llvmlite/bld.bat
+++ b/conda-recipes/llvmlite/bld.bat
@@ -14,7 +14,10 @@ if "%ARCH%"=="32" (
     @rem set CMAKE_GENERATOR_ARCH=Win64
     set CMAKE_GENERATOR_ARCH=x64
 )
-set CMAKE_GENERATOR=Visual Studio 17 2022
+@rem v143 toolset for ABI parity with llvmdev (built with MSVC v14.44);
+@rem VS2026 ships it as a compatibility component.
+@rem ffi/build.py falls back to VS2022/VS2019 if this generator is absent.
+set CMAKE_GENERATOR=Visual Studio 18 2026
 set CMAKE_GENERATOR_TOOLKIT=v143
 
 @rem Ensure there are no build leftovers (CMake can complain)

--- a/ffi/build.py
+++ b/ffi/build.py
@@ -148,7 +148,11 @@ def find_windows_generator():
         )
 
     generators.extend([
-        # use VS2022 first
+        # use VS2026 first, with the v143 toolset: llvmdev packages are
+        # built with MSVC v14.44 (v143), and VS2026 ships a v143
+        # compatibility toolset alongside its native v14.5x
+        ('Visual Studio 18 2026', ('x64' if is_64bit else 'Win32'), 'v143'),
+        # try VS2022 next
         ('Visual Studio 17 2022', ('x64' if is_64bit else 'Win32'), 'v143'),
         # try VS2019 next
         ('Visual Studio 16 2019', ('x64' if is_64bit else 'Win32'), 'v142'),


### PR DESCRIPTION
Fixes: https://github.com/numba/llvmlite/issues/1436

This PR updates build infra for llvmlite and llvmdev for GHA and Azure pipelines change to support build and test on windows system with VS2026. 

No compiler upgrade is involved, we keep building with MSVC v14.44 (v143), the same toolset used previously with VS2022, now hosted inside VS2026. Only the toolchain locators change, which also keeps the `vs2015_runtime >=14.44` run-dependency pins valid. (A move to the `v14.5`x toolset is blocked because `conda` defaults has no `vs2026` activation package yet.)