### PR TITLE
CI: test win-arm64 on windows-11-vs2026-arm preview

### DIFF
--- a/.github/workflows/llvmdev_build_win-arm64.yml
+++ b/.github/workflows/llvmdev_build_win-arm64.yml
@@ -37,7 +37,7 @@ jobs:
 
   build:
     name: ${{ matrix.recipe }}-win-arm64
-    runs-on: windows-11-arm
+    runs-on: windows-11-vs2026-arm
     defaults:
       run:
         shell: bash -el {0}

--- a/.github/workflows/llvmdev_build_win-arm64.yml
+++ b/.github/workflows/llvmdev_build_win-arm64.yml
@@ -62,7 +62,7 @@ jobs:
         run: |
           export CONDA_PREFIX="${RUNNER_TEMP}/conda-base"
           "${CONDA_EXE}" create --prefix "${CONDA_PREFIX}" \
-            -c "${WIN_ARM64_CONDA_CHANNEL}" -c m2-winarm64 -c main --yes conda-build
+            -c "${WIN_ARM64_CONDA_CHANNEL}" -c m2-winarm64 -c defaults --yes conda-build
           echo "CONDA_PREFIX=${CONDA_PREFIX}" >> "${GITHUB_ENV}"
           echo "${CONDA_PREFIX}" >> "${GITHUB_PATH}"
           echo "${CONDA_PREFIX}/Scripts" >> "${GITHUB_PATH}"
@@ -73,7 +73,7 @@ jobs:
           CONDA_CHANNEL_DIR: conda_channel_dir
         run: |
           mkdir -p "${CONDA_CHANNEL_DIR}"
-          conda-build -c "${WIN_ARM64_CONDA_CHANNEL}" -c m2-winarm64 -c main \
+          conda-build -c "${WIN_ARM64_CONDA_CHANNEL}" -c m2-winarm64 -c defaults \
             "./conda-recipes/${{ matrix.recipe }}" "--output-folder=${CONDA_CHANNEL_DIR}"
           ls -lah "${CONDA_CHANNEL_DIR}"
 

--- a/.github/workflows/llvmdev_build_win-arm64.yml
+++ b/.github/workflows/llvmdev_build_win-arm64.yml
@@ -32,6 +32,9 @@ env:
   # win-arm64 has no Miniconda installer, so the base environment is
   # bootstrapped from conda-standalone using the win-arm64 native channel.
   WIN_ARM64_CONDA_CHANNEL: bootstrap-win-arm64-round-2-native
+  BOOTSTRAP_CHANNEL: https://conda.anaconda.org/bootstrap-win-arm64-round-2-native
+  M2_CHANNEL: https://conda.anaconda.org/m2-winarm64
+  PKGS_MAIN: https://repo.anaconda.com/pkgs/main
 
 jobs:
 
@@ -62,7 +65,7 @@ jobs:
         run: |
           export CONDA_PREFIX="${RUNNER_TEMP}/conda-base"
           "${CONDA_EXE}" create --prefix "${CONDA_PREFIX}" \
-            -c "${WIN_ARM64_CONDA_CHANNEL}" -c m2-winarm64 -c defaults --yes conda-build
+            -c "${BOOTSTRAP_CHANNEL}" -c "${M2_CHANNEL}" -c "${PKGS_MAIN}" --yes conda-build
           echo "CONDA_PREFIX=${CONDA_PREFIX}" >> "${GITHUB_ENV}"
           echo "${CONDA_PREFIX}" >> "${GITHUB_PATH}"
           echo "${CONDA_PREFIX}/Scripts" >> "${GITHUB_PATH}"
@@ -73,7 +76,7 @@ jobs:
           CONDA_CHANNEL_DIR: conda_channel_dir
         run: |
           mkdir -p "${CONDA_CHANNEL_DIR}"
-          conda-build -c "${WIN_ARM64_CONDA_CHANNEL}" -c m2-winarm64 -c defaults \
+          conda-build -c "${BOOTSTRAP_CHANNEL}" -c "${M2_CHANNEL}" -c "${PKGS_MAIN}" \
             "./conda-recipes/${{ matrix.recipe }}" "--output-folder=${CONDA_CHANNEL_DIR}"
           ls -lah "${CONDA_CHANNEL_DIR}"
 

