### PR TITLE
CI: upgrade manylinux image to `manylinux_2_28` for llvmdev builds

### DIFF
--- a/.github/workflows/llvmdev_build.yml
+++ b/.github/workflows/llvmdev_build.yml
@@ -117,10 +117,10 @@ jobs:
           MANYLINUX_IMAGE=""
           MINICONDA_FILE=""
           if [[ "${{ matrix.platform }}" == "linux-64" ]]; then
-            MANYLINUX_IMAGE="quay.io/pypa/manylinux2014_x86_64"
+            MANYLINUX_IMAGE="quay.io/pypa/manylinux_2_28_x86_64:2026.08.08-1"
             MINICONDA_FILE="https://repo.anaconda.com/miniconda/Miniconda3-py311_24.9.2-0-Linux-x86_64.sh"
           elif [[ "${{ matrix.platform }}" == "linux-aarch64" ]]; then
-            MANYLINUX_IMAGE="quay.io/pypa/manylinux_2_28_aarch64"
+            MANYLINUX_IMAGE="quay.io/pypa/manylinux_2_28_aarch64:2026.08.08-1"
             MINICONDA_FILE="https://repo.anaconda.com/miniconda/Miniconda3-py311_24.9.2-0-Linux-aarch64.sh"
           fi
 

--- a/buildscripts/manylinux/README.md
+++ b/buildscripts/manylinux/README.md
@@ -6,9 +6,9 @@
 Run the script below to start docker off building `llvmdev` base from the current state of the source tree:
 
 - x86_64 linux: `./buildscripts/manylinux/docker_run_x64.sh build_llvmdev.sh`
-    - uses manylinux2014 image for glibc 2.17+: `pypa.io/pypa/manylinux2014_x86_64`
+    - uses manylinux_2_28 image for glibc 2.28+: `quay.io/pypa/manylinux_2_28_x86_64`
 - aarch64 linux: `./buildscripts/manylinux/docker_run_aarch64.sh build_llvmdev.sh`
-    - uses manylinux_2_28 image for glibc 2.28+: `pypa.io/pypa/manylinux_2_28_aarch64`
+    - uses manylinux_2_28 image for glibc 2.28+: `quay.io/pypa/manylinux_2_28_aarch64`
 
 The conda packages will be stored into `<llvmlite_source_root>/docker_output`
 

--- a/buildscripts/manylinux/docker_run_x64.sh
+++ b/buildscripts/manylinux/docker_run_x64.sh
@@ -1,4 +1,4 @@
-export MANYLINUX_IMAGE="manylinux2014_x86_64"
+export MANYLINUX_IMAGE="manylinux_2_28_x86_64"
 export MINICONDA_FILE="https://repo.anaconda.com/miniconda/Miniconda3-py311_24.9.2-0-Linux-x86_64.sh"
 cd $(dirname $0)
 ./docker_run.sh $1 $2


### PR DESCRIPTION
This is first of the `manylinux` image upgrades for [numba/numba#10774](https://github.com/numba/numba/issues/10774)

It moves docker image used for `linux-64` `llvmdev_for_wheel`  from `manylinux2014` to `manylinux_2_28`