### PR TITLE
fix: <command-line>: error: token '=' is not valid in preprocessor expressions

### DIFF
--- a/ffi/CMakeLists.txt
+++ b/ffi/CMakeLists.txt
@@ -52,7 +52,8 @@ else()
 endif()
 
 include_directories(${LLVM_INCLUDE_DIRS})
-add_definitions(${LLVM_DEFINITIONS})
+separate_arguments(LLVM_DEFINITIONS_LIST NATIVE_COMMAND "${LLVM_DEFINITIONS}")
+add_definitions(${LLVM_DEFINITIONS_LIST})
 
 # Check for presence of the SVML patch in the LLVM build
 set(CMAKE_REQUIRED_INCLUDES ${LLVM_INCLUDE_DIRS})


### PR DESCRIPTION
While working on https://github.com/numba/llvmlite/issues/1034 to add llvmlite to Alpine Linux, our CI threw hundreds of errors like this on 32-bit machines only:
```
<command-line>: error: token '=' is not valid in preprocessor expressions
<command-line>: error: token '=' is not valid in preprocessor expressions
<command-line>: error: token '=' is not valid in preprocessor expressions
<command-line>: error: token '=' is not valid in preprocessor expressions
<command-line>: error: token '=' is not valid in preprocessor expressions
<command-line>: error: token '=' is not valid in preprocessor expressions
<command-line>: error: token '=' is not valid in preprocessor expressions
<command-line>: error: token '=' is not valid in preprocessor expressions
```
The issue is that `LLVM_DEFINITIONS` is a space separated string and not a CMake list, so passing it straight to `add_definitions()` defines a single macro whose value is the remainder of the string. A definition with an `=` in it like `-D_FILE_OFFSET_BITS=64` (added by LLVM on 32 bit targets) ends up inside the value of the first macro, which then fails to parse in any #if that tests it.  It looks like this on armv7, notice the incorrect quoting:
```
CXX_DEFINES = -DHAVE_LLVMLITE_SHARED -DLLVMLITE_LLVM_ASSERTIONS_STATE=2 -D_GLIBCXX_USE_CXX11_ABI="1 -D_LARGEFILE_SOURCE -D_FILE_OFFSET_BITS=64 -D__STDC_CONSTANT_MACROS -D__STDC_FORMAT_MACROS -D__STDC_LIMIT_MACROS" -Dllvmlite_EXPORTS
```

Fixed by splitting the arguments into a Cmake list first, then adding them as definitions.
