### PR TITLE
add GHA CI changes onto release0.48

### DIFF
--- a/.github/workflows/llvmdev_build_win-arm64.yml
+++ b/.github/workflows/llvmdev_build_win-arm64.yml
@@ -55,13 +55,14 @@ jobs:
         uses: conda-incubator/setup-conda-standalone@00a34805e93a8b640aee5f8a20e8f481ad77e3b4 # v0.1.0
         with:
           channel: ${{ env.WIN_ARM64_CONDA_CHANNEL }}
+          conda-standalone-version: 26.3.2.post1
           destination-directory: ${{ runner.temp }}/conda-standalone
 
       - name: Install conda-build
         run: |
           export CONDA_PREFIX="${RUNNER_TEMP}/conda-base"
           "${CONDA_EXE}" create --prefix "${CONDA_PREFIX}" \
-            -c "${WIN_ARM64_CONDA_CHANNEL}" --yes conda-build
+            -c "${WIN_ARM64_CONDA_CHANNEL}" -c m2-winarm64 -c main --yes conda-build
           echo "CONDA_PREFIX=${CONDA_PREFIX}" >> "${GITHUB_ENV}"
           echo "${CONDA_PREFIX}" >> "${GITHUB_PATH}"
           echo "${CONDA_PREFIX}/Scripts" >> "${GITHUB_PATH}"

--- a/CHANGE_LOG
+++ b/CHANGE_LOG
@@ -21,6 +21,7 @@ Pull-Requests:
 * PR `#1426 <https://github.com/numba/llvmlite/pull/1426>`_: CI: add gha workflow to build llvmdev on win-arm64 (`swap357 <https://github.com/swap357>`_)
 * PR `#1430 <https://github.com/numba/llvmlite/pull/1430>`_: update README to document support for LLVM 22 on v0.48.0 (`swap357 <https://github.com/swap357>`_)
 * PR `#1432 <https://github.com/numba/llvmlite/pull/1432>`_: update changelog for `0.48.0rc1` (`swap357 <https://github.com/swap357>`_)
+* PR `#1434 <https://github.com/numba/llvmlite/pull/1434>`_: CI: fix llvmdev recipe and workflow for `win-arm64` (`swap357 <https://github.com/swap357>`_)
 * PR `#1437 <https://github.com/numba/llvmlite/pull/1437>`_: update build scripts to support Visual Studio 2026 (`swap357 <https://github.com/swap357>`_)
 * PR `#1446 <https://github.com/numba/llvmlite/pull/1446>`_: update CHANGE_LOG for v0.48.0 final release (`swap357 <https://github.com/swap357>`_)
 

--- a/CHANGE_LOG
+++ b/CHANGE_LOG
@@ -21,6 +21,7 @@ Pull-Requests:
 * PR `#1426 <https://github.com/numba/llvmlite/pull/1426>`_: CI: add gha workflow to build llvmdev on win-arm64 (`swap357 <https://github.com/swap357>`_)
 * PR `#1430 <https://github.com/numba/llvmlite/pull/1430>`_: update README to document support for LLVM 22 on v0.48.0 (`swap357 <https://github.com/swap357>`_)
 * PR `#1432 <https://github.com/numba/llvmlite/pull/1432>`_: update changelog for `0.48.0rc1` (`swap357 <https://github.com/swap357>`_)
+* PR `#1437 <https://github.com/numba/llvmlite/pull/1437>`_: update build scripts to support Visual Studio 2026 (`swap357 <https://github.com/swap357>`_)
 * PR `#1446 <https://github.com/numba/llvmlite/pull/1446>`_: update CHANGE_LOG for v0.48.0 final release (`swap357 <https://github.com/swap357>`_)
 
 Authors:

--- a/conda-recipes/llvmdev/bld.bat
+++ b/conda-recipes/llvmdev/bld.bat
@@ -1,16 +1,16 @@
 REM base on https://github.com/AnacondaRecipes/llvmdev-feedstock/blob/master/recipe/bld.bat
 echo on
 
