### PR TITLE
CI: add python-3.15 and 3.15t to wheel build and test matrices

### DIFF
--- a/.github/workflows/llvmlite_conda_builder.yml
+++ b/.github/workflows/llvmlite_conda_builder.yml
@@ -73,7 +73,8 @@ jobs:
     name: ${{ matrix.platform }}-py${{ matrix.python-version }}-build
     runs-on: ${{ matrix.runner }}
     env:
-      EXTRA_CHANNELS: ''
+      # Python 3.15 is temporarily on ad-testing until it lands in defaults
+      EXTRA_CHANNELS: ${{ matrix.python-version == '3.15' && '-c ad-testing/label/py315' || '' }}
     defaults:
       run:
         shell: bash -elx {0}
@@ -139,7 +140,8 @@ jobs:
     needs: [check, build]
     runs-on: ${{ matrix.runner }}
     env:
-      EXTRA_CHANNELS: ''
+      # Python 3.15 is temporarily on ad-testing until it lands in defaults
+      EXTRA_CHANNELS: ${{ matrix.python-version == '3.15' && '-c ad-testing/label/py315' || '' }}
     defaults:
       run:
         shell: bash -elx {0}

--- a/.github/workflows/llvmlite_linux-64_wheel_builder.yml
+++ b/.github/workflows/llvmlite_linux-64_wheel_builder.yml
@@ -42,7 +42,7 @@ jobs:
         shell: bash -elx {0}
     strategy:
       matrix:
-        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14", "3.14t"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14", "3.14t", "3.15", "3.15t"]
       fail-fast: false
 
     steps:
@@ -71,6 +71,8 @@ jobs:
             "3.13") echo "PYTHON_PATH=cp313-cp313" >> "$GITHUB_ENV" ;;
             "3.14") echo "PYTHON_PATH=cp314-cp314" >> "$GITHUB_ENV" ;;
             "3.14t") echo "PYTHON_PATH=cp314-cp314t" >> "$GITHUB_ENV" ;;
+            "3.15") echo "PYTHON_PATH=cp315-cp315" >> "$GITHUB_ENV" ;;
+            "3.15t") echo "PYTHON_PATH=cp315-cp315t" >> "$GITHUB_ENV" ;;
             *) echo "Invalid Python version" && exit 1 ;;
           esac
 
@@ -125,7 +127,7 @@ jobs:
         shell: bash -elx {0}
     strategy:
       matrix:
-        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14", "3.14t"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14", "3.14t", "3.15", "3.15t"]
       fail-fast: false
     steps:
       - name: Clone repository
@@ -166,7 +168,7 @@ jobs:
         shell: bash -elx {0}
     strategy:
       matrix:
-        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14", "3.14t"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14", "3.14t", "3.15", "3.15t"]
       fail-fast: false
 
     steps:
@@ -227,7 +229,7 @@ jobs:
         shell: bash -elx {0}
     strategy:
       matrix:
-        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14", "3.14t"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14", "3.14t", "3.15", "3.15t"]
       fail-fast: false
     steps:
       - name: Setup Miniconda

--- a/.github/workflows/llvmlite_linux-aarch64_wheel_builder.yml
+++ b/.github/workflows/llvmlite_linux-aarch64_wheel_builder.yml
@@ -42,7 +42,7 @@ jobs:
         shell: bash -elx {0}
     strategy:
       matrix:
-        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14", "3.14t"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14", "3.14t", "3.15", "3.15t"]
       fail-fast: false
 
     steps:
@@ -71,6 +71,8 @@ jobs:
             "3.13") echo "PYTHON_PATH=cp313-cp313" >> "$GITHUB_ENV" ;;
             "3.14") echo "PYTHON_PATH=cp314-cp314" >> "$GITHUB_ENV" ;;
             "3.14t") echo "PYTHON_PATH=cp314-cp314t" >> "$GITHUB_ENV" ;;
