### PR TITLE
Add LLVM FrameLowering patch to llvmdev recipes

### DIFF
--- a/conda-recipes/llvm22-aarch64-windows-target-detection.patch
+++ b/conda-recipes/llvm22-aarch64-windows-target-detection.patch
@@ -1,9 +1,12 @@
 [AArch64] Fix Windows target detection in FrameLowering
 
-Adapted from llvm/llvm-project PR #204347 to apply on the LLVM 22.1.0 release
-tree, where TargetMachine::getMCAsmInfo() still returns a pointer (the upstream
-PR targets main, where it returns a reference). The functional change and the
-upstream comment are kept verbatim; only the removed line uses ->.
+Adapted from LLVM upstream commit c327ab359a959de2e4241a5fcda409958f2c0d11 (PR #204347):
+https://github.com/llvm/llvm-project/commit/c327ab359a959de2e4241a5fcda409958f2c0d11
+
+Applied on the LLVM 22.1.0 release tree, where TargetMachine::getMCAsmInfo() still
+returns a pointer (the upstream commit targets main, where it returns a reference).
+The functional change and the upstream comment are kept verbatim; only the removed
+line uses ->.
 
 For aarch64-pc-windows-msvc-elf we would use the Windows callee-save list in
 AArch64RegisterInfo::getCalleeSavedRegs(), but FrameLowering would handle this

--- a/conda-recipes/llvm22-aarch64-windows-target-detection.patch
+++ b/conda-recipes/llvm22-aarch64-windows-target-detection.patch
@@ -1,0 +1,28 @@
+[AArch64] Fix Windows target detection in FrameLowering
+
+Adapted from llvm/llvm-project PR #204347 to apply on the LLVM 22.1.0 release
+tree, where TargetMachine::getMCAsmInfo() still returns a pointer (the upstream
+PR targets main, where it returns a reference). The functional change and the
+upstream comment are kept verbatim; only the removed line uses ->.
+
+For aarch64-pc-windows-msvc-elf we would use the Windows callee-save list in
+AArch64RegisterInfo::getCalleeSavedRegs(), but FrameLowering would handle this
+like Linux, and fail to invalidate the (x29, x28) pairing.
+
+This patch switches back to using AArch64Subtarget::isTargetWindows(), which
+aligns with getCalleeSavedRegs().
+
+diff --git a/llvm/lib/Target/AArch64/AArch64FrameLowering.cpp b/llvm/lib/Target/AArch64/AArch64FrameLowering.cpp
+--- a/llvm/lib/Target/AArch64/AArch64FrameLowering.cpp
++++ b/llvm/lib/Target/AArch64/AArch64FrameLowering.cpp
+@@ -384,5 +384,9 @@
+ }
+
+ static bool isTargetWindows(const MachineFunction &MF) {
+-  return MF.getTarget().getMCAsmInfo()->usesWindowsCFI();
++  // TODO: Should this include targets like UEFI (which use Windows CFI)?
++  // Note: Currently, there is not AArch64 support for UEFI. The value returned
++  // here must align with UsesWinAAPCS (as determined by getCalleeSavedRegs())
++  // so we use invalidateWindowsRegisterPairing() where appropriate.
++  return MF.getSubtarget<AArch64Subtarget>().isTargetWindows();
+ }

--- a/conda-recipes/llvmdev/meta.yaml
+++ b/conda-recipes/llvmdev/meta.yaml
@@ -11,6 +11,7 @@ source:
   - url: https://github.com/llvm/llvm-project/releases/download/llvmorg-{{ version.replace(".rc", "-rc") }}/llvm-project-{{ version.replace(".rc", "rc") }}.src.tar.xz
     sha256: {{ sha256_llvm }}
     patches:
+    # Drop on LLVM upgrade that carries PR #204347 (LLVM 23)
     - ../llvm22-aarch64-windows-target-detection.patch
     # - ../llvm15-remove-use-of-clonefile.patch
     # - ../llvm15-svml.patch

