### PR TITLE
CI: upgrade `macos` GHA runner image from v14 to v26

### DIFF
--- a/.github/workflows/llvmlite_osx-arm64_wheel_builder.yml
+++ b/.github/workflows/llvmlite_osx-arm64_wheel_builder.yml
@@ -34,7 +34,7 @@ env:
 jobs:
   osx-arm64-build:
     name: osx-arm64-build
-    runs-on: macos-14
+    runs-on: macos-26
     defaults:
       run:
         shell: bash -elx {0}
@@ -127,7 +127,7 @@ jobs:
   osx-arm64-validate:
     name: osx-arm64-validate
     needs: osx-arm64-build
-    runs-on: macos-14
+    runs-on: macos-26
     defaults:
       run:
         shell: bash -elx {0}
@@ -163,7 +163,7 @@ jobs:
   osx-arm64-test:
     name: osx-arm64-test
     needs: osx-arm64-build
-    runs-on: macos-14
+    runs-on: macos-26
     defaults:
       run:
         shell: bash -elx {0}
@@ -203,7 +203,7 @@ jobs:
     name: osx-arm64-upload
     needs: osx-arm64-test
     if: github.event_name == 'workflow_dispatch' && inputs.upload_wheel_to_anaconda
-    runs-on: macos-14
+    runs-on: macos-26
     defaults:
       run:
         shell: bash -elx {0}

--- a/buildscripts/github/llvmdev_evaluate.py
+++ b/buildscripts/github/llvmdev_evaluate.py
@@ -12,7 +12,7 @@ inputs = os.environ.get("GITHUB_WORKFLOW_INPUT", "{}")
 runner_mapping = {
     "linux-64": "ubuntu-24.04",
     "linux-aarch64": "ubuntu-24.04-arm",
-    "osx-arm64": "macos-14",
+    "osx-arm64": "macos-26",
     "win-64": "windows-2025",
 }
 

--- a/buildscripts/github/llvmlite_evaluate.py
+++ b/buildscripts/github/llvmlite_evaluate.py
@@ -12,7 +12,7 @@ inputs = os.environ.get("GITHUB_WORKFLOW_INPUT", "{}")
 runner_mapping = {
     "linux-64": "ubuntu-24.04",
     "linux-aarch64": "ubuntu-24.04-arm",
-    "osx-arm64": "macos-14",
+    "osx-arm64": "macos-26",
     "win-64": "windows-2025",
 }
 

--- a/conda-recipes/llvmlite/conda_build_config.yaml
+++ b/conda-recipes/llvmlite/conda_build_config.yaml
@@ -1,11 +1,11 @@
 # Numba/llvmlite stack needs an older compiler for backwards compatability.
 c_compiler_version:         # [linux or osx]
   - 11                      # [linux]
-  - 14                      # [osx]
+  - 19                      # [osx]
 
 cxx_compiler_version:       # [linux or osx]
   - 11                      # [linux]
-  - 14                      # [osx]
+  - 19                      # [osx]
 
 fortran_compiler_version:   # [linux]
   - 11                      # [linux]


### PR DESCRIPTION
superset of https://github.com/numba/llvmlite/pull/1422

This PR updates workflow and buildscripts with newer `macos-26` image. This is needed because `macos-14` is unsupported after `2026-11-02` ([runner-images#13518](https://github.com/actions/runner-images/issues/13518)).

Note that this upgrades the **host Apple toolchain** used to compile `libllvmlite` in the wheel:

| | macos-14 (today) | macos-26 (this PR) |
|---|---|---|
| Default Xcode | 15.4 | 26.6 |
| Apple clang | 15 | 21 |
| SDK | macosx14.x | macosx26.x |

`llvmdev` in the wheel is unchanged: still conda clang 19 (`llvmdev_for_wheel`). Wheel tag stays `macosx_12_0`. 

Also update llvmlite conda compiler pin to `19` to match llvmdev and numba. 
`v14` is not able to parse the Xcode 26 SDK libc++ headers (`_LIBCPP_BEGIN_UNVERSIONED_NAMESPACE_STD`).

Assisted by: Cursor Grok 4.6
