### PR TITLE
CI: drop Python 3.11 from the win-arm64 matrix

### DIFF
--- a/.github/workflows/llvmlite_win-arm64_conda_builder.yml
+++ b/.github/workflows/llvmlite_win-arm64_conda_builder.yml
@@ -39,7 +39,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.11", "3.12", "3.13", "3.14"]
+        python-version: ["3.12", "3.13", "3.14"]
 
     steps:
       - name: Clone repository
@@ -119,7 +119,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.11", "3.12", "3.13", "3.14"]
+        python-version: ["3.12", "3.13", "3.14"]
 
     steps:
       - name: Set up conda-standalone

--- a/.github/workflows/llvmlite_win-arm64_wheel_builder.yml
+++ b/.github/workflows/llvmlite_win-arm64_wheel_builder.yml
@@ -44,7 +44,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.11", "3.12", "3.13", "3.14"]
+        python-version: ["3.12", "3.13", "3.14"]
 
     steps:
       - name: Clone repository
@@ -140,7 +140,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.11", "3.12", "3.13", "3.14"]
+        python-version: ["3.12", "3.13", "3.14"]
 
     steps:
       - name: Set up conda-standalone
@@ -197,7 +197,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.11", "3.12", "3.13", "3.14"]
+        python-version: ["3.12", "3.13", "3.14"]
 
     steps:
       - name: Set up conda-standalone


### PR DESCRIPTION
Anaconda defaults on `win-arm64` currently publishes 3.12–3.14 only. Narrow the WoA jobs to those versions.