### PR TITLE
Add `win-arm64` workflows to upload config

### DIFF
--- a/buildscripts/github/workflow_groups.json
+++ b/buildscripts/github/workflow_groups.json
@@ -1,13 +1,15 @@
 {
   "workflows": {
     "conda": [
-      "llvmlite_conda_builder.yml"
+      "llvmlite_conda_builder.yml",
+      "llvmlite_win-arm64_conda_builder.yml"
     ],
     "wheel": [
       "llvmlite_linux-64_wheel_builder.yml",
       "llvmlite_linux-aarch64_wheel_builder.yml",
       "llvmlite_osx-arm64_wheel_builder.yml",
-      "llvmlite_win-64_wheel_builder.yml"
+      "llvmlite_win-64_wheel_builder.yml",
+      "llvmlite_win-arm64_wheel_builder.yml"
     ]
   }
 }


### PR DESCRIPTION
This PR adds `win-arm64` workflows to be discovered by upload workflow by adding them to config json. This will allow discovery and upload of `win-arm64` artifacts to anaconda.org and PyPI.