+            "3.15") echo "PYTHON_PATH=cp315-cp315" >> "$GITHUB_ENV" ;;
+            "3.15t") echo "PYTHON_PATH=cp315-cp315t" >> "$GITHUB_ENV" ;;
             *) echo "Invalid Python version" && exit 1 ;;
           esac
 
@@ -122,7 +124,7 @@ jobs:
         shell: bash -elx {0}
     strategy:
       matrix:
-        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14", "3.14t"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14", "3.14t", "3.15", "3.15t"]
       fail-fast: false
     steps:
       - name: Clone repository
@@ -163,7 +165,7 @@ jobs:
         shell: bash -elx {0}
     strategy:
       matrix:
-        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14", "3.14t"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14", "3.14t", "3.15", "3.15t"]
       fail-fast: false
 
     steps:
@@ -224,7 +226,7 @@ jobs:
         shell: bash -elx {0}
     strategy:
       matrix:
-        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14", "3.14t"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14", "3.14t", "3.15", "3.15t"]
       fail-fast: false
     steps:
       - name: Setup Miniconda

--- a/.github/workflows/llvmlite_osx-arm64_wheel_builder.yml
+++ b/.github/workflows/llvmlite_osx-arm64_wheel_builder.yml
@@ -40,7 +40,7 @@ jobs:
         shell: bash -elx {0}
     strategy:
       matrix:
-        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14", "3.14t"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14", "3.14t", "3.15", "3.15t"]
       fail-fast: false
 
     steps:
@@ -54,6 +54,8 @@ jobs:
         with:
           auto-update-conda: true
           auto-activate-base: true
+          # Python 3.15 is temporarily on ad-testing until it lands in defaults
+          channels: ${{ startsWith(matrix.python-version, '3.15') && 'ad-testing/label/py315,defaults' || 'defaults' }}
 
       - name: Download llvmdev Artifact
         if: ${{ inputs.llvmdev_run_id != '' }}
@@ -69,7 +71,13 @@ jobs:
         run: |
           if [[ "${{ matrix.python-version }}" == *t ]]; then
               PY_VER=${{ matrix.python-version }}
-              conda install -c conda-forge python-freethreading="${PY_VER%t}"
+              if [[ "$PY_VER" == 3.15* ]]; then
+                  conda install -c ad-testing/label/py315 -c defaults python-freethreading="${PY_VER%t}"
+              else
+                  conda install -c conda-forge python-freethreading="${PY_VER%t}"
+              fi
+          elif [[ "${{ matrix.python-version }}" == "3.15" ]]; then
+              conda install -c ad-testing/label/py315 -c defaults python=3.15
           else
               conda install -c defaults python="${{ matrix.python-version }}"
           fi
@@ -133,7 +141,7 @@ jobs:
         shell: bash -elx {0}
     strategy:
       matrix:
-        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14", "3.14t"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14", "3.14t", "3.15", "3.15t"]
       fail-fast: false
     steps:
       - name: Clone repository
@@ -169,7 +177,7 @@ jobs:
         shell: bash -elx {0}
     strategy:
       matrix:
-        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14", "3.14t"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14", "3.14t", "3.15", "3.15t"]
       fail-fast: false
 
     steps:
@@ -212,7 +220,7 @@ jobs:
         shell: bash -elx {0}
     strategy:
       matrix:
-        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14", "3.14t"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14", "3.14t", "3.15", "3.15t"]
       fail-fast: false
     steps:
       - name: Setup Miniconda

--- a/.github/workflows/llvmlite_win-64_wheel_builder.yml
+++ b/.github/workflows/llvmlite_win-64_wheel_builder.yml
@@ -41,7 +41,7 @@ jobs:
         shell: bash -elx {0}
     strategy:
       matrix:
-        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14", "3.14t"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14", "3.14t", "3.15", "3.15t"]
       fail-fast: false
 
     steps:
