### PR TITLE
Fix FloatType/HalfType formatting of special values passed as strings

### DIFF
--- a/llvmlite/ir/types.py
+++ b/llvmlite/ir/types.py
@@ -336,7 +336,7 @@ def _as_float(value):
     """
     Truncate to single-precision float.
     """
-    return struct.unpack('f', struct.pack('f', value))[0]
+    return struct.unpack('f', struct.pack('f', float(value)))[0]
 
 
 def _as_half(value):
@@ -344,7 +344,7 @@ def _as_half(value):
     Truncate to half-precision float.
     """
     try:
-        return struct.unpack('e', struct.pack('e', value))[0]
+        return struct.unpack('e', struct.pack('e', float(value)))[0]
     except struct.error:
         # 'e' only added in Python 3.6+
         return _as_float(value)

--- a/llvmlite/tests/test_ir.py
+++ b/llvmlite/tests/test_ir.py
@@ -2807,7 +2807,6 @@ class TestConstant(TestBase):
         self.assertEqual(str(c), 'i1 0')
 
     def test_reals(self):
-        # XXX Test NaNs and infs
         c = ir.Constant(flt, 1.5)
         self.assertEqual(str(c), 'float 0x3ff8000000000000')
         c = ir.Constant(flt, -1.5)
@@ -2820,6 +2819,17 @@ class TestConstant(TestBase):
         self.assertEqual(str(c), 'double undef')
         c = ir.Constant(dbl, None)
         self.assertEqual(str(c), 'double 0.0')
+
+    def test_reals_special_values(self):
+        # Inf/-Inf/NaN passed as strings must format for all float types,
+        # not just double (issue #833).
+        for ty, prefix in ((hlf, 'half'), (flt, 'float'), (dbl, 'double')):
+            self.assertEqual(str(ir.Constant(ty, 'Inf')),
+                             '%s 0x7ff0000000000000' % prefix)
+            self.assertEqual(str(ir.Constant(ty, '-Inf')),
+                             '%s 0xfff0000000000000' % prefix)
+            self.assertEqual(str(ir.Constant(ty, 'nan')),
+                             '%s 0x7ff8000000000000' % prefix)
 
     def test_arrays(self):
         c = ir.Constant(ir.ArrayType(int32, 3), (c32(5), c32(6), c32(4)))


### PR DESCRIPTION
Fixes #833.

`FloatType` and `HalfType` fail to format a special value passed as a string, while `DoubleType` accepts it:

```python
from llvmlite import ir
ir.DoubleType().format_constant("Inf")  # 0x7ff0000000000000
ir.FloatType().format_constant("Inf")   # struct.error: required argument is not a float
ir.HalfType().format_constant("Inf")    # struct.error: required argument is not a float
```

`DoubleType.format_constant` goes through `_format_float_as_hex`, which does `struct.pack(fmt, float(value))`. The `FloatType`/`HalfType` paths go through `_as_float`/`_as_half`, which call `struct.pack('f'/'e', value)` without the `float()` conversion, so a string argument raises `struct.error`.

The fix converts the argument to float in `_as_float` and `_as_half`, matching what `_format_float_as_hex` already does. After it, all three types produce the same representation for `"Inf"`, `"-Inf"` and `"nan"`.

Added a `test_reals_special_values` case in `TestConstant` covering Inf/-Inf/NaN as strings for half, float and double (this replaces the old `# XXX Test NaNs and infs` note in `test_reals`).
