### PR TITLE
Add support for LLVM range parameter attributes

### DIFF
--- a/llvmlite/ir/values.py
+++ b/llvmlite/ir/values.py
@@ -1052,6 +1052,13 @@ class ArgumentAttributes(AttributeSet):
         'zeroext': False,
     })
 
+    _range_re = re.compile(r'range\([^()]+\)\Z')
+
+    def add(self, name):
+        if name not in self._known and not self._range_re.fullmatch(name):
+            raise ValueError('unknown attr {!r} for {}'.format(name, self))
+        return super(AttributeSet, self).add(name)
+
     def __init__(self, args=()):
         self._align = 0
         self._dereferenceable = 0

--- a/llvmlite/tests/test_ir.py
+++ b/llvmlite/tests/test_ir.py
@@ -162,6 +162,7 @@ class TestFunction(TestBase):
         # Now with parameter attributes
         func = self.function()
         func.args[0].add_attribute("zeroext")
+        func.args[0].add_attribute("range(i32 0, 10)")
         func.args[1].attributes.dereferenceable = 5
         func.args[1].attributes.dereferenceable_or_null = 10
         func.args[3].attributes.align = 4
@@ -170,12 +171,14 @@ class TestFunction(TestBase):
         asm = self.descr(func).strip()
         if not ir_layer_typed_pointers_enabled:
             self.assertEqual(asm,
-                             """declare noalias i32 @"my_func"(i32 zeroext %".1", i32 dereferenceable(5) dereferenceable_or_null(10) %".2", double %".3", ptr nonnull align 4 %".4")"""  # noqa E501
+                             """declare noalias i32 @"my_func"(i32 range(i32 0, 10) zeroext %".1", i32 dereferenceable(5) dereferenceable_or_null(10) %".2", double %".3", ptr nonnull align 4 %".4")"""  # noqa E501
                              )
         else:
             self.assertEqual(asm,
-                             """declare noalias i32 @"my_func"(i32 zeroext %".1", i32 dereferenceable(5) dereferenceable_or_null(10) %".2", double %".3", i32* nonnull align 4 %".4")"""  # noqa E501
+                             """declare noalias i32 @"my_func"(i32 range(i32 0, 10) zeroext %".1", i32 dereferenceable(5) dereferenceable_or_null(10) %".2", double %".3", i32* nonnull align 4 %".4")"""  # noqa E501
                              )
+        with self.assertRaises(ValueError):
+            func.args[0].add_attribute("range(i32 0, 10")
         # Check pickling
         self.assert_pickle_correctly(func)
 


### PR DESCRIPTION
I am using llvmlite in http://github.com/alcides/aeon to lower my programming language to llvm. My language supports refinement types, which I want to keep (as much as llvm supports), so I need this feature in llvmlite to avoid ugly workarounds.

Full transparency: the PR was generated by Codex, but I have reviewed it.

-------

LLVM supports the `range` parameter attribute, but llvmlite's `ArgumentAttributes` allowlist currently rejects it. This patch accepts syntactically formed `range(...)` attributes and emits them for function parameters and call-site arguments.

The accepted form follows LLVM IR's parameter attribute syntax. Malformed values remain rejected, preserving the existing validation behavior for unknown attributes.

Tests: `llvmlite/tests/test_ir.py` updated. The full test suite could not run locally because the shallow checkout environment lacks an LLVM development installation required to build llvmlite's native extension.