@@ -117,7 +117,7 @@ jobs:
         shell: bash -elx {0}
     strategy:
       matrix:
-        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14", "3.14t"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14", "3.14t", "3.15", "3.15t"]
       fail-fast: false
     steps:
       - name: Clone repository
@@ -157,7 +157,7 @@ jobs:
         shell: bash -elx {0}
     strategy:
       matrix:
-        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14", "3.14t"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14", "3.14t", "3.15", "3.15t"]
       fail-fast: false
 
     steps:
@@ -206,7 +206,7 @@ jobs:
         shell: bash -elx {0}
     strategy:
       matrix:
-        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14", "3.14t"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14", "3.14t", "3.15", "3.15t"]
       fail-fast: false
     steps:
       - name: Setup Miniconda

--- a/.github/workflows/llvmlite_win-arm64_wheel_builder.yml
+++ b/.github/workflows/llvmlite_win-arm64_wheel_builder.yml
@@ -38,16 +38,13 @@ jobs:
   win-arm64-build:
     name: win-arm64-build-py${{ matrix.python-version }}
     runs-on: windows-11-arm
-    env:
-      # Python 3.15 is temporarily on ad-testing until it lands in defaults
-      EXTRA_CHANNELS: ${{ matrix.python-version == '3.15' && '-c ad-testing/label/py315' || '' }}
     defaults:
       run:
         shell: bash -elx {0}
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.11", "3.12", "3.13", "3.14", "3.15"]
+        python-version: ["3.11", "3.12", "3.13", "3.14"]
 
     steps:
       - name: Clone repository
@@ -82,15 +79,10 @@ jobs:
           # Free-threaded builds ship as python-freethreading on conda-forge.
           if [[ "${PY_VER}" == *t ]]; then
             PY_SPEC="python-freethreading=${PY_VER%t}"
-            FT_CHANNEL="-c conda-forge"
+            EXTRA_CHANNEL="-c conda-forge"
           else
             PY_SPEC="python=${PY_VER}"
-            FT_CHANNEL=""
-          fi
-          if [ -n "${EXTRA_CHANNELS}" ]; then
-            extra_args=(${EXTRA_CHANNELS})
-          else
-            extra_args=()
+            EXTRA_CHANNEL=""
           fi
           if [ -d llvmdev_channel/win-arm64 ]; then
             LLVMDEV_SRC="-c ${GITHUB_WORKSPACE}/llvmdev_channel"
@@ -98,7 +90,7 @@ jobs:
             LLVMDEV_SRC="-c ${LLVMDEV_CHANNEL}"
           fi
           "${CONDA_EXE}" create --prefix "${CONDA_PREFIX}" --yes \
-            ${LLVMDEV_SRC} -c "${WIN_ARM64_CONDA_CHANNEL}" "${extra_args[@]}" ${FT_CHANNEL} \
+            ${LLVMDEV_SRC} -c "${WIN_ARM64_CONDA_CHANNEL}" ${EXTRA_CHANNEL} \
             -c m2-winarm64 -c main \
             "${PY_SPEC}" "llvmdev=${FALLBACK_LLVMDEV_VERSION}" cmake libxml2 setuptools pip
           echo "${CONDA_PREFIX}" >> "${GITHUB_PATH}"
@@ -142,16 +134,13 @@ jobs:
     name: win-arm64-test-py${{ matrix.python-version }}
     needs: win-arm64-build
     runs-on: windows-11-arm
-    env:
-      # Python 3.15 is temporarily on ad-testing until it lands in defaults
-      EXTRA_CHANNELS: ${{ matrix.python-version == '3.15' && '-c ad-testing/label/py315' || '' }}
     defaults:
       run:
         shell: bash -elx {0}
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.11", "3.12", "3.13", "3.14", "3.15"]
+        python-version: ["3.11", "3.12", "3.13", "3.14"]
 
     steps:
       - name: Set up conda-standalone