--- a/.github/workflows/llvmlite_win-arm64_conda_builder.yml
+++ b/.github/workflows/llvmlite_win-arm64_conda_builder.yml
@@ -59,7 +59,7 @@ jobs:
         run: |
           export CONDA_PREFIX="${RUNNER_TEMP}/conda-base"
           "${CONDA_EXE}" create --prefix "${CONDA_PREFIX}" \
-            -c "${WIN_ARM64_CONDA_CHANNEL}" -c m2-winarm64 -c main --yes conda-build
+            -c "${WIN_ARM64_CONDA_CHANNEL}" -c m2-winarm64 -c defaults --yes conda-build
           echo "CONDA_PREFIX=${CONDA_PREFIX}" >> "${GITHUB_ENV}"
           echo "${CONDA_PREFIX}" >> "${GITHUB_PATH}"
           echo "${CONDA_PREFIX}/Scripts" >> "${GITHUB_PATH}"
@@ -89,7 +89,7 @@ jobs:
           fi
           # bld.bat selects the ARM64 CMake generator when ARCH==arm64.
           conda-build --no-test \
-            ${LLVMDEV_SRC} -c "${WIN_ARM64_CONDA_CHANNEL}" -c m2-winarm64 -c main \
+            ${LLVMDEV_SRC} -c "${WIN_ARM64_CONDA_CHANNEL}" -c m2-winarm64 -c defaults \
             --python="${PY_MATRIX}" \
             ./conda-recipes/llvmlite "--output-folder=${CONDA_CHANNEL_DIR}"
           ls -lah "${CONDA_CHANNEL_DIR}"
@@ -133,7 +133,7 @@ jobs:
         run: |
           export CONDA_PREFIX="${RUNNER_TEMP}/conda-base"
           "${CONDA_EXE}" create --prefix "${CONDA_PREFIX}" \
-            -c "${WIN_ARM64_CONDA_CHANNEL}" -c m2-winarm64 -c main --yes conda-build
+            -c "${WIN_ARM64_CONDA_CHANNEL}" -c m2-winarm64 -c defaults --yes conda-build
           echo "CONDA_PREFIX=${CONDA_PREFIX}" >> "${GITHUB_ENV}"
           echo "${CONDA_PREFIX}" >> "${GITHUB_PATH}"
           echo "${CONDA_PREFIX}/Scripts" >> "${GITHUB_PATH}"
@@ -148,5 +148,5 @@ jobs:
       - name: Test llvmlite conda package
         run: |
           conda-build --test \
-            -c "${LLVMDEV_CHANNEL}" -c "${WIN_ARM64_CONDA_CHANNEL}" -c m2-winarm64 -c main \
+            -c "${LLVMDEV_CHANNEL}" -c "${WIN_ARM64_CONDA_CHANNEL}" -c m2-winarm64 -c defaults \
             conda_channel_dir/win-arm64/llvmlite-*.conda

--- a/.github/workflows/llvmlite_win-arm64_conda_builder.yml
+++ b/.github/workflows/llvmlite_win-arm64_conda_builder.yml
@@ -81,8 +81,6 @@ jobs:
           PY_MATRIX: ${{ matrix.python-version }}
         run: |
           mkdir -p "${CONDA_CHANNEL_DIR}"
-          conda config --set channel_priority strict
-          conda config --add pinned_packages 'defaults::cmake'
           if [ -d llvmdev_channel/win-arm64 ]; then
             LLVMDEV_SRC="-c ${GITHUB_WORKSPACE}/llvmdev_channel"
           else

--- a/.github/workflows/llvmlite_win-arm64_conda_builder.yml
+++ b/.github/workflows/llvmlite_win-arm64_conda_builder.yml
@@ -82,6 +82,7 @@ jobs:
         run: |
           mkdir -p "${CONDA_CHANNEL_DIR}"
           conda config --set channel_priority strict
