### PR TITLE
update changelog for `0.49.0rc1`

### DIFF
--- a/CHANGE_LOG
+++ b/CHANGE_LOG
@@ -1,3 +1,35 @@
+v0.49.0rc1 (July 21, 2026)
+--------------------------
+
+Highlights of this release include:
+
+- Support for Windows ARM64 (`win-arm64`) conda packages and wheels.
+- Fix for invalid fixup errors on Windows ARM64.
+
+Pull-Requests:
+
+* PR `#1427 <https://github.com/numba/llvmlite/pull/1427>`_: Fix invalid fixup errors on Windows ARM64 (`gmarkall <https://github.com/gmarkall>`_ `MugundanMCW <https://github.com/MugundanMCW>`_)
+* PR `#1428 <https://github.com/numba/llvmlite/pull/1428>`_: Update actions/checkout action to v6.0.3 (`renovate[bot] <https://github.com/apps/renovate>`_)
+* PR `#1433 <https://github.com/numba/llvmlite/pull/1433>`_: update installation doc llvm channel references (`swap357 <https://github.com/swap357>`_)
+* PR `#1435 <https://github.com/numba/llvmlite/pull/1435>`_: Add `win-arm64` support for llvmlite (`MugundanMCW <https://github.com/MugundanMCW>`_ `swap357 <https://github.com/swap357>`_)
+* PR `#1438 <https://github.com/numba/llvmlite/pull/1438>`_: Update actions/checkout action to v6.0.3 (`renovate[bot] <https://github.com/apps/renovate>`_)
+* PR `#1439 <https://github.com/numba/llvmlite/pull/1439>`_: Add LLVM FrameLowering patch to llvmdev recipes (`swap357 <https://github.com/swap357>`_)
+* PR `#1440 <https://github.com/numba/llvmlite/pull/1440>`_: Update actions/checkout action to v7 (`renovate[bot] <https://github.com/apps/renovate>`_)
+* PR `#1442 <https://github.com/numba/llvmlite/pull/1442>`_: FIX: llvmlite win-arm64 wheel builder llvmdev channel (`swap357 <https://github.com/swap357>`_)
+* PR `#1443 <https://github.com/numba/llvmlite/pull/1443>`_: Update actions/setup-python action to v6.3.0 (`renovate[bot] <https://github.com/apps/renovate>`_)
+* PR `#1447 <https://github.com/numba/llvmlite/pull/1447>`_: add GHA CI changes onto release0.48 (`swap357 <https://github.com/swap357>`_)
+* PR `#1450 <https://github.com/numba/llvmlite/pull/1450>`_: Cherry pick 0.48 (`sklam <https://github.com/sklam>`_ `swap357 <https://github.com/swap357>`_)
+* PR `#1452 <https://github.com/numba/llvmlite/pull/1452>`_: Update pypa/gh-action-pypi-publish digest to ba38be9 (`renovate[bot] <https://github.com/apps/renovate>`_)
+* PR `#1453 <https://github.com/numba/llvmlite/pull/1453>`_: Update actions/setup-python action to v7 (`renovate[bot] <https://github.com/apps/renovate>`_)
+
+Authors:
+
+* `gmarkall <https://github.com/gmarkall>`_
+* `MugundanMCW <https://github.com/MugundanMCW>`_
+* `renovate[bot] <https://github.com/apps/renovate>`_
+* `sklam <https://github.com/sklam>`_
+* `swap357 <https://github.com/swap357>`_
+
 v0.48.0 (June 30, 2026)
 -----------------------
 


### PR DESCRIPTION
## Summary
- Add `v0.49.0rc1` section to `CHANGE_LOG`
- Generated via local trial of [`generate_changelog.py`](https://github.com/swap357/llvmlite/commit/b5b4d4f6934baad6a723c3d53e045c2c86333ef5) (start: `v0.49.0dev0`; skipped PRs already listed under `v0.48.0`)
- Highlights: `win-arm64` package/wheel support and Windows ARM64 fixup fix

Part of https://github.com/numba/llvmlite/issues/1455

Made with [Cursor](https://cursor.com)