@@ -169,18 +158,13 @@ jobs:
           export CONDA_PREFIX="${RUNNER_TEMP}/conda-test-env"
           if [[ "${PY_VER}" == *t ]]; then
             PY_SPEC="python-freethreading=${PY_VER%t}"
-            FT_CHANNEL="-c conda-forge"
+            EXTRA_CHANNEL="-c conda-forge"
           else
             PY_SPEC="python=${PY_VER}"
-            FT_CHANNEL=""
-          fi
-          if [ -n "${EXTRA_CHANNELS}" ]; then
-            extra_args=(${EXTRA_CHANNELS})
-          else
-            extra_args=()
+            EXTRA_CHANNEL=""
           fi
           "${CONDA_EXE}" create --prefix "${CONDA_PREFIX}" --yes \
-            -c "${WIN_ARM64_CONDA_CHANNEL}" "${extra_args[@]}" ${FT_CHANNEL} -c main \
+            -c "${WIN_ARM64_CONDA_CHANNEL}" ${EXTRA_CHANNEL} -c main \
             "${PY_SPEC}" pip
           echo "${CONDA_PREFIX}" >> "${GITHUB_PATH}"
           echo "${CONDA_PREFIX}/Scripts" >> "${GITHUB_PATH}"
@@ -213,7 +197,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.11", "3.12", "3.13", "3.14", "3.15"]
+        python-version: ["3.11", "3.12", "3.13", "3.14"]
 
     steps:
       - name: Set up conda-standalone

--- a/.github/workflows/llvmlite_win-arm64_wheel_builder.yml
+++ b/.github/workflows/llvmlite_win-arm64_wheel_builder.yml
@@ -38,13 +38,16 @@ jobs:
   win-arm64-build:
     name: win-arm64-build-py${{ matrix.python-version }}
     runs-on: windows-11-arm
+    env:
+      # Python 3.15 is temporarily on ad-testing until it lands in defaults
+      EXTRA_CHANNELS: ${{ matrix.python-version == '3.15' && '-c ad-testing/label/py315' || '' }}
     defaults:
       run:
         shell: bash -elx {0}
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.14"]
+        python-version: ["3.14", "3.15"]
 
     steps:
       - name: Clone repository
@@ -79,10 +82,15 @@ jobs:
           # Free-threaded builds ship as python-freethreading on conda-forge.
           if [[ "${PY_VER}" == *t ]]; then
             PY_SPEC="python-freethreading=${PY_VER%t}"
-            EXTRA_CHANNEL="-c conda-forge"
+            FT_CHANNEL="-c conda-forge"
           else
             PY_SPEC="python=${PY_VER}"
-            EXTRA_CHANNEL=""
+            FT_CHANNEL=""
+          fi
+          if [ -n "${EXTRA_CHANNELS}" ]; then
+            extra_args=(${EXTRA_CHANNELS})
+          else
+            extra_args=()
           fi
           if [ -d llvmdev_channel/win-arm64 ]; then
             LLVMDEV_SRC="-c ${GITHUB_WORKSPACE}/llvmdev_channel"
@@ -90,7 +98,7 @@ jobs:
             LLVMDEV_SRC="-c ${LLVMDEV_CHANNEL}"
           fi
           "${CONDA_EXE}" create --prefix "${CONDA_PREFIX}" --yes \
-            ${LLVMDEV_SRC} -c "${WIN_ARM64_CONDA_CHANNEL}" ${EXTRA_CHANNEL} \
+            ${LLVMDEV_SRC} -c "${WIN_ARM64_CONDA_CHANNEL}" "${extra_args[@]}" ${FT_CHANNEL} \
             -c m2-winarm64 -c main \
             "${PY_SPEC}" "llvmdev=${FALLBACK_LLVMDEV_VERSION}" cmake libxml2 setuptools pip
           echo "${CONDA_PREFIX}" >> "${GITHUB_PATH}"