+          conda config --add pinned_packages 'defaults::cmake'
           if [ -d llvmdev_channel/win-arm64 ]; then
             LLVMDEV_SRC="-c ${GITHUB_WORKSPACE}/llvmdev_channel"
           else

--- a/.github/workflows/llvmlite_win-arm64_conda_builder.yml
+++ b/.github/workflows/llvmlite_win-arm64_conda_builder.yml
@@ -32,7 +32,7 @@ env:
 jobs:
   win-arm64-build:
     name: win-arm64-build-py${{ matrix.python-version }}
-    runs-on: windows-11-arm
+    runs-on: windows-11-vs2026-arm
     defaults:
       run:
         shell: bash -elx {0}
@@ -112,7 +112,7 @@ jobs:
   win-arm64-test:
     name: win-arm64-test-py${{ matrix.python-version }}
     needs: win-arm64-build
-    runs-on: windows-11-arm
+    runs-on: windows-11-vs2026-arm
     defaults:
       run:
         shell: bash -elx {0}

--- a/.github/workflows/llvmlite_win-arm64_conda_builder.yml
+++ b/.github/workflows/llvmlite_win-arm64_conda_builder.yml
@@ -24,10 +24,13 @@ permissions:
 
 env:
   ARTIFACT_RETENTION_DAYS: 7
-  LLVMDEV_CHANNEL: numba/label/llvm
+  LLVMDEV_CHANNEL: https://conda.anaconda.org/numba/label/llvm
   # win-arm64 has no Miniconda installer, so the base environment is
   # bootstrapped from conda-standalone using the win-arm64 native channel.
   WIN_ARM64_CONDA_CHANNEL: bootstrap-win-arm64-round-2-native
+  BOOTSTRAP_CHANNEL: https://conda.anaconda.org/bootstrap-win-arm64-round-2-native
+  M2_CHANNEL: https://conda.anaconda.org/m2-winarm64
+  PKGS_MAIN: https://repo.anaconda.com/pkgs/main
 
 jobs:
   win-arm64-build:
@@ -59,7 +62,7 @@ jobs:
         run: |
           export CONDA_PREFIX="${RUNNER_TEMP}/conda-base"
           "${CONDA_EXE}" create --prefix "${CONDA_PREFIX}" \
-            -c "${WIN_ARM64_CONDA_CHANNEL}" -c m2-winarm64 -c defaults --yes conda-build
+            -c "${BOOTSTRAP_CHANNEL}" -c "${M2_CHANNEL}" -c "${PKGS_MAIN}" --yes conda-build
           echo "CONDA_PREFIX=${CONDA_PREFIX}" >> "${GITHUB_ENV}"
           echo "${CONDA_PREFIX}" >> "${GITHUB_PATH}"
           echo "${CONDA_PREFIX}/Scripts" >> "${GITHUB_PATH}"
@@ -88,7 +91,7 @@ jobs:
           fi
           # bld.bat selects the ARM64 CMake generator when ARCH==arm64.
           conda-build --no-test \
-            ${LLVMDEV_SRC} -c "${WIN_ARM64_CONDA_CHANNEL}" -c m2-winarm64 -c defaults \
+            ${LLVMDEV_SRC} -c "${BOOTSTRAP_CHANNEL}" -c "${M2_CHANNEL}" -c "${PKGS_MAIN}" \
             --python="${PY_MATRIX}" \
             ./conda-recipes/llvmlite "--output-folder=${CONDA_CHANNEL_DIR}"
           ls -lah "${CONDA_CHANNEL_DIR}"
@@ -132,7 +135,7 @@ jobs:
         run: |
           export CONDA_PREFIX="${RUNNER_TEMP}/conda-base"
           "${CONDA_EXE}" create --prefix "${CONDA_PREFIX}" \