--- a/conda-recipes/llvmdev/meta.yaml
+++ b/conda-recipes/llvmdev/meta.yaml
@@ -11,6 +11,7 @@ source:
   - url: https://github.com/llvm/llvm-project/releases/download/llvmorg-{{ version.replace(".rc", "-rc") }}/llvm-project-{{ version.replace(".rc", "rc") }}.src.tar.xz
     sha256: {{ sha256_llvm }}
     patches:
+    - ../llvm22-aarch64-windows-target-detection.patch
     # - ../llvm15-remove-use-of-clonefile.patch
     # - ../llvm15-svml.patch
     # - ../compiler-rt-cfi-startproc-war.patch
@@ -52,12 +53,15 @@ requirements:
 test:
   files:
     - numba-3016.ll
+    - ../test-frame-record-win-arm64.ll
   commands:
     - $PREFIX/bin/llvm-config --libs                         # [not win]
     - $PREFIX/bin/llc -version                               # [not win]
 
     - if not exist %LIBRARY_INC%\\llvm\\Pass.h exit 1        # [win]
     - if not exist %LIBRARY_LIB%\\LLVMSupport.lib exit 1     # [win]
+
+    - llc ../test-frame-record-win-arm64.ll                  # [win and arm64]
 
     - test -f $PREFIX/include/llvm/Pass.h                    # [unix]
     - test -f $PREFIX/lib/libLLVMSupport.a                   # [unix]

--- a/conda-recipes/llvmdev/meta.yaml
+++ b/conda-recipes/llvmdev/meta.yaml
@@ -62,6 +62,11 @@ test:
     - if not exist %LIBRARY_INC%\\llvm\\Pass.h exit 1        # [win]
     - if not exist %LIBRARY_LIB%\\LLVMSupport.lib exit 1     # [win]
 
+    # Regression check for the AArch64 Windows frame-record fix
+    # (https://github.com/llvm/llvm-project/issues/204060).
+    # Only catches the bug on an assertion-enabled LLVM (this recipe is one):
+    # the unpatched backend aborts here. A release/no-assertions LLVM exits 0
+    # and silently emits a corrupted frame record, so the test would pass.
     - llc ../test-frame-record-win-arm64.ll                  # [win and arm64]
 
     - test -f $PREFIX/include/llvm/Pass.h                    # [unix]

--- a/conda-recipes/llvmdev_for_wheel/meta.yaml
+++ b/conda-recipes/llvmdev_for_wheel/meta.yaml
@@ -67,6 +67,11 @@ test:
     - if not exist %LIBRARY_INC%\\llvm\\Pass.h exit 1        # [win]
     - if not exist %LIBRARY_LIB%\\LLVMSupport.lib exit 1     # [win]
 
+    # Regression check for the AArch64 Windows frame-record fix
+    # (https://github.com/llvm/llvm-project/issues/204060).
+    # Only catches the bug on an assertion-enabled LLVM (this recipe is one):
+    # the unpatched backend aborts here. A release/no-assertions LLVM exits 0
+    # and silently emits a corrupted frame record, so the test would pass.
     - llc ../test-frame-record-win-arm64.ll                  # [win and arm64]
 
     - test -f $PREFIX/include/llvm/Pass.h                    # [unix]

--- a/conda-recipes/llvmdev_for_wheel/meta.yaml
+++ b/conda-recipes/llvmdev_for_wheel/meta.yaml
@@ -12,6 +12,7 @@ source:
   - url: https://github.com/llvm/llvm-project/releases/download/llvmorg-{{ version.replace(".rc", "-rc") }}/llvm-project-{{ version.replace(".rc", "rc") }}.src.tar.xz
     sha256: {{ sha256_llvm }}
     patches:
+    - ../llvm22-aarch64-windows-target-detection.patch
     # - ../llvm15-clear-gotoffsetmap.patch
     # - ../llvm15-remove-use-of-clonefile.patch
     # - ../llvm15-svml.patch