@@ -134,13 +142,16 @@ jobs:
     name: win-arm64-test-py${{ matrix.python-version }}
     needs: win-arm64-build
     runs-on: windows-11-arm
+    env:
+      # Python 3.15 is temporarily on ad-testing until it lands in defaults
+      EXTRA_CHANNELS: ${{ matrix.python-version == '3.15' && '-c ad-testing/label/py315' || '' }}
     defaults:
       run:
         shell: bash -elx {0}
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.14"]
+        python-version: ["3.14", "3.15"]
 
     steps:
       - name: Set up conda-standalone
@@ -158,13 +169,18 @@ jobs:
           export CONDA_PREFIX="${RUNNER_TEMP}/conda-test-env"
           if [[ "${PY_VER}" == *t ]]; then
             PY_SPEC="python-freethreading=${PY_VER%t}"
-            EXTRA_CHANNEL="-c conda-forge"
+            FT_CHANNEL="-c conda-forge"
           else
             PY_SPEC="python=${PY_VER}"
-            EXTRA_CHANNEL=""
+            FT_CHANNEL=""
+          fi
+          if [ -n "${EXTRA_CHANNELS}" ]; then
+            extra_args=(${EXTRA_CHANNELS})
+          else
+            extra_args=()
           fi
           "${CONDA_EXE}" create --prefix "${CONDA_PREFIX}" --yes \
-            -c "${WIN_ARM64_CONDA_CHANNEL}" ${EXTRA_CHANNEL} -c main \
+            -c "${WIN_ARM64_CONDA_CHANNEL}" "${extra_args[@]}" ${FT_CHANNEL} -c main \
             "${PY_SPEC}" pip
           echo "${CONDA_PREFIX}" >> "${GITHUB_PATH}"
           echo "${CONDA_PREFIX}/Scripts" >> "${GITHUB_PATH}"
@@ -197,7 +213,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.14"]
+        python-version: ["3.14", "3.15"]
 
     steps:
       - name: Set up conda-standalone

--- a/buildscripts/github/llvmlite_evaluate.py
+++ b/buildscripts/github/llvmlite_evaluate.py
@@ -43,6 +43,11 @@ default_include = [
         "platform": "linux-64",
         "python-version": "3.14"
     },
+    {
+        "runner": runner_mapping["linux-64"],
+        "platform": "linux-64",
+        "python-version": "3.15"
+    },
 
     # linux-aarch64
     {
@@ -69,6 +74,11 @@ default_include = [
         "runner": runner_mapping["linux-aarch64"],
         "platform": "linux-aarch64",
         "python-version": "3.14"
+    },
+    {
+        "runner": runner_mapping["linux-aarch64"],
+        "platform": "linux-aarch64",
+        "python-version": "3.15"
     },
 
     # osx-arm64
@@ -97,6 +107,11 @@ default_include = [
         "platform": "osx-arm64",
         "python-version": "3.14"
     },
+    {
+        "runner": runner_mapping["osx-arm64"],
+        "platform": "osx-arm64",
+        "python-version": "3.15"
+    },
 
     # win-64
     {
@@ -123,6 +138,11 @@ default_include = [
         "runner": runner_mapping["win-64"],
         "platform": "win-64",
         "python-version": "3.14"
+    },
+    {
+        "runner": runner_mapping["win-64"],
+        "platform": "win-64",
+        "python-version": "3.15"
     },
 ]
 

--- a/conda-recipes/llvmlite/meta.yaml
+++ b/conda-recipes/llvmlite/meta.yaml
@@ -43,7 +43,7 @@ requirements:
 
 test:
   requires:
-    - py-lief
+    - py-lief # [py<315]
   imports:
     - llvmlite
     - llvmlite.binding


### PR DESCRIPTION
as title, This PR adds python-3.15 and python 3.15t to GHA workflow build and test matrices.

This PR does not include changes to `win-arm64` build/test matrix (tier-1.5). That will be added on seperate PR.