-            -c "${WIN_ARM64_CONDA_CHANNEL}" -c m2-winarm64 -c defaults --yes conda-build
+            -c "${BOOTSTRAP_CHANNEL}" -c "${M2_CHANNEL}" -c "${PKGS_MAIN}" --yes conda-build
           echo "CONDA_PREFIX=${CONDA_PREFIX}" >> "${GITHUB_ENV}"
           echo "${CONDA_PREFIX}" >> "${GITHUB_PATH}"
           echo "${CONDA_PREFIX}/Scripts" >> "${GITHUB_PATH}"
@@ -147,5 +150,5 @@ jobs:
       - name: Test llvmlite conda package
         run: |
           conda-build --test \
-            -c "${LLVMDEV_CHANNEL}" -c "${WIN_ARM64_CONDA_CHANNEL}" -c m2-winarm64 -c defaults \
+            -c "${LLVMDEV_CHANNEL}" -c "${BOOTSTRAP_CHANNEL}" -c "${M2_CHANNEL}" -c "${PKGS_MAIN}" \
             conda_channel_dir/win-arm64/llvmlite-*.conda

--- a/.github/workflows/llvmlite_win-arm64_wheel_builder.yml
+++ b/.github/workflows/llvmlite_win-arm64_wheel_builder.yml
@@ -89,6 +89,7 @@ jobs:
           else
             LLVMDEV_SRC="-c ${LLVMDEV_CHANNEL}"
           fi
+          "${CONDA_EXE}" config --add pinned_packages 'defaults::cmake'
           "${CONDA_EXE}" create --prefix "${CONDA_PREFIX}" --yes \
             ${LLVMDEV_SRC} -c "${WIN_ARM64_CONDA_CHANNEL}" ${EXTRA_CHANNEL} \
             -c m2-winarm64 -c defaults \

--- a/.github/workflows/llvmlite_win-arm64_wheel_builder.yml
+++ b/.github/workflows/llvmlite_win-arm64_wheel_builder.yml
@@ -29,10 +29,14 @@ permissions:
 env:
   FALLBACK_LLVMDEV_VERSION: "22"
   ARTIFACT_RETENTION_DAYS: 7
-  LLVMDEV_CHANNEL: numba/label/llvm_wheel
+  LLVMDEV_CHANNEL: https://conda.anaconda.org/numba/label/llvm_wheel
   # win-arm64 has no Miniconda installer, so the base environment is
   # bootstrapped from conda-standalone using the win-arm64 native channel.
   WIN_ARM64_CONDA_CHANNEL: bootstrap-win-arm64-round-2-native
+  BOOTSTRAP_CHANNEL: https://conda.anaconda.org/bootstrap-win-arm64-round-2-native
+  M2_CHANNEL: https://conda.anaconda.org/m2-winarm64
+  PKGS_MAIN: https://repo.anaconda.com/pkgs/main
+  CONDA_FORGE: https://conda.anaconda.org/conda-forge
 
 jobs:
   win-arm64-build:
@@ -79,7 +83,7 @@ jobs:
           # Free-threaded builds ship as python-freethreading on conda-forge.
           if [[ "${PY_VER}" == *t ]]; then
             PY_SPEC="python-freethreading=${PY_VER%t}"
-            EXTRA_CHANNEL="-c conda-forge"
+            EXTRA_CHANNEL="-c ${CONDA_FORGE}"
           else
             PY_SPEC="python=${PY_VER}"
             EXTRA_CHANNEL=""
@@ -89,10 +93,10 @@ jobs:
           else
             LLVMDEV_SRC="-c ${LLVMDEV_CHANNEL}"
           fi
-          "${CONDA_EXE}" config --add pinned_packages 'defaults::cmake'
+          "${CONDA_EXE}" config --add pinned_packages 'pkgs/main::cmake'
           "${CONDA_EXE}" create --prefix "${CONDA_PREFIX}" --yes \
-            ${LLVMDEV_SRC} -c "${WIN_ARM64_CONDA_CHANNEL}" ${EXTRA_CHANNEL} \
-            -c m2-winarm64 -c defaults \
+            ${LLVMDEV_SRC} -c "${BOOTSTRAP_CHANNEL}" ${EXTRA_CHANNEL} \
+            -c "${M2_CHANNEL}" -c "${PKGS_MAIN}" \
             "${PY_SPEC}" "llvmdev=${FALLBACK_LLVMDEV_VERSION}" cmake libxml2 setuptools pip
           echo "${CONDA_PREFIX}" >> "${GITHUB_PATH}"
           echo "${CONDA_PREFIX}/Scripts" >> "${GITHUB_PATH}"
