### PR TITLE
CI: upgrade `manylinux` image to `manylinux_2_28` for llvmlite builds

### DIFF
--- a/.github/workflows/llvmlite_linux-64_wheel_builder.yml
+++ b/.github/workflows/llvmlite_linux-64_wheel_builder.yml
@@ -31,7 +31,7 @@ env:
   CONDA_CHANNEL_NUMBA: numba/label/llvm_wheel
   VALIDATION_PYTHON_VERSION: "3.12"
   ARTIFACT_RETENTION_DAYS: 7
-  MANYLINUX_IMAGE: "manylinux2014_x86_64"
+  MANYLINUX_IMAGE: "manylinux_2_28_x86_64:2026.08.08-1"
 
 jobs:
   linux-64-build:

--- a/.github/workflows/llvmlite_linux-aarch64_wheel_builder.yml
+++ b/.github/workflows/llvmlite_linux-aarch64_wheel_builder.yml
@@ -31,7 +31,7 @@ env:
   CONDA_CHANNEL_NUMBA: numba/label/llvm_wheel
   VALIDATION_PYTHON_VERSION: "3.12"
   ARTIFACT_RETENTION_DAYS: 7
-  MANYLINUX_IMAGE: "manylinux_2_28_aarch64"
+  MANYLINUX_IMAGE: "manylinux_2_28_aarch64:2026.08.08-1"
 
 jobs:
   linux-aarch64-build:


### PR DESCRIPTION
This follows https://github.com/numba/llvmlite/pull/1471, to upgrade `manylinux` image for https://github.com/numba/numba/issues/10774

It moves docker image used for `linux-64` `llvmdev_for_wheel` from `manylinux2014` to `manylinux_2_28`