### PR TITLE
remove skipping `lief` installation on GHA wheel workflows test env

### DIFF
--- a/.github/workflows/llvmlite_linux-64_wheel_builder.yml
+++ b/.github/workflows/llvmlite_linux-64_wheel_builder.yml
@@ -206,10 +206,7 @@ jobs:
           fi
 
           echo "Installing lief for distribution testing"
-          # TODO: make unconditional when PyLIEF ships free-threaded wheels
-          if [[ "${{ matrix.python-version }}" != *t ]]; then
-              "${PYTHON_PATH}" -m pip install -v lief
-          fi
+          "${PYTHON_PATH}" -m pip install -v lief
 
           echo "Using wheel: $whl"
           "${PYTHON_PATH}" -m pip install -v "$whl"

--- a/.github/workflows/llvmlite_linux-aarch64_wheel_builder.yml
+++ b/.github/workflows/llvmlite_linux-aarch64_wheel_builder.yml
@@ -203,10 +203,7 @@ jobs:
           fi
 
           echo "Installing lief for distribution testing"
-          # TODO: make unconditional when PyLIEF ships free-threaded wheels
-          if [[ "${{ matrix.python-version }}" != *t ]]; then
-              "${PYTHON_PATH}" -m pip install -v lief
-          fi
+          "${PYTHON_PATH}" -m pip install -v lief
 
           echo "Using wheel: $whl"
           "${PYTHON_PATH}" -m pip install -v "$whl"

--- a/.github/workflows/llvmlite_osx-arm64_wheel_builder.yml
+++ b/.github/workflows/llvmlite_osx-arm64_wheel_builder.yml
@@ -193,10 +193,7 @@ jobs:
           "$PYTHON_PATH" -m venv .venv && source .venv/bin/activate
           python -m pip install --upgrade pip wheel
           echo "Installing lief for distribution testing"
-          # TODO: make unconditional when PyLIEF ships free-threaded wheels
-          if [[ "${{ matrix.python-version }}" != *t ]]; then
-              python -m pip install -v lief
-          fi
+          python -m pip install -v lief
           cd dist && python -m pip install -v ./*.whl
           DYLIB_PATH=$(find "$(python -c "import llvmlite; print(llvmlite.__path__[0])")" -name "libllvmlite.dylib")
           echo "Found dylib at: $DYLIB_PATH" && otool -L "$DYLIB_PATH"

--- a/.github/workflows/llvmlite_win-64_wheel_builder.yml
+++ b/.github/workflows/llvmlite_win-64_wheel_builder.yml
@@ -181,10 +181,7 @@ jobs:
           python -m pip install --upgrade pip wheel
 
           echo "Installing lief for distribution testing"
-          # TODO: make unconditional when PyLIEF ships free-threaded wheels
-          if [[ "${{ matrix.python-version }}" != *t ]]; then
-              python -m pip install -v lief
-          fi
+          python -m pip install -v lief
 
           # Install wheel and run tests
           cd dist


### PR DESCRIPTION
fixes: https://github.com/numba/llvmlite/issues/1388

The `lief` package installation was skipped on wheel test env for free-threaded (`py314t`) python version. With newer release of `lief` - https://pypi.org/project/lief/1.0.0/#files, it now has support for `3.14t` and `3.15t`

Hence, This PR removes the condition that was placed to skip lief installation on test env. This will re-enable tests that depend on `lief`. 