@@ -159,13 +163,13 @@ jobs:
           export CONDA_PREFIX="${RUNNER_TEMP}/conda-test-env"
           if [[ "${PY_VER}" == *t ]]; then
             PY_SPEC="python-freethreading=${PY_VER%t}"
-            EXTRA_CHANNEL="-c conda-forge"
+            EXTRA_CHANNEL="-c ${CONDA_FORGE}"
           else
             PY_SPEC="python=${PY_VER}"
             EXTRA_CHANNEL=""
           fi
           "${CONDA_EXE}" create --prefix "${CONDA_PREFIX}" --yes \
-            -c "${WIN_ARM64_CONDA_CHANNEL}" ${EXTRA_CHANNEL} -c defaults \
+            -c "${BOOTSTRAP_CHANNEL}" ${EXTRA_CHANNEL} -c "${PKGS_MAIN}" \
             "${PY_SPEC}" pip
           echo "${CONDA_PREFIX}" >> "${GITHUB_PATH}"
           echo "${CONDA_PREFIX}/Scripts" >> "${GITHUB_PATH}"
@@ -212,7 +216,7 @@ jobs:
         run: |
           export CONDA_PREFIX="${RUNNER_TEMP}/conda-upload-env"
           "${CONDA_EXE}" create --prefix "${CONDA_PREFIX}" --yes \
-            -c "${WIN_ARM64_CONDA_CHANNEL}" -c defaults anaconda-client
+            -c "${BOOTSTRAP_CHANNEL}" -c "${PKGS_MAIN}" anaconda-client
           echo "${CONDA_PREFIX}" >> "${GITHUB_PATH}"
           echo "${CONDA_PREFIX}/Scripts" >> "${GITHUB_PATH}"
 

--- a/.github/workflows/llvmlite_win-arm64_wheel_builder.yml
+++ b/.github/workflows/llvmlite_win-arm64_wheel_builder.yml
@@ -93,11 +93,10 @@ jobs:
           else
             LLVMDEV_SRC="-c ${LLVMDEV_CHANNEL}"
           fi
-          "${CONDA_EXE}" config --add pinned_packages 'pkgs/main::cmake'
           "${CONDA_EXE}" create --prefix "${CONDA_PREFIX}" --yes \
             ${LLVMDEV_SRC} -c "${BOOTSTRAP_CHANNEL}" ${EXTRA_CHANNEL} \
             -c "${M2_CHANNEL}" -c "${PKGS_MAIN}" \
-            "${PY_SPEC}" "llvmdev=${FALLBACK_LLVMDEV_VERSION}" cmake libxml2 setuptools pip
+            "${PY_SPEC}" "llvmdev=${FALLBACK_LLVMDEV_VERSION}" "cmake>=4.2" libxml2 setuptools pip
           echo "${CONDA_PREFIX}" >> "${GITHUB_PATH}"
           echo "${CONDA_PREFIX}/Scripts" >> "${GITHUB_PATH}"
           echo "${CONDA_PREFIX}/Library/bin" >> "${GITHUB_PATH}"

--- a/.github/workflows/llvmlite_win-arm64_wheel_builder.yml
+++ b/.github/workflows/llvmlite_win-arm64_wheel_builder.yml
@@ -91,7 +91,7 @@ jobs:
           fi
           "${CONDA_EXE}" create --prefix "${CONDA_PREFIX}" --yes \
             ${LLVMDEV_SRC} -c "${WIN_ARM64_CONDA_CHANNEL}" ${EXTRA_CHANNEL} \