@@ -54,8 +55,9 @@ requirements:
     - zlib      # [not win]
 
 test:
+  files:
+    - ../test-frame-record-win-arm64.ll
   # Unused test file
-  # files:
   #   - numba-3016.ll
   commands:
     - $PREFIX/bin/llvm-config --libs                         # [not win]
@@ -63,6 +65,8 @@ test:
 
     - if not exist %LIBRARY_INC%\\llvm\\Pass.h exit 1        # [win]
     - if not exist %LIBRARY_LIB%\\LLVMSupport.lib exit 1     # [win]
+
+    - llc ../test-frame-record-win-arm64.ll                  # [win and arm64]
 
     - test -f $PREFIX/include/llvm/Pass.h                    # [unix]
     - test -f $PREFIX/lib/libLLVMSupport.a                   # [unix]

--- a/conda-recipes/llvmdev_for_wheel/meta.yaml
+++ b/conda-recipes/llvmdev_for_wheel/meta.yaml
@@ -12,6 +12,7 @@ source:
   - url: https://github.com/llvm/llvm-project/releases/download/llvmorg-{{ version.replace(".rc", "-rc") }}/llvm-project-{{ version.replace(".rc", "rc") }}.src.tar.xz
     sha256: {{ sha256_llvm }}
     patches:
+    # Drop on LLVM upgrade that carries PR #204347 (LLVM 23)
     - ../llvm22-aarch64-windows-target-detection.patch
     # - ../llvm15-clear-gotoffsetmap.patch
     # - ../llvm15-remove-use-of-clonefile.patch

--- a/conda-recipes/test-frame-record-win-arm64.ll
+++ b/conda-recipes/test-frame-record-win-arm64.ll
@@ -1,0 +1,23 @@
+; From llvm/llvm-project PR #204347. llvmdev is built with assertions,
+; so the recipe runs the built llc on this and the unpatched backend aborts.
+
+; This test uses a Windows triple with ELF binaries. This triple does not use
+; Windows CFI. Since it's Windows though it uses the
+; CSR_Win_AArch64_AAPCS_SaveList for callee-saves.
+;
+; Functions with a large stack reserve and extra register, so this function will
+; save x28 followed by the frame record. This test checks we do not attempt to
+; pair x28 with the frame pointer (x29). Previously we would, as we'd not
+; recognize aarch64-pc-windows-msvc-elf as Windows in FrameLowering and
+; handle it as if it was using the default CSR_AArch64_AAPCS_SaveList, and fail
+; to invalidate the pairing.
+
+target triple = "aarch64-pc-windows-msvc-elf"
+
+define i32 @large_stack_requires_frame_record() "frame-pointer"="all" nounwind {
+  %x = alloca [500 x i8], align 16
+  call void @baz(ptr %x)
+  ret i32 0
+}
+
+declare void @baz(ptr)

--- a/conda-recipes/test-frame-record-win-arm64.ll
+++ b/conda-recipes/test-frame-record-win-arm64.ll
@@ -1,4 +1,6 @@
-; From llvm/llvm-project PR #204347. llvmdev is built with assertions,
+; From LLVM upstream commit c327ab359a959de2e4241a5fcda409958f2c0d11 (PR #204347):
+; https://github.com/llvm/llvm-project/commit/c327ab359a959de2e4241a5fcda409958f2c0d11
+; llvmdev is built with assertions,
 ; so the recipe runs the built llc on this and the unpatched backend aborts.
 
 ; This test uses a Windows triple with ELF binaries. This triple does not use


### PR DESCRIPTION
LLVM PR https://github.com/llvm/llvm-project/pull/204347 addressed cause of errors on https://github.com/numba/numba/issues/10652. 

This PR adds adapted patch from LLVM PR on llvmdev recipes. Adapted because current llvmdev recipe uses LLVM 22.1.0, where TargetMachine::getMCAsmInfo() still returns a pointer (the upstream PR targets main, where it returns a reference).
The functional change and the upstream comment are kept verbatim; only the removed line uses `->`.