-REM First, setup the VS2022 environment
-for /F "usebackq tokens=*" %%i in (`vswhere.exe -nologo -products * -version "[17.0,18.0)" -property installationPath`) do (
+REM First, setup the VS environment (VS2022 or VS2026)
+for /F "usebackq tokens=*" %%i in (`vswhere.exe -nologo -products * -version "[17.0,19.0)" -property installationPath`) do (
   set "VSINSTALLDIR=%%i\\"
 )
 if not exist "%VSINSTALLDIR%" (
-  echo "Could not find VS 2022"
+  echo "Could not find VS 2022 or VS 2026"
   exit /B 1
 )
 
-echo "Found VS 2022 in %VSINSTALLDIR%"
+echo "Found VS in %VSINSTALLDIR%"
 
 REM ARCH is set by conda-build (e.g., "64" for x64, "arm64" for ARM64)
 if "%ARCH%"=="arm64" (
@@ -20,7 +20,10 @@ if "%ARCH%"=="arm64" (
 )
 
 echo "Building for architecture: %VCVARS_ARCH%"
-call "%VSINSTALLDIR%VC\\Auxiliary\\Build\\vcvarsall.bat" %VCVARS_ARCH%
+REM Pin MSVC v14.44 (v143): the vs2022 activation package and llvmlite's
+REM link step are v14.44; VS2026 would otherwise default to v14.5x, and
+REM v14.5x objects cannot be linked by a v14.44 toolset.
+call "%VSINSTALLDIR%VC\\Auxiliary\\Build\\vcvarsall.bat" %VCVARS_ARCH% -vcvars_ver=14.44
 
 mkdir build
 cd build

--- a/conda-recipes/llvmdev/conda_build_config.yaml
+++ b/conda-recipes/llvmdev/conda_build_config.yaml
@@ -14,3 +14,7 @@ c_compiler:              # [win]
   - vs2022               # [win]
 cxx_compiler:            # [win]
   - vs2022               # [win]
+
+target_platform:
+  - win-64               # [win and not arm64]
+  - win-arm64            # [win and arm64]

--- a/conda-recipes/llvmdev_for_wheel/bld.bat
+++ b/conda-recipes/llvmdev_for_wheel/bld.bat
@@ -1,16 +1,16 @@
 REM base on https://github.com/AnacondaRecipes/llvmdev-feedstock/blob/master/recipe/bld.bat
 echo on
 
-REM First, setup the VS2022 environment
-for /F "usebackq tokens=*" %%i in (`vswhere.exe -nologo -products * -version "[17.0,18.0)" -property installationPath`) do (
+REM First, setup the VS environment (VS2022 or VS2026)
+for /F "usebackq tokens=*" %%i in (`vswhere.exe -nologo -products * -version "[17.0,19.0)" -property installationPath`) do (
   set "VSINSTALLDIR=%%i\\"
 )
 if not exist "%VSINSTALLDIR%" (
-  echo "Could not find VS 2022"
+  echo "Could not find VS 2022 or VS 2026"
   exit /B 1
 )
 
-echo "Found VS 2022 in %VSINSTALLDIR%"
+echo "Found VS in %VSINSTALLDIR%"
 
 REM ARCH is set by conda-build (e.g., "64" for x64, "arm64" for ARM64)
 if "%ARCH%"=="arm64" (
@@ -20,7 +20,10 @@ if "%ARCH%"=="arm64" (
 )
 
 echo "Building for architecture: %VCVARS_ARCH%"
-call "%VSINSTALLDIR%VC\\Auxiliary\\Build\\vcvarsall.bat" %VCVARS_ARCH%
+REM Pin MSVC v14.44 (v143): the vs2022 activation package and llvmlite's
+REM link step are v14.44; VS2026 would otherwise default to v14.5x, and
+REM v14.5x objects cannot be linked by a v14.44 toolset.
+call "%VSINSTALLDIR%VC\\Auxiliary\\Build\\vcvarsall.bat" %VCVARS_ARCH% -vcvars_ver=14.44
 
 mkdir build
 cd build

--- a/conda-recipes/llvmlite/bld.bat
+++ b/conda-recipes/llvmlite/bld.bat
@@ -14,7 +14,10 @@ if "%ARCH%"=="32" (
     @rem set CMAKE_GENERATOR_ARCH=Win64
     set CMAKE_GENERATOR_ARCH=x64
 )
-set CMAKE_GENERATOR=Visual Studio 17 2022
+@rem v143 toolset for ABI parity with llvmdev (built with MSVC v14.44);
+@rem VS2026 ships it as a compatibility component.
+@rem ffi/build.py falls back to VS2022/VS2019 if this generator is absent.
+set CMAKE_GENERATOR=Visual Studio 18 2026
 set CMAKE_GENERATOR_TOOLKIT=v143
 
 @rem Ensure there are no build leftovers (CMake can complain)

--- a/ffi/build.py
+++ b/ffi/build.py
@@ -148,7 +148,11 @@ def find_windows_generator():
         )
 
     generators.extend([
-        # use VS2022 first
+        # use VS2026 first, with the v143 toolset: llvmdev packages are
+        # built with MSVC v14.44 (v143), and VS2026 ships a v143
+        # compatibility toolset alongside its native v14.5x
+        ('Visual Studio 18 2026', ('x64' if is_64bit else 'Win32'), 'v143'),
+        # try VS2022 next
         ('Visual Studio 17 2022', ('x64' if is_64bit else 'Win32'), 'v143'),
         # try VS2019 next
         ('Visual Studio 16 2019', ('x64' if is_64bit else 'Win32'), 'v142'),


### PR DESCRIPTION
The changes for VS2026 support was merged to main (https://github.com/numba/llvmlite/pull/1437) but was not carried on release0.48 branch.
This PR cherry-picks the Merge PR and adds entry for it on changelog. 