-            -c m2-winarm64 -c main \
+            -c m2-winarm64 -c defaults \
             "${PY_SPEC}" "llvmdev=${FALLBACK_LLVMDEV_VERSION}" cmake libxml2 setuptools pip
           echo "${CONDA_PREFIX}" >> "${GITHUB_PATH}"
           echo "${CONDA_PREFIX}/Scripts" >> "${GITHUB_PATH}"
@@ -164,7 +164,7 @@ jobs:
             EXTRA_CHANNEL=""
           fi
           "${CONDA_EXE}" create --prefix "${CONDA_PREFIX}" --yes \
-            -c "${WIN_ARM64_CONDA_CHANNEL}" ${EXTRA_CHANNEL} -c main \
+            -c "${WIN_ARM64_CONDA_CHANNEL}" ${EXTRA_CHANNEL} -c defaults \
             "${PY_SPEC}" pip
           echo "${CONDA_PREFIX}" >> "${GITHUB_PATH}"
           echo "${CONDA_PREFIX}/Scripts" >> "${GITHUB_PATH}"
@@ -211,7 +211,7 @@ jobs:
         run: |
           export CONDA_PREFIX="${RUNNER_TEMP}/conda-upload-env"
           "${CONDA_EXE}" create --prefix "${CONDA_PREFIX}" --yes \
-            -c "${WIN_ARM64_CONDA_CHANNEL}" -c main anaconda-client
+            -c "${WIN_ARM64_CONDA_CHANNEL}" -c defaults anaconda-client
           echo "${CONDA_PREFIX}" >> "${GITHUB_PATH}"
           echo "${CONDA_PREFIX}/Scripts" >> "${GITHUB_PATH}"
 

--- a/.github/workflows/llvmlite_win-arm64_wheel_builder.yml
+++ b/.github/workflows/llvmlite_win-arm64_wheel_builder.yml
@@ -37,7 +37,7 @@ env:
 jobs:
   win-arm64-build:
     name: win-arm64-build-py${{ matrix.python-version }}
-    runs-on: windows-11-arm
+    runs-on: windows-11-vs2026-arm
     defaults:
       run:
         shell: bash -elx {0}
@@ -133,7 +133,7 @@ jobs:
   win-arm64-test:
     name: win-arm64-test-py${{ matrix.python-version }}
     needs: win-arm64-build
-    runs-on: windows-11-arm
+    runs-on: windows-11-vs2026-arm
     defaults:
       run:
         shell: bash -elx {0}
@@ -190,7 +190,7 @@ jobs:
     name: win-arm64-upload-py${{ matrix.python-version }}
     needs: win-arm64-test
     if: github.event_name == 'workflow_dispatch' && inputs.upload_wheel_to_anaconda
-    runs-on: windows-11-arm
+    runs-on: windows-11-vs2026-arm
     defaults:
       run:
         shell: bash -elx {0}

--- a/conda-recipes/llvmlite/meta.yaml
+++ b/conda-recipes/llvmlite/meta.yaml
@@ -19,7 +19,8 @@ requirements:
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}
     - vs2022_{{ target_platform  }}    # [win]
-    - cmake
+    - cmake >=4.2    # [win and arm64]
+    - cmake          # [not (win and arm64)]
     - make           # [unix]
   host:
     - python


### PR DESCRIPTION
The intention of this PR is to get `win-arm64` workflows ready for upcoming change of `windows-11-arm` image to Visual Studio 2026 ([link](https://github.blog/changelog/2026-08-20-windows-11-arm64-vs2026-image-generally-available/)) . To prepare for it, this PR updates image to `windows-11-vs2026-arm` preview image.

As I found, that image needs cmake >= 4.2 for the Visual Studio 18 2026 generator.
bootstrap still has 3.31.2; defaults (pkgs/main) has 4.3.4.
Jobs use `-c defaults` instead of `-c main`. For cmake, 
- for conda: `cmake >=4.2` in now specified in the recipe ( constraint >=4.2 for win and arm64), no strict channel priority
- for wheel: ~`conda config --add pinned_packages 'defaults::cmake'` to pin cmake from defaults when using `conda create` for build environment.~
EDIT: same `cmake >=4.2` constraint on conda build env create command